### PR TITLE
added a note about creating patches from directories in .gitignore

### DIFF
--- a/docs/Guides/Porting.md
+++ b/docs/Guides/Porting.md
@@ -8,7 +8,7 @@ Before you begin to build code, ensure that you have access to a z/OS UNIX envir
 
 ### Set up your environment
 
-This is the most cumbersome step, but is only required to be done once. 
+This is the most cumbersome step, but is only required to be done once.
 
 The tools assume an ASCII/UTF-8 environment, and so you should ensure that you have the following environment
 variables set:
@@ -38,40 +38,39 @@ The utils repo (https://github.com/ZOSOpenTools/utils) consists of common tools 
 in the porting process, including the `zopen` suite of tools.  Specifically, `zopen build` provides a common way to bootstrap, configure, build, check,
 and install a software package.  `zopen download` provides a mechanism to download the latest published z/OS Open Tools.
 
-Many tools depend on other tools to be able to build or run. You will need to provide both _bootstrap_ tools 
-(i.e. binary tools not from source), as well as _prod_ tools (i.e. _production_ level tools previously built 
-from another z/OS Open Tools repository). 
+Many tools depend on other tools to be able to build or run. You will need to provide both _bootstrap_ tools
+(i.e. binary tools not from source), as well as _prod_ tools (i.e. _production_ level tools previously built
+from another z/OS Open Tools repository).
 
-Our goal is to eventually have our own version of all the _bootstrap_ tools, but right now, we rely on some 
-tools from Rocket. These Rocket tools can be downloaded [here](https://my.rocketsoftware.com/RocketCommunity#/downloads). 
+Our goal is to eventually have our own version of all the _bootstrap_ tools, but right now, we rely on some
+tools from Rocket. These Rocket tools can be downloaded [here](https://my.rocketsoftware.com/RocketCommunity#/downloads).
 
 Many tools require a C or C++ compiler (or both). xlclang 2.4.1 or higher should be used for C/C++ compilation
-and can be downloaded [here](https://www.ibm.com/servers/resourcelink/svc00100.nsf/pages/xlCC++V241ForZOsV24). 
+and can be downloaded [here](https://www.ibm.com/servers/resourcelink/svc00100.nsf/pages/xlCC++V241ForZOsV24).
 
-In order for zopen to be able to locate dependent tools, they need to be in well-defined locations. 
+In order for zopen to be able to locate dependent tools, they need to be in well-defined locations.
 Tools will be searched for in the following locations, in order:
 - `${HOME}/zopen/prod/<tool>`
 - `/usr/bin/zopen/<tool>`
-- `${HOME}/zopen/boot/<tool>` 
+- `${HOME}/zopen/boot/<tool>`
 
 So for example, `make` depends on `m4` to build. `zopen build` will search for `m4` first in the
 personal _prod_ build from `${HOME}/zopen/prod/m4`, then the system-wide build in `/usr/bin/zopen/m4`, and
-finally in the personal _boot_ directory `${HOME}/zopen/boot/m4`. Symbolic links can be used as required 
-to share builds between developers on a system, if desired.  You can also add your own directories to the search path by specifying the -d option to `zopen build` as follows:
+finally in the personal _boot_ directory `${HOME}/zopen/boot/m4`. Symbolic links can be used as required to share builds between developers on a system, if desired.  You can also add your own directories to the search path by specifying the -d option to `zopen build` as follows:
 ```bash
 zopen build -d $HOME/mytools
 ```
 
 Each tool is responsible for knowing how to set it's own environment up (e.g. PATH, LIBPATH, and any other environment variables).
-Each tool needs to provide a `.env` program that can be source'd from it's directory to set up it's environment. 
+Each tool needs to provide a `.env` program that can be source'd from it's directory to set up it's environment.
 If you are building from a ZOSOpenTools port, this `.env` file will be created as part of the install process, but if you
-are providing a `boot` version of the tool (e.g. cURL), then you will need to provide your own version of `.env`. 
+are providing a `boot` version of the tool (e.g. cURL), then you will need to provide your own version of `.env`.
 
 ### Create your first z/OS port leveraging the zopen framework
 
 Before you begin porting a tool to z/OS, you must first identify the tool or library that you wish to port. For the sake of this guide, let's assume we are porting [jq](https://stedolan.github.io/jq/), a lightweight and flexible json parser. Next, check if the tool already exists under https://github.com/ZOSOpenTools. If it does exist, then please collaborate with the existing contributors.
 
-Begin first by cloning the example repository [zotsampleport](https://github.com/ZOSOpenTools/zotsampleport). 
+Begin first by cloning the example repository [zotsampleport](https://github.com/ZOSOpenTools/zotsampleport).
 This repository contains the essential elements required to begin porting your application or library to z/OS. We will use it as a template for our new project.
 
 In addition to the zotsamplerepo, you must also clone the https://github.com/ZOSOpenTools/utils repo.  This repo contains the `zopen` framework and it is what we will use to build, test, and install our port.
@@ -82,9 +81,15 @@ git clone git@github.com:ZOSOpenTools/utils.git
 git clone git@github.com:ZOSOpenTools/zotsampleport.git jqport # make sure to name the directory as <toolname>port
 ```
 
-Next, in order to use the `zopen` suite of tools, you must set your path environment variable to the `utils/bin` directory. 
+Next, in order to use the `zopen` suite of tools, you must set your path environment variable to the `utils/bin` directory.
 ```bash
 export PATH=<pathtozopen>/utils/bin:$PATH
+```
+
+Source the enviroments to complete the setup.
+
+```bash
+. zopen-importenvs
 ```
 
 Ok, now you are ready to begin porting. Change your current directory to the `jqport` directory: `cd jqport`. You will notice several files. The key files of interest are:
@@ -100,20 +105,19 @@ In the `buildenv` file, we'll erase the existing contents and the following:
 export ZOPEN_ROOT=$PWD
 export ZOPEN_TYPE="TARBALL"
 export ZOPEN_TARBALL_URL="https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz"
-export ZOPEN_TARBALL_DEPS="make curl gzip" 
+export ZOPEN_TARBALL_DEPS="make curl gzip"
 ```
 ZOPEN_TARBALL_DEPS represents the set of dependencies that jq needs. We're currently only aware of `make` since it contains a Makefile.
 
 Next, we can go ahead and test our build.  Run the following:
 ```bash
-zopen build -v 
+zopen build -v
 ```
 
 The `-v` option above specifies verbose output.
 
-
-
 *Creating Patches*
+
 As you may have noticed, `zopen build` downloads the `tar.gz` file, and then attempts to patch it with the patch contents in the `patches` directory.
 
 As you port your application to z/OS, you will identify a set of _patches_. These patches represent the set of changes in order to get your tool or library to work on z/OS. To create a patch, change to the `jq-1.6` directory and perform a `git diff HEAD` and redirect your patches to a file in the patches directory.
@@ -122,6 +126,12 @@ As you port your application to z/OS, you will identify a set of _patches_. Thes
 cd jq-1.6
 # Make your changes
 git diff HEAD > ../patches/initial_zos.patch
+```
+
+In some cases, the tool directory will not be tracked by git (when using a tarball and/or the tool directory is included in .gitignore). In this case, you will need to create the patch by hand using diff and an untouched copy of the tool directory.
+
+```bash
+diff -r jq-1.6 jq-1.6.orig > patches/initial_zos.patch
 ```
 
 Once you have a working prototype of your tool, you can proceed to the next step.


### PR DESCRIPTION
The instructions in the porting guide for creating patches only work if the open source tool has been cloned via git. For the example and for some of the existing ports, the open source tool code is sourced from a tarball. In that case, the patches will have to be manually created with diff. I tried to highlight this in this update, but the version of diff on the zOS instance that I am using is missing some of my favorite diff options.

I am not sure whether git apply will be able to use the patches created manually using diff. If git can't use the patches, then the document should be amended to say that patches can only be created when the tool source is cloned via git, and not when the tool source comes from a tarball.

I also needed the environment sourcing command before I could get anything to work, so I thought it would be a useful addition to this document. I wasn't really sure where to put it.

Also some whitespace cleanup.