### PR TITLE
mention rocket curl for consumers

### DIFF
--- a/docs/Guides/Pre-req.md
+++ b/docs/Guides/Pre-req.md
@@ -24,7 +24,7 @@ It is recommended that you add the above environment variables to your `.profile
 
 If you interested in leveraging `zopen download` to download and install the z/OS Open Source tools, then you will require the following tools on your z/OS system. Alternatively, you can manually download the pax.Z releases from Github and transfer them over to your z/OS system without any additional tooling requirements.
 
-* Obtain from Rocket: Git
+* Obtain from Rocket: git, curl (7.77 or later if downloading releases directly without `zopen download`)
 * Obtain from z/OS Open Source: curl, gzip, tar, which you can download from the [available releases](../Latest.md).
 
 Our goal is to eventually have our own version of all the _bootstrap_ tools, but right now, we rely on some


### PR DESCRIPTION
Both GH release one-liners and `zopen download` depend on pre-existing curl.

`zopen download` will tolerate older curl, but the one liners on the release pages fail with 7.42 (circa 2017). It is some pipe translation issue that results in:
>  pax: checksum error on tape (got f5bd, expected 0)