### PR TITLE
Better error message when destination is read-only

### DIFF
--- a/tools/src/createdirs.c
+++ b/tools/src/createdirs.c
@@ -1,5 +1,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
 #include "createdirs.h"
@@ -30,8 +31,8 @@ static int createsubdir(const char* rootdir, const char* subdir) {
  * passed in.
  *
  * If a directory already exists, it will not be modified,
- * and this will not be considered a 'failure' 
- * 
+ * and this will not be considered a 'failure'
+ *
  * Returns non-zero if the directories can not be created
  */
 
@@ -48,6 +49,7 @@ int createdirs(const char* rootdir) {
   for (i=0; subdir[i] != NULL; ++i ) {
     if (rc = createsubdir(rootdir, subdir[i])) {
       if (rc != ZOPEN_CREATEDIR_DIR_EXISTS) {
+        fprintf(stderr, "Could not create subdirectory '%s': %s\n", subdir[i], strerror(errno));
         return rc;
       }
     }


### PR DESCRIPTION
I tried installing to a directory that I didn't have write permissions for, and the error message wasn't very obvious.  This PR adds a nice and verbose reason as to why the failure occurred.