### PR TITLE
Adjust directory permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,14 @@ tools/src/zopen-setup
 tools/src/httpsget
 tools/src/*.o
 tools/src/hwthic.h
+
+# Vim swap files
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Vim backup files
+*~
+

--- a/tools/src/createdirs.c
+++ b/tools/src/createdirs.c
@@ -13,7 +13,7 @@ static int createsubdir(const char* rootdir, const char* subdir) {
     return ZOPEN_CREATEDIR_DIR_TOO_LONG;
   }
   if (stat(fulldir, &stfull) == -1) {
-    if (mkdir(fulldir, S_IRWXU|S_IRGRP)) {
+    if (mkdir(fulldir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)) {
       return ZOPEN_CREATEDIR_CREATE_FAILED;
     } else {
       return 0;


### PR DESCRIPTION
The permissions on the subdirectories created under the zopen base directory are too restrictive by default.  They are 0740, which isn't useful for anyone except the owner.  This patch adjusts them to be 0755, so all users across the system can access the tools.

This also adjusts the `.gitignore` file to ignore vim backup and swap files.