### PR TITLE
Enable compiler informational messages, and fix the results

### DIFF
--- a/tools/src/Makefile
+++ b/tools/src/Makefile
@@ -3,7 +3,8 @@
 #
 CC=xlc
 LD=xlc
-CFLAGS=-c -qdll -qrent -qlongname -Wl,DYNAM=DLL -Wc,GONUM
+INFO = 'info(cmp,cnv,cns,enu,lan,por,pro,ret)'
+CFLAGS=-c -qdll -qrent -qlongname -Wl,DYNAM=DLL -Wc,GONUM,${INFO}
 
 all: headers zopen-setup httpsget
 clean:

--- a/tools/src/createbootenv.c
+++ b/tools/src/createbootenv.c
@@ -1,13 +1,15 @@
 #define _POSIX_SOURCE
 #define _OPEN_SYS_FILE_EXT 1
-
-#include "createbootenv.h"
-#include "zopenio.h"
+#define _ISOC99_SOURCE
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <string.h>
+
+#include "createbootenv.h"
+#include "zopenio.h"
 
 static int setccsid(int fd, int ccsid) {
   attrib_t attr;
@@ -32,8 +34,8 @@ int createbootenv(const char* root, const char* subdir, const char* bootpkg[]) {
 	           "  return 0\n"
                    "fi\n"
                    "bootdir=\"${PWD}\"\n"
-                   "for p in ";  
- 
+                   "for p in ";
+
   char trailer[] = "; do\n"
                    "  cd \"${p}\"\n  "
                    "  . ./.env\n"
@@ -61,11 +63,11 @@ int createbootenv(const char* root, const char* subdir, const char* bootpkg[]) {
   if (!(fd = open(absbootenv, O_CREAT|O_WRONLY, S_IRUSR | S_IWUSR))) {
     fprintf(stderr, "Unable to create %s\n", absbootenv);
     return 4;
-  } 
+  }
   if (setccsid(fd, ccsid)) {
     fprintf(stderr, "Unable to tag %s\n", absbootenv);
     return 4;
-  } 
+  }
 
   if (write(fd, header, sizeof(header)-1) < sizeof(header)-1) {
     fprintf(stderr, "Unable to write header to %s\n", absbootenv);
@@ -74,25 +76,25 @@ int createbootenv(const char* root, const char* subdir, const char* bootpkg[]) {
 
   for (i=0; bootpkg[i]; ++i) {
     size_t bootlen = strlen(bootpkg[i]);
-    if (write(fd, bootpkg[i], bootlen) < bootlen) { 
+    if (write(fd, bootpkg[i], bootlen) < bootlen) {
       fprintf(stderr, "Unable to write pkg %s to %s\n", bootpkg[i], absbootenv);
       return 4;
-    } 
-    if (write(fd, " ", 1) < 1) { 
+    }
+    if (write(fd, " ", 1) < 1) {
       fprintf(stderr, "Unable to write space to %s\n", absbootenv);
       return 4;
-    } 
+    }
   }
 
   if (write(fd, trailer, sizeof(trailer)-1) < sizeof(trailer)-1) {
     fprintf(stderr, "Unable to write trailer to %s\n", absbootenv);
     return 4;
   }
- 
+
   if (close(fd)) {
     fprintf(stderr, "Unable to close %s\n", absbootenv);
     return 4;
-  } 
+  }
 #ifdef VERY_VERBOSE
   fprintf(stdout, "Successfully created boot environment file for sourcing: %s\n", absbootenv);
 #endif

--- a/tools/src/createdirs.c
+++ b/tools/src/createdirs.c
@@ -1,7 +1,9 @@
+#define _ISOC99_SOURCE
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdio.h>
+
 #include "createdirs.h"
 #include "zopenio.h"
 
@@ -30,8 +32,8 @@ static int createsubdir(const char* rootdir, const char* subdir) {
  * passed in.
  *
  * If a directory already exists, it will not be modified,
- * and this will not be considered a 'failure' 
- * 
+ * and this will not be considered a 'failure'
+ *
  * Returns non-zero if the directories can not be created
  */
 

--- a/tools/src/download.c
+++ b/tools/src/download.c
@@ -80,6 +80,8 @@
 #pragma langlvl(extc99)
 #define _ALL_SOURCE
 #define _LARGE_FILES
+#define  _XOPEN_SOURCE_EXTENDED 1
+#include <strings.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -343,7 +345,7 @@ int toolkitSetOption( HWTH_RETURNCODE_TYPE *rcPtr,
 int  setRequestHeaders( HWTH_RETURNCODE_TYPE *rcPtr,
                         HWTH_HANDLE_TYPE     *requestHandlePtr,
                         HWTH_DIAGAREA_TYPE   *diagAreaPtr );
-char  **getRequestHeaders();
+char  **getRequestHeaders(void);
 void  freeRequestHeaders( char **headersList );
 int toolkitSlistOperation( HWTH_RETURNCODE_TYPE    *rcPtr,
                            HWTH_HANDLE_TYPE        *handlePtr,
@@ -2716,7 +2718,7 @@ int setRequestHeaders( HWTH_RETURNCODE_TYPE *rcPtr,
  *
  * Returns: Address of heap-allocated ptr array
  ****************************************************************/
-char **getRequestHeaders() {
+char **getRequestHeaders(void) {
  char buf[80];
  char **headers = NULL;
  int NUM_HEADERS = 1;

--- a/tools/src/httpsget.c
+++ b/tools/src/httpsget.c
@@ -1,9 +1,13 @@
+#define _POSIX_SOURCE
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
+
 #include "createdb.h"
 #include "httpsget.h"
 #include "zopenio.h"
+#include "download.h"
 
 int httpsget(const char* host, const char* uri, const char* pem, const char* output) {
   char* keydb;
@@ -41,12 +45,12 @@ int httpsget(const char* host, const char* uri, const char* pem, const char* out
     fprintf(stderr, "error creating temporary key db %s\n", keydb);
     return rc;
   }
-   
+
   if (rc = download(host, uri, output, keydb, stashfile)) {
-    fprintf(stderr, "error downloading  https://%s%s to %s: %d\n", host, uri, output, keydb, stashfile, rc);
+    fprintf(stderr, "error downloading  https://%s%s to %s: %d\n", host, uri, output, rc);
     return rc;
   }
-    
+
   if (rc = removedb(keydb, reqdb, stashfile)) {
     fprintf(stderr, "error removing temporary key db file %s\n", keydb);
     return rc;

--- a/tools/src/httpspkg.c
+++ b/tools/src/httpspkg.c
@@ -1,7 +1,12 @@
+#define _ISOC99_SOURCE
+#include <stdio.h>
+
 #include "zopenio.h"
 #include "httpspkg.h"
-#include "zopen_boot_uri.h"
+#include "httpsget.h"
+#include "syscmd.h"
 
+#include "zopen_boot_uri.h"
 
 /*
  This is the URI pattern we want to generate:

--- a/tools/src/syscmd.c
+++ b/tools/src/syscmd.c
@@ -1,11 +1,12 @@
-#include "syscmd.h"
+#define _ISOC99_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 
+#include "syscmd.h"
 
-int unpaxandlink(const char* root, const char* subdir, const char* pkg, const char* shortname) { 
+int unpaxandlink(const char* root, const char* subdir, const char* pkg, const char* shortname) {
   char pax_format[] = "cd %s/%s && /bin/pax -rf %s && rm %s";
   char pax[ZOPEN_CMD_MAX+1];
   char ln_format[] = "/bin/sh -c \"cd %s/%s && /bin/rm -f %s && /bin/ln -s %s* %s\"";
@@ -66,7 +67,7 @@ int getpkgname(const char* temprawpkg, const char* temppkg, char* buffer, size_t
   char getpkg[ZOPEN_CMD_MAX+1];
   int rc;
   ssize_t len;
-  int fd; 
+  int fd;
 
   if ((rc = snprintf(getpkg, sizeof(getpkg), getpkg_format, temprawpkg, temprawpkg, temprawpkg, temppkg)) > sizeof(getpkg)) {
     fprintf(stderr, "error building command to get package from %s and write it to %s\n", temprawpkg, temppkg);

--- a/tools/src/zopenio.c
+++ b/tools/src/zopenio.c
@@ -1,11 +1,13 @@
-#include "zopenio.h"
-#include "zopen_boot_uri.h"
+
+#define _ISOC99_SOURCE
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <stdio.h>
 
+#include "zopenio.h"
+#include "zopen_boot_uri.h"
 
-static char* zopentmpdir() {
+static char* zopentmpdir(void) {
   char* tmpdir;
   int rc;
   if (! ((tmpdir = getenv("TMP")) || (tmpdir = getenv("TMPDIR"))) ) {

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -1,4 +1,9 @@
+#define _ISOC99_SOURCE
+#define _XOPEN_SOURCE_EXTENDED 1
+#include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+
 #include "download.h"
 #include "zopenio.h"
 #include "createpem.h"
@@ -7,6 +12,7 @@
 #include "github_pem_ca.h"
 #include "zopen_boot_uri.h"
 #include "httpsget.h"
+#include "httpspkg.h"
 #include "syscmd.h"
 #include "createbootenv.h"
 
@@ -22,7 +28,7 @@ static const char* lastpos(const char* str, int c) {
   }
   return NULL;
 }
- 
+
 static void syntax(const char* pgm) {
   const char* base;
   if (base = lastpos(pgm, '/')) {
@@ -36,7 +42,7 @@ static void syntax(const char* pgm) {
                   "  The boot subdirectory will have:\n"
                   "    sub-directories created for each of the tools needed for running the zopen utility\n"
                   "  The dev subdirectory will have:\n"
-                  "    a 'git clone' of both the utils and meta repositories\n" 
+                  "    a 'git clone' of both the utils and meta repositories\n"
                   "Options:\n"
                   " -v : print out verbose messages\n"
                   " -q : only print out errors\n",
@@ -70,7 +76,7 @@ int main(int argc, char* argv[]) {
 
   if (argc < 2) {
     syntax(argv[0]);
-    return 4; 
+    return 4;
   }
   for (i=1; i<argc; ++i) {
     if (!strcmp(argv[i], "-v")) {
@@ -99,7 +105,7 @@ int main(int argc, char* argv[]) {
     syntax(argv[0]);
     return 4;
   }
- 
+
   if (!tmppem || genfilename("pem", tmppem, ZOPEN_PATH_MAX)) {
     fprintf(stderr, "error acquiring storage\n");
     return 4;
@@ -139,7 +145,7 @@ int main(int argc, char* argv[]) {
     if ((rc = snprintf(uri, sizeof(uri), "/%s/%s%s/%s/%s", ZOPEN_BOOT_URI_PREFIX, bootpkg[i], pkgsfx, ZOPEN_BOOT_URI_SUFFIX, filename)) > sizeof(uri)) {
       fprintf(stderr, "error building uri for /%s/%s%s/%s/%s", ZOPEN_BOOT_URI_PREFIX, bootpkg[i], pkgsfx, ZOPEN_BOOT_URI_SUFFIX, filename);
       return 4;
-    }   
+    }
     if (rc = httpsget(host, uri, tmppem, output)) {
       fprintf(stderr, "error downloading https://%s%s with PEM file %s to %s\n", host, uri, tmppem, output);
       return rc;
@@ -165,7 +171,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "error creating symbolic link from %s/%s to %s\n", ZOPEN_HOME, ZOPEN_HOME_NAME, root);
     return rc;
   }
-   
+
   if (remove(tmppem)) {
     fprintf(stderr, "error removing temporary pem file: %s\n", tmppem);
     return 4;


### PR DESCRIPTION
I noticed a call to `fprintf` that had too many arguments for the number of formatters in the string, so I fixed that.  Then I wondered why it wasn't called out by the compiler, and I noticed that the informational messages weren't enabled.  I fixed that, and then got a whole bunch of warnings across the source tree.  I fixed all **that**, and finally got a clean compile.