### PR TITLE
Updates to zopen download, plus zopen update|upgrade

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -188,7 +188,7 @@ printSyntax()
   echo "  -h: print this information"
   echo "  -v: run in verbose mode"
   echo "  -vv: run in very verbose mode (sets environment variables V=1 and VERBOSE=1)"
-  echo "  -u|--updatedeps: update all dependencies by running zopen download"
+  echo "  -u|--upgradedeps: upgrade all dependencies by running zopen download"
   echo "  --buildtype: release|debug. The default is release"
   echo "  --comp: xl|clang.  The compiler used for building.  The default is xl."
   echo "  --oci: build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY"
@@ -221,7 +221,7 @@ processOptions()
   if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
     depsPath="$ZOPEN_SEARCH_PATH/prod|$ZOPEN_SEARCH_PATH/boot|$depsPath"
   fi
-  forceUpdateDeps=false
+  forceUpgradeDeps=false
   while [[ $# -gt 0 ]]; do
     case $1 in
       "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
@@ -236,8 +236,8 @@ processOptions()
         export VERBOSE=1
         verbose=true
         ;;
-      "-u" | "--updateDeps")
-        forceUpdateDeps=true
+      "-u" | "--upgradeDeps")
+        forceUpgradeDeps=true
         ;;
       "-buildtype" | "--buildtype" | "-b")
         shift
@@ -409,8 +409,8 @@ setDepsEnv()
     for path in `echo ${depsPath} | tr '|' '\n'` ; do
       if [ -r "$path/${dep}/.env" ]; then
         depdir="$path/${dep}"
-        # Avoid double sourcing the .env if we're forcing an update it
-        if ! $forceUpdateDeps; then
+        # Avoid double sourcing the .env if we're forcing an upgrade on it
+        if ! $forceUpgradeDeps; then
           printVerbose "Setting up ${depdir} dependency environment"
           cd "${depdir}" && . ./.env
         fi
@@ -418,11 +418,11 @@ setDepsEnv()
         break
       fi
     done
-    if ! $foundDep || $forceUpdateDeps; then
-      if ! $forceUpdateDeps; then
+    if ! $foundDep || $forceUpgradeDeps; then
+      if ! $forceUpgradeDeps; then
         printWarning "Dependency $dep not found. Downloading via zopen-download"
       else
-        printHeader "Updating dependency $dep. Downloading via zopen-download"
+        printHeader "Upgrading dependency $dep. Downloading via zopen-download"
       fi
       # Use the first path specified in the dependency search list
       path=$(echo ${depsPath} | tr '|' '\n' | head -1)
@@ -430,7 +430,7 @@ setDepsEnv()
       if ! zopen download -r $dep -d $path; then
         printError "zopen download command failed"
       fi
-      printVerbose "Setting up updated ${path}/${dep} dependency environment"
+      printVerbose "Setting up upgraded ${path}/${dep} dependency environment"
       cd "${path}/${dep}" && . ./.env
     fi
   done

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1118,7 +1118,7 @@ export _TAG_REDIR_ERR=txt
 export _TAG_REDIR_OUT=txt
 export ${projectName}_HOME=\${PWD}
 # Run setup.sh if it hasn't been run yet
-if [ ! -f \".installed\" ] && [ -x \"setup.sh\" ]; then
+if [ ! -f \".installed\" ] && [ ! -f \".installing\" ] && [ -x \"setup.sh\" ]; then
   ./setup.sh
 fi
 zz
@@ -1142,22 +1142,28 @@ zz
   projectName_lower=$(echo "${projectName}" | tr '[A-Z]' '[a-z]')
   cat <<zz >"${ZOPEN_INSTALL_DIR}/setup.sh"
 #!/bin/sh
+touch \".installing\"
+. ./.env
 echo \"Setting up ${projectName_lower}...\"
 zz
   if $hasHardcodedPaths; then
-  cat <<zz >>"${ZOPEN_INSTALL_DIR}/setup.sh"
-for f in \$(/bin/find \$PWD/ -type f | /bin/xargs grep -l \"ZOPEN_INSTALL_ROOT\" 2>/dev/null); do
-  if [ \"\$f\" != \"\${PWD}/setup.sh\" ] && [ \"\$f\" != \"\${PWD}/.env\" ]; then
+    cat <<zz >>"${ZOPEN_INSTALL_DIR}/setup.sh"
+for f in \$(/bin/find \$${projectName}_HOME/ -type f | /bin/xargs grep -l \"ZOPEN_INSTALL_ROOT\" 2>/dev/null); do
+  if [ \"\$f\" != \"\$${projectName}_HOME/setup.sh\" ] && [ \"\$f\" != \"\$${projectName}_HOME/.env\" ]; then
     cp \$f \$f.tmp
-    /bin/sed -e \"s#ZOPEN_INSTALL_ROOT#\${PWD}#g\" \$f.tmp > \$f
+    /bin/sed -e \"s#ZOPEN_INSTALL_ROOT#\$${projectName}_HOME#g\" \$f.tmp > \$f
     rm \$f.tmp;
   fi
 done
-touch \"\${PWD}/.installed\"
-echo \"Setup completed.\"
-
 zz
   fi
+
+  cat <<zz >>"${ZOPEN_INSTALL_DIR}/setup.sh"
+touch \".installed\"
+rm \".installing\"
+echo \"Setup completed.\"
+zz
+
   chmod 755 "${ZOPEN_INSTALL_DIR}/setup.sh"
 }
 

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1124,13 +1124,13 @@ fi
 zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
-    echo "export PATH=\"\${PWD}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export PATH=\"\${${projectName}_HOME}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then
-    echo "export LIBPATH=\"\${PWD}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export LIBPATH=\"\${${projectName}_HOME}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ]; then
-    echo "export MANPATH=\"\${PWD}/share/man:\$MANPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export MANPATH=\"\${${projectName}_HOME}/share/man:\$MANPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if command -V "${ZOPEN_APPEND_TO_ENV}" >/dev/null 2>&1; then
     printVerbose "Appending additional environment variables..."

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -8,12 +8,12 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to download/update all packages." >&2
+  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to download/upgrade all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools. If no parameters are specified, --list is the default."  >&2
-  echo "  -u|--update|--upgrade: updates installed z/OS Open Tools packages."  >&2
+  echo "  -u|--upgrade: upgrades installed z/OS Open Tools packages."  >&2
   echo "  --reinstall: reinstall already installed z/OS Open Tools packages."  >&2
   echo "  --all: downloads all z/OS Open Tools packages."  >&2
   echo "  -v: run in verbose mode." >&2
@@ -94,12 +94,12 @@ downloadRepos()
     fi
 
     latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
-    if $updateInstalled; then
+    if $upgradeInstalled; then
       if [ -e "${name}/.releaseinfo" ]; then
         originalTag=$(cat "${name}/.releaseinfo" | xargs) 
       else
         # We're only updating alreaady installed products
-        printVerbose "${downloadDir}/${name} will not be updated as it is not installed."
+        printVerbose "${downloadDir}/${name} will not be upgraded as it is not installed."
         continue;
       fi
       if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
@@ -148,6 +148,9 @@ downloadRepos()
 
     # Add tag information as a .releaseinfo file
     echo "$latestTag" > "${name}/.releaseinfo"
+
+    # Delete the .installed file if it was previously there
+    rm -f "${name}/.installed"
     printInfo "Successfully downloaded $name to $downloadDir/$name/"
 done
 }
@@ -160,7 +163,7 @@ if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
 else
   downloadDir=$PWD
 fi
-updateInstalled=false
+upgradeInstalled=false
 verbose=false
 reinstall=false
 downloadAll=false
@@ -173,8 +176,8 @@ while [[ $# -gt 0 ]]; do
       downloadDir=$2;
       shift
       ;;
-    "-u" | "--update" | "-update" | "-upgrade" | "--upgrade")
-      updateInstalled=true
+    "-u" | "--upgrade" | "-upgrade" | "-upgrade" | "--upgrade")
+      upgradeInstalled=true
       ;;
     "-reinstall" | "--reinstall")
       reinstall=true

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -12,13 +12,14 @@ printSyntax()
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
-  echo "  --list: list all available z/OS Open Tools"  >&2
-  echo "  --update: update z/OS Open Tools packages. On by default."  >&2
-  echo "  --force: force downloads all z/OS Open Tools packages."  >&2
+  echo "  --list: list all available z/OS Open Tools. If no parameters are specified, --list is the default."  >&2
+  echo "  -u|--update|--upgrade: updates installed z/OS Open Tools packages."  >&2
+  echo "  --reinstall: reinstall already installed z/OS Open Tools packages."  >&2
+  echo "  --all: downloads all z/OS Open Tools packages."  >&2
+  echo "  -v: run in verbose mode." >&2
+  echo "  -d <dir>: directory to download binaries to.  Uses current working directory or path from ~/.zopen-config (generated via zopen init) if not specified." >&2
+  echo "  <project,...>: a set of comma delimited projects to download." >&2
   echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, or skipped (no filter by default))"  >&2
-  echo "  -v: run in verbose mode" >&2
-  echo "  -d <dir>: directory to download binaries to.  Uses current working directory if not specified." >&2
-  echo "  -r <repo,...>: a set of comma delimited projects to download. Downloads all ZOSOpenTools if not specified." >&2
 }
 
 getContentsFromGithub()
@@ -92,22 +93,26 @@ downloadRepos()
       fi
     fi
 
+    latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
+    if $updateInstalled; then
+      if [ -e "${name}/.releaseinfo" ]; then
+        originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+      else
+        # We're only updating alreaady installed products
+        printInfo "${downloadDir}/${name} will not be updated as it is not installed."
+        continue;
+      fi
+      if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
+        printInfo "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
+        continue;
+      fi
+    fi
     printHeader "Preparing to download $repo"
     if [ -z "$latest_url" ]; then
       printInfo "No releases published for $repo"
       continue
     fi
 
-    latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
-    if $updateOnly; then
-      if [ -e "${name}/.releaseinfo" ]; then
-        originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-      fi
-      if [ "${latestTag}" = "${originalTag}" ]; then
-        printInfo "${downloadDir}/${name} with tag ${latestTag} already installed. Skipping..."
-        continue;
-      fi
-    fi
     latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
     printInfo "Downloading latest release from $repo..."
     if ! $verbose; then
@@ -154,23 +159,24 @@ if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
 else
   downloadDir=$PWD
 fi
-updateOnly=true
+updateInstalled=false
 verbose=false
+reinstall=false
+downloadAll=false
+if [[ $# -eq 0 ]]; then
+  list=1
+fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     "-d")
       downloadDir=$2;
       shift
       ;;
-    "-r")
-      chosenRepos=$2;
-      shift
+    "-u" | "--update" | "-update" | "-upgrade" | "--upgrade")
+      updateInstalled=true
       ;;
-    "-u" | "--update" | "-update")
-      updateOnly=true
-      ;;
-    "-f" | "-force" | "--force")
-      updateOnly=false
+    "-reinstall" | "--reinstall")
+      reinstall=true
       ;;
     "--list")
       list=1;
@@ -183,8 +189,11 @@ while [[ $# -gt 0 ]]; do
       printSyntax "${args}"
       exit 4
       ;;
+    "--all")
+      downloadAll=true
+      ;;
     "-v" | "--v" | "-verbose" | "--verbose")
-       verbose=true
+      verbose=true
       ;;
     *)
       chosenRepos=$1;
@@ -192,6 +201,10 @@ while [[ $# -gt 0 ]]; do
   esac
   shift;
 done
+
+if $downloadAll; then
+  unset chosenRepos
+fi
 
 export ZOPEN_CA="${utildir}/../../cacert.pem"
 if ! [ -r "${ZOPEN_CA}" ]; then

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -99,15 +99,16 @@ downloadRepos()
         originalTag=$(cat "${name}/.releaseinfo" | xargs) 
       else
         # We're only updating alreaady installed products
-        printInfo "${downloadDir}/${name} will not be updated as it is not installed."
+        printVerbose "${downloadDir}/${name} will not be updated as it is not installed."
         continue;
       fi
       if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
-        printInfo "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
+        printVerbose "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
         continue;
       fi
+      printInfo "New release with tag \"${latestTag}\" found for $repo"
     fi
-    printHeader "Preparing to download $repo"
+    printInfo "Preparing to download $repo"
     if [ -z "$latest_url" ]; then
       printInfo "No releases published for $repo"
       continue

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -8,7 +8,7 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to download/upgrade all packages." >&2
+  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to list all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
   echo "Syntax: zopen-download [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -1,4 +1,7 @@
-
+#!/bin/sh
+#
+# Creates a $HOME/.zopen-config file
+#
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
 . "${utildir}/common.inc"

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -1,5 +1,3 @@
-#!/bin/sh
-# Initialize zopen
 
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
@@ -28,7 +26,18 @@ if [ ! -e "$zopen_path/boot" ]; then
   mkdir -p "$zopen_path/boot"
 fi
 
+echo "Enter the github oauth token for use in zopen-download. If none, press enter"
+zopen_oauth=$(getInput)
+if [ ! -z "$zopen_oauth" ]; then
+  zopen_oauth="export ZOPEN_GIT_OAUTH_TOKEN=$zopen_oauth"
+fi
+
+
 # Save the configuration to the file
-echo "export ZOPEN_SEARCH_PATH=$zopen_path" > "$HOME/.zopen-config"
+
+cat <<zz >"${HOME}/.zopen-config"
+export ZOPEN_SEARCH_PATH=$zopen_path
+$zopen_oauth
+zz
 
 printInfo "Creating config in $HOME/.zopen-config"

--- a/bin/zopen
+++ b/bin/zopen
@@ -7,10 +7,12 @@ printSyntax()
   echo "" >&2
   echo "Syntax: zopen <command>" >&2
   echo "where <command> may be one of the following:" >&2
+  echo " init: generate a $HOME/.zopen-config file." >&2
   echo " build: invokes the build script." >&2
-  echo " download: downloads binaries" >&2
+  echo " download: downloads z/OS Open Tools" >&2
   echo " generate: generate a zopen project" >&2
   echo " update-cacert: update the cacert.pem file" >&2
+  echo " update|upgrade: updates already installed tools" >&2
   echo "" >&2
 }
 
@@ -43,6 +45,10 @@ while [[ $# -gt 0 ]]; do
     "download")
       shift
       exec "${bindir}/lib/zopen-download" $@
+      ;;
+    "update" | "upgrade")
+      shift
+      exec "${bindir}/lib/zopen-download" -u $@
       ;;
     "generate")
       shift

--- a/bin/zopen
+++ b/bin/zopen
@@ -12,7 +12,7 @@ printSyntax()
   echo " download: downloads z/OS Open Tools" >&2
   echo " generate: generate a zopen project" >&2
   echo " update-cacert: update the cacert.pem file" >&2
-  echo " update|upgrade: updates already installed tools" >&2
+  echo " upgrade: upgrades already installed tools" >&2
   echo "" >&2
 }
 
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
       shift
       exec "${bindir}/lib/zopen-download" $@
       ;;
-    "update" | "upgrade")
+    "upgrade")
       shift
       exec "${bindir}/lib/zopen-download" -u $@
       ;;

--- a/docs/Guides/zopen.md
+++ b/docs/Guides/zopen.md
@@ -21,12 +21,12 @@ To update the cacert.pem file, you can use `zopen update-cacert`. This will down
 
 ### zopen download
 
-To download and install the latest software packages, you can use `zopen download`. By default it will download all of the binaries hosted on ZOSOpenTools.
+To download and install the latest software packages, you can use `zopen download`. By default it will list all of the packages hosted on ZOSOpenTools.
 
 It is recommended that you generate a [github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 Then set `export ZOPEN_GIT_OAUTH_TOKEN=<yourapitoken>`
 
-To list the available packages, specify the `--list` option as follows:
+To list the available packages, specify no parameters or the `--list` option as follows:
 ```
 zopen download --list
 ```
@@ -36,7 +36,7 @@ To download and install specfic packages, you can specify the packages as a comm
 zopen download make,gzip
 ```
 
-This will download it to the current working directory. To change the destination directory, you can specify the `-d` option as follows:
+This will download it to the directory specified by your ~/.zopen-config. To change the destination directory, you can specify the `-d` option as follows:
 
 ```
 zopen download make -d $HOME/zopen/prod

--- a/docs/Guides/zopen.md
+++ b/docs/Guides/zopen.md
@@ -15,7 +15,7 @@ Alternatively, you can download meta, along with the foundational set of tools v
 ### zopen init
 To initialize the zopen installation directory to a location other than the default ($HOME/zopen), you can run the command zopen init and specify the desired directory. This will configure the directory for future use. Subsequently, tools like zopen download will download and install files to this specified directory."
 
-### zopen cacert
+### zopen update-cacacert
 
 To update the cacert.pem file, you can use `zopen update-cacert`. This will download the latest cacert.pem file https://curl.se/docs/caextract.html. This cacert.pem file is then used by other tools such as `zopen download` and `zopen build`.
 
@@ -40,6 +40,21 @@ This will download it to the current working directory. To change the destinatio
 
 ```
 zopen download make -d $HOME/zopen/prod
+```
+
+You can then change to the install directory and source the .env file: `. ./.env` to setup the tool.
+
+### zopen upgrade
+
+To upgrade already installed software packages, you can use `zopen upgrade`.
+
+```
+zopen upgrade
+```
+
+To upgrade a specific set of packages, you can specify the packages as a comma seperated list as follows:
+```
+zopen upgrade make,gzip
 ```
 
 ## If you are contributing to or developing z/OS Open Tools


### PR DESCRIPTION
Implements @dougburns suggestions:
```
"zopen download" with no parameters implicitly does a --list
"zopen download --update" updates existing packages
"zopen download --all" gets everything, with update of anything already there
"zopen download <packagelist>" downloads the specified packages, updating any of those that already exist
```

In addition, it aliases `zopen update` and `zopen upgrade` to `zopen download --update` 
Also adds `zopen init` description to the zopen help