### PR TITLE
change order of tools to be set up from .bootenv and fixed UX issues

### DIFF
--- a/tools/src/download.c
+++ b/tools/src/download.c
@@ -147,6 +147,7 @@ char *DS_TYPE = "blocked";         /* TRSMAIN convention */
 #define HTTP_RC_REDIRECT  302 
 #define HTTP_RC_UNAUTHORIZED 401
 #define HTTP_RC_FORBIDDEN 403
+#define HTTP_RC_NOTFOUND 404
 
 /********************************
  * variables and constants which
@@ -1555,6 +1556,9 @@ int toolkitSlistOperation( HWTH_RETURNCODE_TYPE    *rcPtr,
 		 break;
 	 case HTTP_RC_FORBIDDEN:
      rc = HTTP_RC_FORBIDDEN;
+     break; /* this is an error - but we will not print a message about it */
+	 case HTTP_RC_NOTFOUND:
+     rc = HTTP_RC_NOTFOUND;
      break; /* this is an error - but we will not print a message about it */
 	 case HTTP_RC_UNAUTHORIZED:
      rc = HTTP_RC_UNAUTHORIZED;

--- a/tools/src/httpsget.c
+++ b/tools/src/httpsget.c
@@ -57,6 +57,10 @@ int httpsget(const char* host, const char* uri, const char* pem, const char* out
       fprintf(stderr, "This is likely because you have an expired or invalid github OAUTH id.\n");
       fprintf(stderr, "Please see: https://zosopentools.link/github-oauth for instructions on how to set up a new github OAUTH id.\n");
       fprintf(stderr, "Once your OAUTH id is reset, export ZOPEN_GIT_OAUTH_TOKEN=<your token> and then re-run zopen-setup.\n");
+    } else if (rc == 404) {
+      fprintf(stderr, "You have received a 404 Not Found error from %s%s\n", host, uri);
+      fprintf(stderr, "This is likely because there is no release currently tagged as 'boot' for this package\n");
+      fprintf(stderr, "Open an issue at https://github.com/ZOSOpenTools/<pkg>port/issues\n");
     } else {
       fprintf(stderr, "error downloading  https://%s%s to %s: %d\n", host, uri, output, rc);
     }

--- a/tools/src/syscmd.c
+++ b/tools/src/syscmd.c
@@ -43,11 +43,11 @@ int unpaxandlink(const char* root, const char* subdir, const char* pkg, const ch
 }
 
 int createhomelink(const char* home, const char* name, const char* root) {
-  char ln_format[] = "/bin/sh -c \"cd %s && /bin/rm -f %s && /bin/ln -s %s %s/zopen\"";
+  char ln_format[] = "/bin/sh -c \"/bin/rm -rf %s/%s/* && /bin/ln -s %s %s/%s\"";
   char ln[ZOPEN_CMD_MAX+1];
   int rc;
-  if ((rc = snprintf(ln, sizeof(ln), ln_format, home, name, root, home)) > sizeof(ln)) {
-    fprintf(stderr, "error building command for symbolic link of %s from %s/%s\n", root, home, name);
+  if ((rc = snprintf(ln, sizeof(ln), ln_format, home, name, root, home, name)) > sizeof(ln)) {
+    fprintf(stderr, "error building command for symbolic link to %s from %s/%s\n", root, home, name);
     return rc;
   }
   rc = system(ln);

--- a/tools/src/zopen_boot_uri.h
+++ b/tools/src/zopen_boot_uri.h
@@ -6,5 +6,11 @@
   #define ZOPEN_BOOT_URI_PREFIX "ZOSOpenTools"
   #define ZOPEN_BOOT_URI_SUFFIX "releases/download/boot"
   #define ZOPEN_BOOT_URI_TYPE "zos.pax.Z"
-  #define ZOPEN_BOOT_PKG { "curl", "gzip", "tar", "make", "git", "meta", NULL }
+
+  /*
+   * Make sure 'meta' is first - we should make all packages independent, but they are not quite yet
+   * We may want to trim down the list of tools a bit. In particular vim and ncurses are not _required_
+   * but they sure are nice.
+   */
+  #define ZOPEN_BOOT_PKG { "meta", "curl", "make", "git", "less", "perl", "jq", "bash", "diffutils", "findutils", "coreutils", "tar", "gzip", "xz", "bzip2", "vim", "ncurses", NULL }
 #endif

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -130,8 +130,9 @@ int main(int argc, char* argv[]) {
     if (verbose) {
       fprintf(STDTRC, "Download %s into %s/%s\n", bootpkg[i], root,  ZOPEN_BOOT);
     }
-    if (getfilenamefrompkg(bootpkg[i], pkgsfx, tmppem, filename, ZOPEN_PATH_MAX)) {
-      return 4;
+    if (rc = getfilenamefrompkg(bootpkg[i], pkgsfx, tmppem, filename, ZOPEN_PATH_MAX)) {
+      /* If the boot package isn't found (404), keep going */
+      if (rc == 404) { continue; }
     }
     if (genfilenameinsubdir(root, ZOPEN_BOOT, filename, output, ZOPEN_PATH_MAX)) {
       return 4;
@@ -141,8 +142,7 @@ int main(int argc, char* argv[]) {
       return 4;
     }
     if (rc = httpsget(host, uri, tmppem, output)) {
-      fprintf(stderr, "error downloading https://%s%s with PEM file %s to %s\n", host, uri, tmppem, output);
-      return rc;
+      fprintf(stderr, "error %d downloading https://%s%s with PEM file %s to %s\n", rc, host, uri, tmppem, output);
     }
     if (rc = unpaxandlink(root, ZOPEN_BOOT, output, bootpkg[i])) {
       return rc;


### PR DESCRIPTION
Added graceful failure when package not found (404) so that we can use zopen-setup while we add more boot releases

Cleaned up code that was cleaning up the directories before creating symbolic links

Changed the order of the packages so 'meta' is first and added in more packages

