### PR TITLE
Add install-or-upgrade option to zopen download to eliminate having to re-download packages every build

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -427,7 +427,7 @@ setDepsEnv()
       fi
       # Use the first path specified in the dependency search list
       path=$(echo ${depsPath} | tr '|' '\n' | head -1)
-      printVerbose "Running zopen download -r $dep -d $path"
+      printVerbose "Running zopen download --install-or-upgrade -r $dep -d $path -v"
       if ! zopen download -r $dep -d $path; then
         printError "zopen download command failed"
       fi
@@ -1306,7 +1306,14 @@ resolveCommands()
   fi
 
   if [ "${ZOPEN_INSTALL}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_INSTALL})" ]; then
-    export ZOPEN_INSTALL_CMD="${ZOPEN_INSTALL} ${ZOPEN_INSTALL_OPTS}"
+    case "${ZOPEN_CONFIGURE}" in
+      (*cmake*)
+        export ZOPEN_INSTALL_CMD="\"${ZOPEN_INSTALL}\" ${ZOPEN_INSTALL_OPTS}"
+        ;;
+      (*)
+        export ZOPEN_INSTALL_CMD="\"${ZOPEN_INSTALL}\" ${ZOPEN_INSTALL_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\""
+        ;;
+    esac
     [[ -d ${ZOPEN_ROOT}/install ]] || mkdir -p ${ZOPEN_ROOT}/install
     paxFileName="${ZOPEN_ROOT}/install/${ZOPEN_NAME}.${LOG_PFX}.zos.pax.Z"
     export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -14,6 +14,7 @@ printSyntax()
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools. If no parameters are specified, --list is the default."  >&2
   echo "  -u|--upgrade: upgrades installed z/OS Open Tools packages."  >&2
+  echo "  --install-or-upgrade: installs the package if not installed, or upgrades the package if installed."  >&2
   echo "  --reinstall: reinstall already installed z/OS Open Tools packages."  >&2
   echo "  --all: downloads all z/OS Open Tools packages."  >&2
   echo "  -v: run in verbose mode." >&2
@@ -94,10 +95,10 @@ downloadRepos()
     fi
 
     latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
-    if $upgradeInstalled; then
+    if $upgradeInstalled || $installOrUpgrade; then
       if [ -e "${name}/.releaseinfo" ]; then
         originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-      else
+      elif ! $installOrUpgrade; then
         # We're only updating alreaady installed products
         printVerbose "${downloadDir}/${name} will not be upgraded as it is not installed."
         continue;
@@ -167,6 +168,7 @@ upgradeInstalled=false
 verbose=false
 reinstall=false
 downloadAll=false
+installOrUpgrade=false
 if [[ $# -eq 0 ]]; then
   list=1
 fi
@@ -181,6 +183,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     "-reinstall" | "--reinstall")
       reinstall=true
+      ;;
+    "--install-or-upgrade")
+      installOrUpgrade=true
       ;;
     "--list")
       list=1;


### PR DESCRIPTION
* Also appends flags to make install command, otherwise make install that has compile steps may fail (happened in Git)