### PR TITLE
Add new 'common solution' for S_TYPExxx macros

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,4 @@ The [z/OS Open Tools community](https://github.com/ZOSOpenTools) is here to enco
 
 <hr />
 
-<sup>You can update this page. Learn more at [Updating docs](/README_docs.md).</sup>
+<sup>You can update this page. Learn more at [Updating docs](./README_docs.md).</sup>

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
   - [Available ports](/Latest.md)
     - [Current Status](/Progress.md)
   - [FAQ](/Guides/FAQ.md)
+  - [Common Solutions](/Guides/CommonSolutions.md)
   - Articles
     - [Using Git on z/OS](/Guides/GitOnZOS.md)
     - [Using Vim on z/OS](/Guides/VimOnZOS.md)


### PR DESCRIPTION
- fix broken link to 'Updating docs', 
- add back 'Common Solutions'
- add the new common solution to working around broken S_TYPExxxx macros