### PR TITLE
Use /bin/echo to intrepret backslash escapes. Modern echo requires -e option

### DIFF
--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -126,7 +126,7 @@ zopen_append_to_env()
   # echo envars outside of PATH, MANPATH, LIBPATH
 }"
 
-echo "$buildenvContents" > $buildenv
+/bin/echo "$buildenvContents" > $buildenv
 
 printInfo "$buildenv created"
 


### PR DESCRIPTION
If we pass -e to /bin/echo it gets displayed. Rather than adding conditions to handle both coreutils echo and /bin/echo, just use /bin/echo.