### PR TITLE
Increase buffer size used for GitHub token.

### DIFF
--- a/tools/src/download.c
+++ b/tools/src/download.c
@@ -2731,7 +2731,7 @@ int setRequestHeaders( HWTH_RETURNCODE_TYPE *rcPtr,
  * Returns: Address of heap-allocated ptr array
  ****************************************************************/
 char **getRequestHeaders(void) {
- char buf[80];
+ char buf[280];
  char **headers = NULL;
  int num_headers = 1;
 

--- a/tools/src/download.c
+++ b/tools/src/download.c
@@ -2731,7 +2731,13 @@ int setRequestHeaders( HWTH_RETURNCODE_TYPE *rcPtr,
  * Returns: Address of heap-allocated ptr array
  ****************************************************************/
 char **getRequestHeaders(void) {
- char buf[280];
+ /* See https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/
+  * The GitHub token can be up to 255 characters in length.
+    Size the buffer accordingly:
+    255 (max token length) + 20 (string Authorization:Bearer)
+    + a couple of spare bytes for zero terminator etc.
+  */
+ char buf[255 + 20 + 5];
  char **headers = NULL;
  int num_headers = 1;
 


### PR DESCRIPTION
According to the [GitHub blog](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/) a GitHub token can be aup to 255 characters in length. The current temporary buffer has size 80, which is too small.
This PR changes the size to 280 (255 for the token, 20 for Authorization:Bearer, and a couple of spare bytes).