### PR TITLE
Migrate source to OpenXL

### DIFF
--- a/tools/src/createdirs.c
+++ b/tools/src/createdirs.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "createdirs.h"
 #include "zopenio.h"

--- a/tools/src/download.c
+++ b/tools/src/download.c
@@ -81,6 +81,9 @@
 #define _ALL_SOURCE
 #define _LARGE_FILES
 #define  _XOPEN_SOURCE_EXTENDED 1
+#ifndef _EXT
+#define _EXT
+#endif
 #include <strings.h>
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
Compiling the source with OpenXL results in 2 errors:

- In createdirs.c the include <string.h> is missing
- In download.c, the macro _EXT must be defined for the fldata() function.

There are many warnings coming from OpenXL - this only fixes the compile errors.