### PR TITLE
Add support for $HOME/zopen as target location and running without _BPX_AUTOCVT set

### DIFF
--- a/tools/src/Makefile
+++ b/tools/src/Makefile
@@ -15,7 +15,10 @@ hwthic.h:
 
 headers: hwthic.h
 
-httpsget: httpsgetmain.o httpsget.o createdb.o createpem.o download.o zopenio.o
+ceeuopt.o: ceeuopt.s
+	as ceeuopt.s
+
+httpsget: httpsgetmain.o httpsget.o createdb.o createpem.o download.o zopenio.o ceeuopt.o
 	$(LD) $(LDFLAGS) -o$@ $^
     
 zopen-setup: zopensetupmain.o download.o createdirs.o createdb.o createpem.o httpsget.o zopenio.o syscmd.o createbootenv.o httpspkg.o

--- a/tools/src/ceeuopt.s
+++ b/tools/src/ceeuopt.s
@@ -1,0 +1,77 @@
+*/****************************************************************/     00010000
+*/* LICENSED MATERIALS - PROPERTY OF IBM                         */     00020000
+*/*                                                              */     00030000
+*/* 5650-ZOS                                                     */     00040000
+*/*                                                              */     00050000
+*/*     COPYRIGHT IBM CORP. 1991, 2012                           */     00060000
+*/*                                                              */     00070000
+*/* US GOVERNMENT USERS RESTRICTED RIGHTS - USE,                 */     00080000
+*/* DUPLICATION OR DISCLOSURE RESTRICTED BY GSA ADP              */     00090000
+*/* SCHEDULE CONTRACT WITH IBM CORP.                             */     00100000
+*/*                                                              */     00110000
+*/* STATUS = HLE7790                                             */     00120000
+*/****************************************************************/     00130000
+CEEUOPT  CSECT                                                          00180000
+CEEUOPT  AMODE ANY                                                      00190000
+CEEUOPT  RMODE ANY                                                      00200000
+         CEEXOPT ABPERC=(NONE),                                        X00210000
+               ABTERMENC=(ABEND),                                      X00220000
+               AIXBLD=(OFF),                                           X00230000
+               ALL31=(ON),                                             X00240000
+               ANYHEAP=(16K,8K,ANYWHERE,FREE),                         X00250000
+               BELOWHEAP=(8K,4K,FREE),                                 X00260000
+               CBLOPTS=(ON),                                           X00270000
+               CBLPSHPOP=(ON),                                         X00280000
+               CBLQDA=(OFF),                                           X00290000
+               CEEDUMP=(60,SYSOUT=*,FREE=END,SPIN=UNALLOC),            X00290100
+               CHECK=(ON),                                             X00300000
+               COUNTRY=(US),                                           X00310000
+               DEBUG=(OFF),                                            X00320000
+               DEPTHCONDLMT=(10),                                      X00330000
+               DYNDUMP=(*USERID,NODYNAMIC,TDUMP),                      X00331000
+               ENVAR=(''),                                             X00340000
+               ERRCOUNT=(0),                                           X00350000
+               ERRUNIT=(6),                                            X00360000
+               FILEHIST=(ON),                                          X00370000
+               FILETAG=(AUTOCVT,AUTOTAG),                              X00375000
+               HEAP=(32K,32K,ANYWHERE,KEEP,8K,4K),                     X00380000
+               HEAPCHK=(OFF,1,0,0,0,1024,0,1024,0),                    X00390000
+               HEAPPOOLS=(OFF,8,10,32,10,128,10,256,10,1024,10,2048,   X00400000
+               10,0,10,0,10,0,10,0,10,0,10,0,10),                      X00410000
+               HEAPZONES=(0,ABEND,0,ABEND),                            X00415000
+               INFOMSGFILTER=(OFF,,,,),                                X00420000
+               INQPCOPN=(ON),                                          X00430000
+               INTERRUPT=(OFF),                                        X00440000
+               LIBSTACK=(4K,4K,FREE),                                  X00460000
+               MSGFILE=(SYSOUT,FBA,121,0,NOENQ),                       X00470000
+               MSGQ=(15),                                              X00480000
+               NATLANG=(ENU),                                          X00490000
+               NOAUTOTASK=,                                            X00500000
+               NOTEST=(ALL,*,PROMPT,INSPPREF),                         X00520000
+               NOUSRHDLR=(''),                                         X00530000
+               OCSTATUS=(ON),                                          X00540000
+               PAGEFRAMESIZE=(4K,4K,4K),                               X00541000
+               PC=(OFF),                                               X00550000
+               PLITASKCOUNT=(20),                                      X00560000
+               POSIX=(ON),                                             X00570000
+               PROFILE=(OFF,''),                                       X00580000
+               PRTUNIT=(6),                                            X00590000
+               PUNUNIT=(7),                                            X00600000
+               RDRUNIT=(5),                                            X00610000
+               RECPAD=(OFF),                                           X00620000
+               RPTOPTS=(OFF),                                          X00630000
+               RPTSTG=(OFF),                                           X00640000
+               RTEREUS=(OFF),                                          X00650000
+               SIMVRD=(OFF),                                           X00670000
+               STACK=(128K,128K,ANYWHERE,KEEP,512K,128K),              X00680000
+               STORAGE=(NONE,NONE,NONE,0K),                            X00690000
+               TERMTHDACT=(TRACE,,96),                                 X00700000
+               THREADHEAP=(4K,4K,ANYWHERE,KEEP),                       X00710000
+               THREADSTACK=(OFF,4K,4K,ANYWHERE,KEEP,128K,128K),        X00720000
+               TRACE=(OFF,4K,DUMP,LE=0),                               X00730000
+               TRAP=(ON,SPIE),                                         X00740000
+               UPSI=(00000000),                                        X00750000
+               VCTRSAVE=(OFF),                                         X00760000
+               XPLINK=(OFF),                                           X00780000
+               XUFLOW=(AUTO)                                            00790000
+         END                                                            00800000

--- a/tools/src/syscmd.c
+++ b/tools/src/syscmd.c
@@ -63,7 +63,7 @@ int createhomelink(const char* home, const char* root) {
 }
 
 int getpkgname(const char* temprawpkg, const char* temppkg, char* buffer, size_t bufflen) {
-  char getpkg_format[] = "/bin/sh -c \"chtag -t %s && chtag -cISO8859-1 %s && cat %s | awk ' BEGIN { RS=\\\",\\\" } { print }' | grep '\\\"name\\\":' | grep pax.Z | tr '\\\"' ' ' | /bin/awk '{ print \\$3 }' >%s\"";
+  char getpkg_format[] = "/bin/sh -c \"export _BPXK_AUTOCVT=ON && /bin/chtag -r %s && /bin/chtag -tcISO8859-1 %s && /bin/cat %s | /bin/awk ' BEGIN { RS=\\\",\\\" } { print }' | /bin/grep '\\\"name\\\":' | /bin/grep pax.Z | /bin/tr '\\\"' ' ' | /bin/awk '{ print \\$3 }' >%s\"";
   char getpkg[ZOPEN_CMD_MAX+1];
   int rc;
   ssize_t len;

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -168,6 +168,7 @@ int main(int argc, char* argv[]) {
     if (rc = getfilenamefrompkg(bootpkg[i], pkgsfx, tmppem, filename, ZOPEN_PATH_MAX)) {
       /* If the boot package isn't found (404), keep going */
       if (rc == 404) { continue; }
+      return rc;
     }
     if (genfilenameinsubdir(root, ZOPEN_BOOT, filename, output, ZOPEN_PATH_MAX)) {
       return 4;
@@ -178,6 +179,7 @@ int main(int argc, char* argv[]) {
     }
     if (rc = httpsget(host, uri, tmppem, output)) {
       fprintf(stderr, "error %d downloading https://%s%s with PEM file %s to %s\n", rc, host, uri, tmppem, output);
+      return rc;
     }
     if (rc = unpaxandlink(root, ZOPEN_BOOT, output, bootpkg[i])) {
       return rc;

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -43,7 +43,9 @@ static void syntax(const char* pgm) {
                   "    sub-directories created for each of the tools needed for running the zopen utility\n"
                   "Options:\n"
                   " -v : print out verbose messages\n"
-                  " -q : only print out errors\n",
+                  " -q : only print out errors\n"
+                  "Note:\n"
+                  " Special consideration is made if <root> is ${HOME}/zopen in which case no link is created\n",
                   pgm, ZOPEN_TOOLS_URL, pgm);
   return;
 }

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -48,6 +48,15 @@ static void syntax(const char* pgm) {
   return;
 }
 
+#define _CVTSTATE_OFF     0
+#define _CVTSTATE_ON      1
+#define _CVTSTATE_ALL     4
+
+#define _CVTSTATE_SWAP    2
+#define _CVTSTATE_QUERY   3
+
+int __ae_autoconvert_state(int action);
+
 /*
  * This program does the following:
  * - creates the directories for z/OS Open Source Tools from the 'root' directory provided (boot, prod, dev)
@@ -74,6 +83,8 @@ int main(int argc, char* argv[]) {
   int   i;
   int parmsok=0;
   char* zopen_c_home_var = getenv("HOME");
+
+  __ae_autoconvert_state(_CVTSTATE_ON); 
 
   if (argc < 2) {
     syntax(argv[0]);

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -77,10 +77,11 @@ int main(int argc, char* argv[]) {
   char  output[ZOPEN_PATH_MAX+1];
   char  tmppem[ZOPEN_PATH_MAX+1];
   char  zopenhome[ZOPEN_PATH_MAX+1];
-  char  realpathbuffer[ZOPEN_PATH_MAX+1];
+  char  realpathhome[ZOPEN_PATH_MAX+1];
   char  uri[ZOPEN_PATH_MAX+1];
   int   rc;
   int   i;
+  int symlink;
   int parmsok=0;
   char* zopen_c_home_var = getenv("HOME");
 
@@ -125,10 +126,17 @@ int main(int argc, char* argv[]) {
     return 4;
   }
 
-  if (realpath(zopenhome, realpathbuffer)) {
-    fprintf(stderr, "File or directory %s exists. Please move this file before running since a symbolic link will be created\n", zopenhome);
-    syntax(argv[0]);
-    return 4;
+  if (realpath(zopenhome, realpathhome)) {
+    if (strcmp(root, realpathhome)) {
+      fprintf(stderr, "File or directory %s exists. Please move this file before running since a symbolic link will be created\n", zopenhome);
+      syntax(argv[0]);
+      return 4;
+    } else {
+      /* Special case - if zopenhome and realpathhome are the same, recognize this and skip creating a symbolic link */
+      symlink=0;
+    }
+  } else {
+    symlink=1;
   }
 
   if (gentmpfilename("pem", tmppem, ZOPEN_PATH_MAX)) {
@@ -181,13 +189,20 @@ int main(int argc, char* argv[]) {
     return rc;
   }
 
-  if (verbose) {
-    fprintf(STDTRC, "Create symbolic link from %s to %s\n", zopenhome, ZOPEN_HOME_NAME, root);
+  if (symlink) {
+    if (verbose) {
+      fprintf(STDTRC, "Create symbolic link from %s to %s\n", zopenhome, root);
+    }
+    if (createhomelink(zopenhome, root)) {
+      fprintf(stderr, "error creating symbolic link from %s to %s\n", zopenhome, root);
+      return rc;
+    }
+  } else {
+    if (verbose) {
+      fprintf(STDTRC, "No symbolic link from %s to %s required\n", zopenhome, root);
+    }
   }
-  if (createhomelink(zopenhome, root)) {
-    fprintf(stderr, "error creating symbolic link from %s to %s\n", zopenhome, root);
-    return rc;
-  }
+
 
   if (remove(tmppem)) {
     fprintf(stderr, "error removing temporary pem file: %s\n", tmppem);


### PR DESCRIPTION
This PR fixes two bugs:
- if someone does not have _BPX_AUTOCVT=ON set, then errors occur - fix is to explicitly set the environment variable when running a shell that cares
- If someone specifies a target location of $HOME/zopen it will now 'work' (writing to that location and not creating a symlink)