### PR TITLE
Step 1 of deps parsing of optional operator and version, and cleanup of envars

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -163,4 +163,48 @@ processConfig()
   fi
 }
 
+parseDeps()
+{
+  dep="$1"
+  version=$(echo $dep | awk -F '[>=<]+' '{print $2}')
+  if [ -z "$version" ]; then
+    operator=""
+    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
+  else
+    operator=$(echo $dep | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
+    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
+    case $operator in
+      ">=") ;;
+      "=") ;;
+      *) printError "$operator is not supported."
+    esac
+    major=$(echo $version | awk -F. '{print $1}')
+    minor=$(echo $version | awk -F. '{print $2}')
+    if [ -z "$minor" ]; then
+      patch=0
+    fi
+    patch=$(echo $version | awk -F. '{print $3}')
+    if [ -z "$patch" ]; then
+      patch=0
+    fi
+  fi
+
+  echo "$dep|$operator|$major|$minor|$patch"
+}
+
+validateVersion()
+{
+  version=$1
+  operator=$2
+  requestedVersion=$3
+  if [ ! -z "$operator" ] && [ -z "$version" ]; then
+    printWarning "$operator ${requestedVersion} requsted, but no version file found in $versionPath." 
+    return 1
+  elif [ ! -z "$operator" ] && [ ! $(echo "${version} $operator \"${requestedVersion}\"" | bc -l) -eq 1 ]; then
+    printWarning "Dependency does not satisfy ${version} $operator \"${requestedVersion}\""
+    return 1
+  fi
+  return 0
+}
+
 zopenInitialize

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -192,16 +192,52 @@ parseDeps()
   echo "$dep|$operator|$major|$minor|$patch"
 }
 
+compareVersions()
+{
+ v1="$1"
+  v2="$2"
+  result=$(awk -v v1="$v1" -v v2="$v2" '
+  function vercmp(v1, v2) {
+    n1 = split(v1, v1_array, ".")
+    n2 = split(v2, v2_array, ".")
+
+    for (i = 1; i <= n1 || i <= n2; i++) {
+      if (i > n1) {
+        return -1
+      }
+      if (i > n2) {
+        return 1
+      }
+      if (v1_array[i] != v2_array[i]) {
+        return (v1_array[i] < v2_array[i] ? -1 : 1)
+      }
+    }
+    return 0
+  }
+
+  BEGIN {
+    if (vercmp(v1, v2) >= 0) {
+      exit 0
+    } else {
+      exit 1
+    }
+  }
+  ')
+
+  return $result
+}
+
 validateVersion()
 {
   version=$1
   operator=$2
   requestedVersion=$3
+  dependency=$4
   if [ ! -z "$operator" ] && [ -z "$version" ]; then
-    printWarning "$operator ${requestedVersion} requsted, but no version file found in $versionPath." 
+    printVerbose "$operator ${requestedVersion} requsted, but no version file found in $versionPath." 
     return 1
-  elif [ ! -z "$operator" ] && [ ! $(echo "${version} $operator \"${requestedVersion}\"" | bc -l) -eq 1 ]; then
-    printWarning "Dependency does not satisfy ${version} $operator \"${requestedVersion}\""
+  elif [ ! -z "$operator" ] && ! compareVersions "${version}" "${requestedVersion}"; then
+    printVerbose "$dependency does not satisfy ${version} $operator ${requestedVersion}"
     return 1
   fi
   return 0

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -181,33 +181,31 @@ parseDeps()
     major=$(echo $version | awk -F. '{print $1}')
     minor=$(echo $version | awk -F. '{print $2}')
     if [ -z "$minor" ]; then
-      patch=0
+      minor=0
     fi
     patch=$(echo $version | awk -F. '{print $3}')
     if [ -z "$patch" ]; then
       patch=0
     fi
+    prerelease=$(echo $version | awk -F. '{print $4}')
+    if [ -z "$prerelease" ]; then
+      prerelease=0
+    fi
   fi
 
-  echo "$dep|$operator|$major|$minor|$patch"
+  echo "$dep|$operator|$major|$minor|$patch|$prerelease"
 }
 
 compareVersions()
 {
- v1="$1"
+  v1="$1"
   v2="$2"
-  result=$(awk -v v1="$v1" -v v2="$v2" '
+  awk -v v1="$v1" -v v2="$v2" '
   function vercmp(v1, v2) {
     n1 = split(v1, v1_array, ".")
     n2 = split(v2, v2_array, ".")
 
     for (i = 1; i <= n1 || i <= n2; i++) {
-      if (i > n1) {
-        return -1
-      }
-      if (i > n2) {
-        return 1
-      }
       if (v1_array[i] != v2_array[i]) {
         return (v1_array[i] < v2_array[i] ? -1 : 1)
       }
@@ -222,9 +220,9 @@ compareVersions()
       exit 1
     }
   }
-  ')
+  '
 
-  return $result
+  return $?
 }
 
 validateVersion()

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -394,6 +394,35 @@ checkEnv()
   fi
 }
 
+parseDeps()
+{
+  dep="$1"
+  version=$(echo $dep | awk -F '[>=<]+' '{print $2}')
+  if [ -z "$version" ]; then
+    operator=""
+    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
+  else
+    operator=$(echo $dep | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
+    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
+    case $operator in
+      ">=") ;;
+      "=") ;;
+      *) printError "$operator is not supported."
+    esac
+    major=$(echo $version | awk -F. '{print $1}')
+    minor=$(echo $version | awk -F. '{print $2}')
+    if [ -z "$minor" ]; then
+      patch=0
+    fi
+    patch=$(echo $version | awk -F. '{print $3}')
+    if [ -z "$patch" ]; then
+      patch=0
+    fi
+  fi
+
+  echo "$dep|$operator|$major|$minor|$patch"
+}
+
 setDepsEnv()
 {
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
@@ -406,10 +435,17 @@ setDepsEnv()
   # Filter out duplicate deps
   deps=$(echo "$deps" | xargs | tr ' ' '\n' | sort -u)
   for dep in $deps; do
+    parseline=$(parseDeps $dep)
+    dep=$(echo $parseline | awk -F'|' '{print $1}')
+    operator=$(echo $parseline | awk -F'|' '{print $2}')
+    major=$(echo $parseline | awk -F'|' '{print $3}')
+    minor=$(echo $parseline | awk -F'|' '{print $4}')
+    patch=$(echo $parseline | awk -F'|' '{print $5}')
     foundDep=false
     for path in `echo ${depsPath} | tr '|' '\n'` ; do
       if [ -r "$path/${dep}/.env" ]; then
         depdir="$path/${dep}"
+        # TODO: Check if version requested is satisfied by dependency
         # Avoid double sourcing the .env if we're forcing an upgrade on it
         if ! $forceUpgradeDeps; then
           printVerbose "Setting up ${depdir} dependency environment"
@@ -980,7 +1016,7 @@ build()
   if [ -n "${ZOPEN_MAKE_CMD}" ]; then
     printHeader "Running Build"
     create_fifo_pipe "${makelog}"
-    if ! runAndLog "${ZOPEN_MAKE_CMD} > $TMP_FIFO_PIPE"; then
+    if ! runAndLog "${ZOPEN_MAKE_CMD} > $TMP_FIFO_PIPE 2>&1"; then
       if [ "${ZOPEN_MAKE_MINIMAL}" = "yes" ]; then
         printError "Make (minimal) failed. Log: ${makelog}"
       else
@@ -1093,8 +1129,17 @@ if ! [ -f ./.env ]; then
   echo "Need to source from the .env directory" >&2
   return 0
 fi
-export _BPXK_AUTOCVT=ON
-export _CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+
+cleanup_envars() 
+{
+  value=\$1
+  delim=\$2
+  echo "\$value" | awk -v RS="\$delim" '!(\$0 in a) {a[\$0]; printf("%s%s", col, \$0); col=RS; }'
+}
+
+_CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+export _CEE_RUNOPTS="\$(cleanup_envars "\$_CEE_RUNOPTS" " ")"
+
 export _TAG_REDIR_IN=txt
 export _TAG_REDIR_ERR=txt
 export _TAG_REDIR_OUT=txt
@@ -1102,13 +1147,16 @@ export ${projectName}_HOME=\${PWD}
 zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
-    echo "export PATH=\"\${${projectName}_HOME}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "PATH=\"\${${projectName}_HOME}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export PATH=\$(cleanup_envars \"\$PATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then
     echo "export LIBPATH=\"\${${projectName}_HOME}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export LIBPATH=\$(cleanup_envars \"\$LIBPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ]; then
     echo "export MANPATH=\"\${${projectName}_HOME}/share/man:\$MANPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export MANPATH=\$(cleanup_envars \"\$MANPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if command -V "${ZOPEN_APPEND_TO_ENV}" >/dev/null 2>&1; then
     printVerbose "Appending additional environment variables..."
@@ -1177,7 +1225,7 @@ install()
     printHeader "Running Install"
     installlog="${ZOPEN_LOG_DIR}/${LOG_PFX}_install.log"
     create_fifo_pipe "${installlog}"
-    if ! runAndLog "${ZOPEN_INSTALL_CMD} > $TMP_FIFO_PIPE"; then
+    if ! runAndLog "${ZOPEN_INSTALL_CMD} > $TMP_FIFO_PIPE 2>&1"; then
       printError "Install failed. Log: ${installlog}"
     fi
     replaceHardcodedPaths

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -394,35 +394,6 @@ checkEnv()
   fi
 }
 
-parseDeps()
-{
-  dep="$1"
-  version=$(echo $dep | awk -F '[>=<]+' '{print $2}')
-  if [ -z "$version" ]; then
-    operator=""
-    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
-  else
-    operator=$(echo $dep | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
-    dep=$(echo $dep | awk -F '[>=<]+' '{print $1}')
-    case $operator in
-      ">=") ;;
-      "=") ;;
-      *) printError "$operator is not supported."
-    esac
-    major=$(echo $version | awk -F. '{print $1}')
-    minor=$(echo $version | awk -F. '{print $2}')
-    if [ -z "$minor" ]; then
-      patch=0
-    fi
-    patch=$(echo $version | awk -F. '{print $3}')
-    if [ -z "$patch" ]; then
-      patch=0
-    fi
-  fi
-
-  echo "$dep|$operator|$major|$minor|$patch"
-}
-
 setDepsEnv()
 {
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
@@ -438,16 +409,24 @@ setDepsEnv()
     parseline=$(parseDeps $dep)
     dep=$(echo $parseline | awk -F'|' '{print $1}')
     operator=$(echo $parseline | awk -F'|' '{print $2}')
-    major=$(echo $parseline | awk -F'|' '{print $3}')
-    minor=$(echo $parseline | awk -F'|' '{print $4}')
-    patch=$(echo $parseline | awk -F'|' '{print $5}')
+    requestedMajor=$(echo $parseline | awk -F'|' '{print $3}')
+    requestedMinor=$(echo $parseline | awk -F'|' '{print $4}')
+    requstedPatch=$(echo $parseline | awk -F'|' '{print $5}')
+    requestedVersion="${requestedMajor}.${requestedMinor}.${requstedPatch}"
     foundDep=false
     for path in `echo ${depsPath} | tr '|' '\n'` ; do
       if [ -r "$path/${dep}/.env" ]; then
         depdir="$path/${dep}"
-        # TODO: Check if version requested is satisfied by dependency
+        versionPath="$depdir/.version"
+        if [ -r "$versionPath" ]; then
+          version=$(cat "$versionPath");
+        fi
         # Avoid double sourcing the .env if we're forcing an upgrade on it
         if ! $forceUpgradeDeps; then
+          if ! validateVersion "${version}" "$operator" "${requestedVersion}"; then
+            continue
+          fi
+
           printVerbose "Setting up ${depdir} dependency environment"
           cd "${depdir}" && . ./.env
         fi
@@ -468,7 +447,15 @@ setDepsEnv()
         printError "zopen install command failed"
       fi
       printVerbose "Setting up upgraded ${path}/${dep} dependency environment"
-      cd "${path}/${dep}" && . ./.env
+      depdir="$path/${dep}"
+      cd "$depdir" && . ./.env
+      versionPath="$depdir/.version"
+      if [ -r "$versionPath" ]; then
+        version=$(cat "$versionPath");
+      fi
+      if ! validateVersion "${version}" "$operator" "${requestedVersion}"; then
+        continue
+      fi
     fi
   done
   cd "${orig}" || exit 99

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -406,6 +406,7 @@ setDepsEnv()
   # Filter out duplicate deps
   deps=$(echo "$deps" | xargs | tr ' ' '\n' | sort -u)
   for dep in $deps; do
+    printVerbose "Searching for dependency $dep"
     parseline=$(parseDeps $dep)
     dep=$(echo $parseline | awk -F'|' '{print $1}')
     operator=$(echo $parseline | awk -F'|' '{print $2}')
@@ -423,7 +424,7 @@ setDepsEnv()
         fi
         # Avoid double sourcing the .env if we're forcing an upgrade on it
         if ! $forceUpgradeDeps; then
-          if ! validateVersion "${version}" "$operator" "${requestedVersion}"; then
+          if ! validateVersion "${version}" "$operator" "${requestedVersion}" "$depdir"; then
             continue
           fi
 
@@ -436,7 +437,11 @@ setDepsEnv()
     done
     if ! $foundDep || $forceUpgradeDeps; then
       if ! $forceUpgradeDeps; then
-        printWarning "Dependency $dep not found. Installing via zopen install"
+        if [ -z "$operator" ]; then
+          printWarning "Dependency $dep not found. Downloading via zopen install"
+        else
+          printWarning "Dependency $dep $operator ${requestedVersion} not found. Downloading via zopen install"
+        fi
       else
         printHeader "Upgrading dependency $dep. Installing via zopen install"
       fi
@@ -446,15 +451,15 @@ setDepsEnv()
       if ! zopen install -r $dep -d $path; then
         printError "zopen install command failed"
       fi
-      printVerbose "Setting up upgraded ${path}/${dep} dependency environment"
       depdir="$path/${dep}"
+      printVerbose "Setting up upgraded $depdir dependency environment"
       cd "$depdir" && . ./.env
       versionPath="$depdir/.version"
       if [ -r "$versionPath" ]; then
         version=$(cat "$versionPath");
       fi
-      if ! validateVersion "${version}" "$operator" "${requestedVersion}"; then
-        continue
+      if ! validateVersion "${version}" "$operator" "${requestedVersion}" "$depdir"; then
+        printError "Dependency $depdir upgraded, but does not satisfy \"$operator\" \"${requestedVersion}\"" 
       fi
     fi
   done
@@ -1117,7 +1122,7 @@ if ! [ -f ./.env ]; then
   return 0
 fi
 
-cleanup_envars() 
+deleteDuplicateEntries() 
 {
   value=\$1
   delim=\$2
@@ -1125,7 +1130,7 @@ cleanup_envars()
 }
 
 _CEE_RUNOPTS="\$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
-export _CEE_RUNOPTS="\$(cleanup_envars "\$_CEE_RUNOPTS" " ")"
+export _CEE_RUNOPTS="\$(deleteDuplicateEntries "\$_CEE_RUNOPTS" " ")"
 
 export _TAG_REDIR_IN=txt
 export _TAG_REDIR_ERR=txt
@@ -1135,15 +1140,15 @@ zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
     echo "PATH=\"\${${projectName}_HOME}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
-    echo "export PATH=\$(cleanup_envars \"\$PATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export PATH=\$(deleteDuplicateEntries \"\$PATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then
     echo "export LIBPATH=\"\${${projectName}_HOME}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
-    echo "export LIBPATH=\$(cleanup_envars \"\$LIBPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export LIBPATH=\$(deleteDuplicateEntries \"\$LIBPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ]; then
     echo "export MANPATH=\"\${${projectName}_HOME}/share/man:\$MANPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
-    echo "export MANPATH=\$(cleanup_envars \"\$MANPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "export MANPATH=\$(deleteDuplicateEntries \"\$MANPATH\" \":\")" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if command -V "${ZOPEN_APPEND_TO_ENV}" >/dev/null 2>&1; then
     printVerbose "Appending additional environment variables..."
@@ -1230,6 +1235,39 @@ install()
     chtag -tc 819 "${ZOPEN_INSTALL_DIR}/test.status"
     echo "$ZOPEN_STATUS" > "${ZOPEN_INSTALL_DIR}/test.status"
 
+    if [ -z "$(command -v zopen_get_version)" ]; then
+      printWarning "A zopen_get_version() function should be defined in the buildenv to extract the version contents"
+    else
+      versionString=$(zopen_get_version)
+      echo $versionString | awk -F. '{
+        if (NF < 2 || NF > 4) {
+          exit 1
+        }
+        if ($1 ~ /[^0-9]/) {
+          exit 1
+        }
+        if ($2 ~ /[^0-9]/) {
+          exit 1
+        }
+        if (NF >= 3 && $3 ~ /[^0-9A-Za-z-]+/) {
+          exit 1
+        }
+        if (NF == 4 && $4 !~ /[0-9A-Za-z-]+/) {
+          exit 1
+        }
+        exit 0
+      }'
+
+      if [ $? -ne 0 ]; then
+        printError "$versionString uses an invalid version format"
+      fi 
+      echo "$versionString" > "${ZOPEN_INSTALL_DIR}/.version"
+    fi
+
+    if [ ! -z "$ZOPEN_RUNTIME_DEPS" ]; then
+      echo "$ZOPEN_RUNTIME_DEPS" > "${ZOPEN_INSTALL_DIR}/.deps"
+    fi
+
     if $generatePax; then
       printHeader "Generating pax.Z from ${ZOPEN_INSTALL_DIR}"
       if ! runAndLog "${ZOPEN_PAX_CMD}"; then
@@ -1306,7 +1344,7 @@ resolveCommands()
     unset ZOPEN_CONFIGURE_CMD
     unset ZOPEN_CONFIGURE_MINIMAL_CMD
   fi
-  
+
   if [ "${ZOPEN_MAKE}x" != "skipx" ] && [ ! -z "$(command -v ${ZOPEN_MAKE})" ] ; then
     if [ "${ZOPEN_MAKE_MINIMAL}x" = "x" ]; then
       export ZOPEN_MAKE_CMD="\"${ZOPEN_MAKE}\" ${ZOPEN_MAKE_OPTS} CC=${CC} \"CPPFLAGS=${CPPFLAGS}\" \"CFLAGS=${CFLAGS}\" CXX=${CXX} \"CXXFLAGS=${CXXFLAGS}\" \"LDFLAGS=${LDFLAGS}\" \"LDLIBS=${LIBS}\""

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -412,8 +412,9 @@ setDepsEnv()
     operator=$(echo $parseline | awk -F'|' '{print $2}')
     requestedMajor=$(echo $parseline | awk -F'|' '{print $3}')
     requestedMinor=$(echo $parseline | awk -F'|' '{print $4}')
-    requstedPatch=$(echo $parseline | awk -F'|' '{print $5}')
-    requestedVersion="${requestedMajor}.${requestedMinor}.${requstedPatch}"
+    requestedPatch=$(echo $parseline | awk -F'|' '{print $5}')
+    requestedSubrelease=$(echo $parseline | awk -F'|' '{print $6}')
+    requestedVersion="${requestedMajor}.${requestedMinor}.${requestedPatch}.${requestedSubrelease}"
     foundDep=false
     for path in `echo ${depsPath} | tr '|' '\n'` ; do
       if [ -r "$path/${dep}/.env" ]; then
@@ -1240,7 +1241,7 @@ install()
     else
       versionString=$(zopen_get_version)
       echo $versionString | awk -F. '{
-        if (NF < 2 || NF > 4) {
+        if (NF < 1 || NF > 4) {
           exit 1
         }
         if ($1 ~ /[^0-9]/) {

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -62,6 +62,8 @@ echo "Enter ${name}'s build dependencies for the Tar source: (example: curl make
 tardeps=$(getInput)
 echo "Enter the default build type: (tar or git)"
 buildtype=$(getInput)
+echo "Enter ${name}'s runtime dependencies for the Tar source: (example: bash)"
+runtimedeps=$(getInput)
 
 project_path="${name}port"
 
@@ -109,6 +111,11 @@ else
   buildenvContents="${buildenvContents}export ZOPEN_TYPE=\"TARBALL\"\n"
 fi
 
+if [ ! -z "$runtimedeps" ]; then
+  buildenvContents="${buildenvContents}export ZOPEN_RUNTIME_DEPS=\"$runtimedeps\"\n"
+fi
+
+
 buildenvContents="${buildenvContents}\nzopen_check_results()
 {
   dir=\"\$1\"
@@ -124,6 +131,18 @@ buildenvContents="${buildenvContents}\nzopen_check_results()
 zopen_append_to_env()
 {
   # echo envars outside of PATH, MANPATH, LIBPATH
+}
+
+zopen_append_to_setup()
+{
+  # echo commands that will run when installing via setup.sh
+}
+
+zopen_get_version()
+{
+  # Modify to echo the version of your tool/library
+  # Rather than hardcoding the version, obtain the version by running the tool/library
+  echo \"1.0.0\"
 }"
 
 /bin/echo "$buildenvContents" > $buildenv


### PR DESCRIPTION
This is step of parsing the dependencies which can have a comparison and version. I am not currently using it in any way yet, that logic will come in a later commit.

I will likely move it to common.inc in step 2 because zopen download will need it for runtime dependencies.

I have also added cleanup_envars, which will cleanup dupes in our envars.

If you have any comments on the code so far, please let me know.