### PR TITLE
Add install option, also fix zopen download so that it sets up ports

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -188,7 +188,7 @@ printSyntax()
   echo "  -h: print this information"
   echo "  -v: run in verbose mode"
   echo "  -vv: run in very verbose mode (sets environment variables V=1 and VERBOSE=1)"
-  echo "  -u|--upgradedeps: upgrade all dependencies by running zopen download"
+  echo "  -u|--upgradedeps: upgrade all dependencies by running zopen install"
   echo "  --buildtype: release|debug. The default is release"
   echo "  --comp: xl|clang.  The compiler used for building.  The default is xl."
   echo "  --oci: build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY"
@@ -421,15 +421,15 @@ setDepsEnv()
     done
     if ! $foundDep || $forceUpgradeDeps; then
       if ! $forceUpgradeDeps; then
-        printWarning "Dependency $dep not found. Downloading via zopen-download"
+        printWarning "Dependency $dep not found. Installing via zopen install"
       else
-        printHeader "Upgrading dependency $dep. Downloading via zopen-download"
+        printHeader "Upgrading dependency $dep. Installing via zopen install"
       fi
       # Use the first path specified in the dependency search list
       path=$(echo ${depsPath} | tr '|' '\n' | head -1)
-      printVerbose "Running zopen download --install-or-upgrade -r $dep -d $path -v"
-      if ! zopen download -r $dep -d $path; then
-        printError "zopen download command failed"
+      printVerbose "Running zopen install --install-or-upgrade -r $dep -d $path -v"
+      if ! zopen install -r $dep -d $path; then
+        printError "zopen install command failed"
       fi
       printVerbose "Setting up upgraded ${path}/${dep} dependency environment"
       cd "${path}/${dep}" && . ./.env

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -157,7 +157,11 @@ downloadRepos()
 
     # Delete the .installed file if it was previously there
     rm -f "${name}/.installed"
-    printInfo "Successfully downloaded $name to $downloadDir/$name/"
+
+    printVerbose "Installing"
+    #TODO: when we rebuild all the tools, simply call setup.sh
+    (cd "${name}" && . ./.env)
+    printInfo "Successfully installed $name to $downloadDir/$name/"
 done
 }
 

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Download utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+# Install utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 
 export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
@@ -8,18 +8,18 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 printSyntax() 
 {
   args=$*
-  echo "zopen-download is a download utility for z/OS Open Tools. The default action is to list all packages." >&2
+  echo "zopen install is a install utility for z/OS Open Tools. The default action is to list all packages." >&2
   echo "If you have a Github OAUTH token, export the environment variable ZOPEN_GIT_OAUTH_TOKEN" >&2
-  echo "Syntax: zopen-download [<option>]*" >&2
+  echo "Syntax: zopen install [<option>]*" >&2
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools. If no parameters are specified, --list is the default."  >&2
   echo "  -u|--upgrade: upgrades installed z/OS Open Tools packages."  >&2
   echo "  --install-or-upgrade: installs the package if not installed, or upgrades the package if installed."  >&2
   echo "  --reinstall: reinstall already installed z/OS Open Tools packages."  >&2
-  echo "  --all: downloads all z/OS Open Tools packages."  >&2
+  echo "  --all: installs all z/OS Open Tools packages."  >&2
   echo "  -v: run in verbose mode." >&2
-  echo "  -d <dir>: directory to download binaries to.  Uses current working directory or path from ~/.zopen-config (generated via zopen init) if not specified." >&2
-  echo "  <project,...>: a set of comma delimited projects to download." >&2
+  echo "  -d <dir>: directory to install binaries to.  Uses current working directory or path from ~/.zopen-config (generated via zopen init) if not specified." >&2
+  echo "  <project,...>: a set of comma delimited projects to install." >&2
   echo "  --filter <color>: filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, or skipped (no filter by default))"  >&2
 }
 
@@ -73,7 +73,7 @@ printListEntries()
   done
 }
 
-downloadRepos()
+installRepos()
 {
   echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
     name=${repo%port}
@@ -158,7 +158,7 @@ downloadRepos()
     # Delete the .installed file if it was previously there
     rm -f "${name}/.installed"
 
-    printVerbose "Installing"
+    printVerbose "Installing ${name}..."
     #TODO: when we rebuild all the tools, simply call setup.sh
     (cd "${name}" && . ./.env)
     printInfo "Successfully installed $name to $downloadDir/$name/"
@@ -256,7 +256,7 @@ repo_results=$(echo "$repo_results" | grep "\"full_name\":" 2>/dev/null | cut -d
 if [ ! -d "${downloadDir}" ]; then
   mkdir -p "${downloadDir}"
   if $?; then
-    printError "Could not create download directory: $downloadDir"
+    printError "Could not create install directory: $downloadDir"
   fi
 fi
 
@@ -264,7 +264,7 @@ if [ ! -z "${downloadDir}" ] && [ -d "${downloadDir}" ]; then
   cd "${downloadDir}"
 fi
 
-printVerbose "Download directory: ${downloadDir}"
+printVerbose "Install directory: ${downloadDir}"
 
 # Parse repositories for zopen framework repos
 foundPort=false
@@ -302,4 +302,4 @@ if [ ! -z "$list" ]; then
   exit 0;
 fi
 
-downloadRepos
+installRepos

--- a/bin/zopen
+++ b/bin/zopen
@@ -9,7 +9,7 @@ printSyntax()
   echo "where <command> may be one of the following:" >&2
   echo " init: generate a $HOME/.zopen-config file." >&2
   echo " build: invokes the build script." >&2
-  echo " download: downloads z/OS Open Tools" >&2
+  echo " download: downloads z/OS Open Tools (deprecated)" >&2
   echo " install: downloads and installs z/OS Open Tools" >&2
   echo " generate: generate a zopen project" >&2
   echo " update-cacert: update the cacert.pem file" >&2
@@ -26,9 +26,9 @@ printHelp()
   echo " # Build a port" >&2
   echo " zopen build -v # Build port" >&2
   echo " # List available ports to download" >&2
-  echo " zopen download --list" >&2
+  echo " zopen install" >&2
   echo " # Download binaries from Github" >&2
-  echo " zopen download" >&2
+  echo " zopen install --all" >&2
   echo " # Generate a zopen template project" >&2
   echo " zopen generate" >&2
 }
@@ -45,15 +45,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     "download")
       shift
-      exec "${bindir}/lib/zopen-download" $@
+      printWarning "zopen download is deprecated and will be removed March 1, 2023. Please use zopen install instead."
+      exec "${bindir}/lib/zopen-install" $@
       ;;
     "install")
       shift
-      exec "${bindir}/lib/zopen-download" $@
+      exec "${bindir}/lib/zopen-install" $@
       ;;
     "upgrade")
       shift
-      exec "${bindir}/lib/zopen-download" -u $@
+      exec "${bindir}/lib/zopen-install" -u $@
       ;;
     "generate")
       shift

--- a/bin/zopen
+++ b/bin/zopen
@@ -10,6 +10,7 @@ printSyntax()
   echo " init: generate a $HOME/.zopen-config file." >&2
   echo " build: invokes the build script." >&2
   echo " download: downloads z/OS Open Tools" >&2
+  echo " install: downloads and installs z/OS Open Tools" >&2
   echo " generate: generate a zopen project" >&2
   echo " update-cacert: update the cacert.pem file" >&2
   echo " upgrade: upgrades already installed tools" >&2
@@ -43,6 +44,10 @@ while [[ $# -gt 0 ]]; do
       exec "${bindir}/lib/zopen-build" $@
       ;;
     "download")
+      shift
+      exec "${bindir}/lib/zopen-download" $@
+      ;;
+    "install")
       shift
       exec "${bindir}/lib/zopen-download" $@
       ;;

--- a/docs/Guides/FAQ.md
+++ b/docs/Guides/FAQ.md
@@ -7,7 +7,7 @@ The z/OS Open Tools initiative was started to help modernize z/OS and encourage 
 If you have access to a z/OS system, you can get started with porting [here](https://zosopentools.github.io/meta/contributing/). Not sure what to work on? Start with the [help wanted issues](https://github.com/ZOSOpenTools/meta/labels/help%20wanted). If you do not have access to a z/OS system, speak to [@Mike Fulton](https://github.com/MikeFultonDev) or [@Igor Todorovski](https://github.com/IgorTodorovskiIBM).
 
 ## How do I consume the z/OS Open Tools?
-You can download them directly from the zOS Open Tools repo's [GitHub releases](https://github.com/ZOSOpenTools/meta/releases). All z/OS Open Tools releases are consolidated into a [table here](https://zosopentools.github.io/meta/releases/). Or you can use the [zopen download tool](https://github.com/ZOSOpenTools/utils/tree/main/zopen) from the [utils repository](https://github.com/ZOSOpenTools/utils) to download the tools, [documented here](https://zosopentools.github.io/meta/zopen/).
+You can install them directly from the zOS Open Tools repo's [GitHub releases](https://github.com/ZOSOpenTools/meta/releases). All z/OS Open Tools releases are consolidated into a [table here](https://zosopentools.github.io/meta/releases/). Or you can use the [zopen install tool](https://github.com/ZOSOpenTools/utils/tree/main/zopen) from the [utils repository](https://github.com/ZOSOpenTools/utils) to install the tools, [documented here](https://zosopentools.github.io/meta/zopen/).
 
 ## How do I raise issues?
 If the issue pertains to a given project, open the issue in the project's Github repository. If you have a general issue or discussion item, [create a discussion](https://github.com/ZOSOpenTools/meta/discussions).

--- a/docs/Guides/Porting.md
+++ b/docs/Guides/Porting.md
@@ -18,7 +18,7 @@ This assumes that you have the latest version of [Git](https://github.com/ZOSOpe
 ### Leveraging the z/OS Open Tools meta repo
 
 The meta repo (https://github.com/ZOSOpenTools/meta) consists of common tools and files that aid in the porting process, including the `zopen` suite of tools.  Specifically, `zopen build` provides a common way to bootstrap, configure, build, check,
-and install a software package. `zopen download` provides a mechanism to download the latest published z/OS Open Tools packages.
+and install a software package. `zopen install` provides a mechanism to install the latest published z/OS Open Tools packages.
 
 Many tools depend on other tools to be able to build or run. You will need to provide both _bootstrap_ tools
 (i.e. binary tools not from source), as well as _prod_ tools (i.e. _production_ level tools previously built

--- a/docs/Guides/Pre-req.md
+++ b/docs/Guides/Pre-req.md
@@ -62,20 +62,20 @@ Download [zopen-setup](https://github.com/ZOSOpenTools/meta/releases/tag/v1.0.0)
 
 For more details on porting, visit the [porting to z/OS guide](Porting.md).
 
-## Downloading tools to z/OS
+## Installing tools to z/OS
 
-Once you have your development environment set up, you can download tools directly to z/OS with `zopen download`.
+Once you have your development environment set up, you can install tools directly to z/OS with `zopen install`.
 
-To download and install the latest software packages, enter the command `zopen download`. By default it will download all of the tools hosted on ZOSOpenTools.
+To download and install the latest software packages, enter the command `zopen install`. By default it will list all of the tools hosted on ZOSOpenTools.
 
-To list the available packages, specify the --list option as follows:
+To download the available packages, specify the --all option as follows:
 
 ```bash
-zopen download --list
+zopen install --all
 ```
 
 To download and install specific packages, specify them as a comma delimited list as follows:
 ```bash
-zopen download make,curl,gzip
+zopen install make,curl,gzip
 ```
 For more details, see the section on [zopen tools](zopen.md).

--- a/docs/Guides/VimOnZOS.md
+++ b/docs/Guides/VimOnZOS.md
@@ -6,9 +6,9 @@ VIM is a popular and powerful text editor that is often used by programmers for 
 ## How to obtain VIM on z/OS?
 To obtain VIM on z/OS, download it from [VIM Github Release page](https://github.com/ZOSOpenTools/vimport/releases).
 
-Alternatively, you can use `zopen download` to download vim as follows:
+Alternatively, you can use `zopen install` to download vim as follows:
 ```
-zopen download vim ncurses
+zopen install vim ncurses
 ```
 Since VIM depends on ncurses, we also need to download [ncurses](https://github.com/ZOSOpenTools/ncursesport/releases) and source the .env file.
 
@@ -32,7 +32,7 @@ VIM on z/OS currently understands the `IBM-1047` and `ISO8959-1` file tags. If y
 ### Cscope
 **Cscope** is a tool that allows users to search for symbols, functions, and other code constructs in a codebase. This can be incredibly useful when working with large codebases on z/OS, as it allows users to quickly navigate and find the code they need.
 
-To use Cscope, first download it using `zopen download cscope` and then source the .env file as follows: `. ./.env`
+To use Cscope, first download it using `zopen install cscope` and then source the .env file as follows: `. ./.env`
 
 Now, navigate to a codebase. Let's take the Git source as an example. Since Git is a C-based project, we'll use Cscope to a cscope database for all of the C source files and headers.
 ```
@@ -53,7 +53,7 @@ To map the cscope to shortcut keys, the following vim script is recommended: htt
 ### CTags
 Another useful tool is **ctags**, which is similar to cscope but operates at a lower level. Ctags generates a list of tags for a codebase, which can then be used by VIM to quickly navigate to specific functions and other code constructs. This can be a huge time-saver when working with complex codebases on z/OS.
 
-To use CTags, first download it using `zopen download ctags` and then source the .env file as follows: `. ./.env`
+To use CTags, first download it using `zopen install ctags` and then source the .env file as follows: `. ./.env`
 
 Now, navigate to a codebase. Let's take the Git source as an example.
 ```

--- a/docs/Guides/zopen.md
+++ b/docs/Guides/zopen.md
@@ -13,33 +13,33 @@ Alternatively, you can download meta, along with the foundational set of tools v
 ## If you are using z/OS Open Tools
 
 ### zopen init
-To initialize the zopen installation directory to a location other than the default ($HOME/zopen), you can run the command zopen init and specify the desired directory. This will configure the directory for future use. Subsequently, tools like zopen download will download and install files to this specified directory."
+To initialize the zopen installation directory to a location other than the default ($HOME/zopen), you can run the command zopen init and specify the desired directory. This will configure the directory for future use. Subsequently, tools like `zopen install` will download and install files to this specified directory."
 
 ### zopen update-cacacert
 
-To update the cacert.pem file, you can use `zopen update-cacert`. This will download the latest cacert.pem file https://curl.se/docs/caextract.html. This cacert.pem file is then used by other tools such as `zopen download` and `zopen build`.
+To update the cacert.pem file, you can use `zopen update-cacert`. This will download the latest cacert.pem file https://curl.se/docs/caextract.html. This cacert.pem file is then used by other tools such as `zopen install` and `zopen build`.
 
-### zopen download
+### zopen install
 
-To download and install the latest software packages, you can use `zopen download`. By default it will list all of the packages hosted on ZOSOpenTools.
+To download and install the latest software packages, you can use `zopen install`. By default it will list all of the packages hosted on ZOSOpenTools.
 
 It is recommended that you generate a [github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 Then set `export ZOPEN_GIT_OAUTH_TOKEN=<yourapitoken>`
 
 To list the available packages, specify no parameters or the `--list` option as follows:
 ```
-zopen download --list
+zopen install --list
 ```
 
 To download and install specfic packages, you can specify the packages as a comma seperated list as follows:
 ```
-zopen download make,gzip
+zopen install make,gzip
 ```
 
 This will download it to the directory specified by your ~/.zopen-config. To change the destination directory, you can specify the `-d` option as follows:
 
 ```
-zopen download make -d $HOME/zopen/prod
+zopen install make -d $HOME/zopen/prod
 ```
 
 You can then change to the install directory and source the .env file: `. ./.env` to setup the tool.

--- a/tools/getbinaries.py
+++ b/tools/getbinaries.py
@@ -41,7 +41,7 @@ g = Github(os.getenv('GITHUB_OAUTH_TOKEN'))
 with open('docs/Latest.md', 'w') as f:
 	sys.stdout = f # Change the standard output to the file we created.
 	print("# z/OS Open Tools - Packages\n")
-	print("Note: to download the latest packages, use the `zopen download` script from the [meta repo](https://github.com/ZOSOpenTools/meta)\n")
+	print("Note: to download the latest packages, use the `zopen install` script from the [meta repo](https://github.com/ZOSOpenTools/meta)\n")
 	print("| Package | Status | Test Success Rate | Latest Release | Description |")
 	print("|---|---|---|---|---|")
 


### PR DESCRIPTION
The install option is added to make zopen more similar to brew and apt-get.

In addition, as @ccw-1 requested, install should setup the port. Since not all ports have a setup.sh, we'll source the .env for now.