### PR TITLE
Fix upgrade dependency call in zopen-build - prevents unnecessary re-install

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -448,8 +448,7 @@ setDepsEnv()
       fi
       # Use the first path specified in the dependency search list
       path=$(echo ${depsPath} | tr '|' '\n' | head -1)
-      printVerbose "Running zopen install --install-or-upgrade -r $dep -d $path -v"
-      if ! zopen install -r $dep -d $path; then
+      if ! runAndLog "zopen install --install-or-upgrade -r $dep -d $path -v"; then
         printError "zopen install command failed"
       fi
       depdir="$path/${dep}"


### PR DESCRIPTION
I forgot to add --install-or-upgrade to the zopen call, no wonder dependencies were always being re-dowloaded