### PR TITLE
Add support for installing runtime dependencies

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1113,7 +1113,7 @@ replaceHardcodedPaths()
     printVerbose "Processing $f"
     cp $f $f.tmp && sed -e "s#${ZOPEN_INSTALL_DIR}#ZOPEN_INSTALL_ROOT#g" $f.tmp > $f && rm $f.tmp;
   done
-  for f in $(find ${ZOPEN_INSTALL_PREFIX}/ -type f | xargs grep -l "${ZOPEN_INSTALL_PREFIX}" 2>/dev/null); do
+  for f in $(find ${ZOPEN_INSTALL_DIR}/ -type f | xargs grep -l "${ZOPEN_INSTALL_PREFIX}" 2>/dev/null); do
     hasHardcodedPaths=true
     printVerbose "Processing $f"
     cp $f $f.tmp && sed -e "s#${ZOPEN_INSTALL_PREFIX}#ZOPEN_INSTALL_PREFIX#g" $f.tmp > $f && rm $f.tmp;
@@ -1278,12 +1278,20 @@ install()
       if [ $? -ne 0 ]; then
         printError "$versionString uses an invalid version format"
       fi 
-      echo "$versionString" > "${ZOPEN_INSTALL_DIR}/.version"
+      asciiecho "$versionString" "${ZOPEN_INSTALL_DIR}/.version"
     fi
 
     if [ ! -z "$ZOPEN_RUNTIME_DEPS" ]; then
-      echo "$ZOPEN_RUNTIME_DEPS" > "${ZOPEN_INSTALL_DIR}/.deps"
+      asciiecho "$ZOPEN_RUNTIME_DEPS" "${ZOPEN_INSTALL_DIR}/.runtimedeps"
     fi
+
+    buildDeps=""
+    if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
+        buildDeps="${ZOPEN_TARBALL_DEPS}"
+    elif [ "${ZOPEN_TYPE}x" = "GITx" ]; then
+        buildDeps="${ZOPEN_GIT_DEPS}"
+    fi
+    asciiecho "$buildDeps" "${ZOPEN_INSTALL_DIR}/.builddeps"
 
     if $generatePax; then
       printHeader "Generating pax.Z from ${ZOPEN_INSTALL_DIR}"

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -5,6 +5,27 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
 . "${utildir}/common.inc"
 
+# Temporary files
+for tmp in "$TMPDIR" "$TMP" /tmp
+do
+  if [ ! -z $tmp ] && [ -d $tmp ]; then
+    TMP_DEP_STATS="$tmp/$LOGNAME.$RANDOM.file"
+    break
+  fi
+done
+
+touch $TMP_DEP_STATS
+
+# Remove temoraries on exit and report elapsed time
+cleanupOnExit() {
+  rv=$?
+  [ -f $TMP_DEP_STATS ] && rm -rf $TMP_DEP_STATS
+  trap - EXIT # clear the EXIT trap so that it's not double called
+  exit $rv
+}
+
+trap "cleanupOnExit" EXIT INT TERM QUIT HUP
+
 printSyntax() 
 {
   args=$*
@@ -41,7 +62,7 @@ getContentsFromGithub()
 
 printListEntries()
 {
-  printf "${NC}${UNDERLINE}${1}%-20s %-20s %-20s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Status" "Quality"
+  printf "${NC}${UNDERLINE}${1}%-20s %-20s %-20s %-30s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Dependencies" "Status" "Quality"
   echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
     name=${repo%port}
     if ! contents="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
@@ -52,6 +73,11 @@ printListEntries()
     statusline="$(echo "$contents" | grep "\"body\":.*Test Status:.*(.*)<br />")"
     buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
     testStatus="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>[^(]*(##" -e "s#).*##")"
+    if echo "$statusline" | grep "Runtime Dependencies:" >/dev/null; then
+      dependencies="$(echo "$statusline" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
+    else
+      dependencies="No dependencies"
+    fi
     if [ -z "$buildQuality" ]; then
       buildQuality="Untested"
       testStatus="N/A";
@@ -68,12 +94,130 @@ printListEntries()
     else
       originalTag="Not installed"
     fi
-    printf '%-20s %-20s %-20s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$buildQuality" "$testStatus"
+    printf '%-20s %-20s %-20s %-30s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$dependencies" "$buildQuality" "$testStatus"
     continue;
   done
 }
 
-installRepos()
+installPort()
+{
+  name=$1
+  if grep -q "^$name=" $TMP_DEP_STATS; then
+    printVerbose "Already processed $name...skipping"
+    return
+  fi
+  repo="${name}port"
+
+  printHeader "Installing $name..."
+  if ! latest_url="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
+    exit 4;
+  fi
+
+  #FIXME: use jq to parse
+  statusline="$(echo "$latest_url" | grep "\"body\":.*Test Status:.*(.*)<br />")"
+  if echo "$statusline" | grep "Runtime Dependencies:" >/dev/null; then
+    dependencies="$(echo "$statusline" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
+  else
+    dependencies="No dependencies"
+  fi
+
+  buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
+  if [ -z "$buildQuality" ]; then
+    buildQuality="Untested"
+  fi
+  if [ ! -z "$filter" ]; then
+    qualityLower=$(echo "$buildQuality" | awk '{print tolower($0)}')
+    if [ "$filter" != "$qualityLower" ]; then
+      continue;
+    fi
+  fi
+
+  latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
+  if $upgradeInstalled || $installOrUpgrade || ! $reinstall; then
+    if [ -e "${name}/.releaseinfo" ]; then
+      originalTag=$(cat "${name}/.releaseinfo" | xargs) 
+    elif ! $installOrUpgrade; then
+      # We're only updating alreaady installed products
+      printVerbose "${downloadDir}/${name} will not be upgraded as it is not installed."
+      continue;
+    fi
+    if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
+      printVerbose "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
+      continue;
+    fi
+    printInfo "New release with tag \"${latestTag}\" found for $repo"
+  fi
+  printInfo "Preparing to download $name"
+  if [ -z "$latest_url" ]; then
+    printInfo "No releases published for $name"
+    continue
+  fi
+
+  latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
+  printInfo "Downloading latest release from $repo..."
+  if ! $verbose; then
+    redirectToDevNull="2>/dev/null"
+  fi 
+  if ! runAndLog "curl -L ${latest_url} -O ${redirectToDevNull}"; then
+    printWarning "Could not download ${latest_url}"
+    continue;
+  fi
+
+  pax=$(basename ${latest_url})
+  if [ ! -f "${pax}" ]; then
+    printError "${pax} was not actually downloaded?"
+  fi
+
+  dirname=${pax%.pax.Z}
+  if [ -d "$dirname" ]; then
+    printInfo "Deleting existing $dirname..."
+    rm -rf "$dirname"
+  fi
+
+  printInfo "Extracting $pax..."
+  if ! runAndLog "pax -rf $pax -p p ${redirectToDevNull}"; then
+    printWarning "Could not extract $pax. Skipping"
+    continue;
+  fi
+  rm -f "${pax}"
+
+  # Remove old symlink and recreate
+  if [ -L $name ]; then
+    rm $name
+  fi 
+
+  if ! ln -s $dirname $name; then
+    printError "Could not create symbolic link name"
+  fi 
+
+  # Add tag information as a .releaseinfo file
+  echo "$latestTag" > "${name}/.releaseinfo"
+
+  # Delete the .installed file if it was previously there
+  rm -f "${name}/.installed"
+
+  printVerbose "Installing ${name}..."
+  #TODO: when we rebuild all the tools, simply call setup.sh
+  (cd "${name}" && . ./.env)
+  versionPath="$name/.version"
+  if [ -r "$versionPath" ]; then
+    version=$(cat "$versionPath");
+  fi
+  printInfo "Successfully installed $name to $downloadDir/$name/"
+  if ! grep -q "^$name=" $TMP_DEP_STATS; then
+    echo "$name=$version" >> $TMP_DEP_STATS
+  fi
+
+  if [ "$dependencies" != "No dependencies" ]; then
+    printHeader "Installing dependencies for $name: $dependencies..."
+    
+    echo "$dependencies" | xargs | tr ' ' '\n' | sort | while read dep; do
+      installPort $dep
+    done
+  fi
+}
+
+installPorts()
 {
   echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
     name=${repo%port}
@@ -81,87 +225,7 @@ installRepos()
       exit 4;
     fi
 
-    #FIXME: use jq to parse
-    statusline="$(echo "$latest_url" | grep "\"body\":.*Test Status:.*(.*)<br />")"
-    buildQuality="$(echo "$statusline" | sed -e "s#.*Test Status:<\/b>##" -e "s#[ ]*(.*##" | tr -d ' ')"
-    if [ -z "$buildQuality" ]; then
-      buildQuality="Untested"
-    fi
-    if [ ! -z "$filter" ]; then
-      qualityLower=$(echo "$buildQuality" | awk '{print tolower($0)}')
-      if [ "$filter" != "$qualityLower" ]; then
-        continue;
-      fi
-    fi
-
-    latestTag="$(echo "$latest_url" | grep "\"tag_name\":" | cut -d '"' -f 4)"
-    if $upgradeInstalled || $installOrUpgrade; then
-      if [ -e "${name}/.releaseinfo" ]; then
-        originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-      elif ! $installOrUpgrade; then
-        # We're only updating alreaady installed products
-        printVerbose "${downloadDir}/${name} will not be upgraded as it is not installed."
-        continue;
-      fi
-      if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
-        printVerbose "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
-        continue;
-      fi
-      printInfo "New release with tag \"${latestTag}\" found for $repo"
-    fi
-    printInfo "Preparing to download $repo"
-    if [ -z "$latest_url" ]; then
-      printInfo "No releases published for $repo"
-      continue
-    fi
-
-    latest_url="$(echo "$latest_url" | grep "\"browser_download_url\":" | cut -d '"' -f 4)"
-    printInfo "Downloading latest release from $repo..."
-    if ! $verbose; then
-      redirectToDevNull="2>/dev/null"
-    fi 
-    if ! runAndLog "curl -L ${latest_url} -O ${redirectToDevNull}"; then
-      printWarning "Could not download ${latest_url}"
-      continue;
-    fi
-
-    pax=$(basename ${latest_url})
-    if [ ! -f "${pax}" ]; then
-      printError "${pax} was not actually downloaded?"
-    fi
-
-    dirname=${pax%.pax.Z}
-    if [ -d "$dirname" ]; then
-      printInfo "Deleting existing $dirname..."
-      rm -rf "$dirname"
-    fi
-
-    printInfo "Extracting $pax..."
-    if ! runAndLog "pax -rf $pax -p p ${redirectToDevNull}"; then
-      printWarning "Could not extract $pax. Skipping"
-      continue;
-    fi
-    rm -f "${pax}"
-
-    # Remove old symlink and recreate
-    if [ -L $name ]; then
-      rm $name
-    fi 
-
-    if ! ln -s $dirname $name; then
-      printError "Could not create symbolic link name"
-    fi 
-
-    # Add tag information as a .releaseinfo file
-    echo "$latestTag" > "${name}/.releaseinfo"
-
-    # Delete the .installed file if it was previously there
-    rm -f "${name}/.installed"
-
-    printVerbose "Installing ${name}..."
-    #TODO: when we rebuild all the tools, simply call setup.sh
-    (cd "${name}" && . ./.env)
-    printInfo "Successfully installed $name to $downloadDir/$name/"
+  installPort $name
 done
 }
 
@@ -302,4 +366,4 @@ if [ ! -z "$list" ]; then
   exit 0;
 fi
 
-installRepos
+installPorts

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -14,6 +14,10 @@ do
   fi
 done
 
+if [ -z "$TMP_DEP_STATS" ]; then
+  printError "Could not find a temporary write location in \$TMPDIR, \$TMP, or /tmp"
+fi
+
 touch $TMP_DEP_STATS
 
 # Remove temoraries on exit
@@ -37,6 +41,7 @@ printSyntax()
   echo "  -u|--upgrade: upgrades installed z/OS Open Tools packages."  >&2
   echo "  --install-or-upgrade: installs the package if not installed, or upgrades the package if installed."  >&2
   echo "  --reinstall: reinstall already installed z/OS Open Tools packages."  >&2
+  echo "  --nodeps: do not install dependencies.do not install dependencies."  >&2
   echo "  --all: installs all z/OS Open Tools packages."  >&2
   echo "  -v: run in verbose mode." >&2
   echo "  -d <dir>: directory to install binaries to.  Uses current working directory or path from ~/.zopen-config (generated via zopen init) if not specified." >&2
@@ -99,6 +104,22 @@ printListEntries()
   done
 }
 
+installDependencies()
+{
+  name=$1
+  dependencies=$2
+  if $doNotInstallDeps; then
+    return 0;
+  fi
+  if [ "$dependencies" != "No dependencies" ]; then
+    printHeader "Installing dependencies for $name: $dependencies..."
+    
+    echo "$dependencies" | xargs | tr ' ' '\n' | sort | while read dep; do
+      installPort $dep
+    done
+  fi
+}
+
 installPort()
 {
   name=$1
@@ -136,13 +157,19 @@ installPort()
   if $upgradeInstalled || $installOrUpgrade || ! $reinstall; then
     if [ -e "${name}/.releaseinfo" ]; then
       originalTag=$(cat "${name}/.releaseinfo" | xargs) 
-    elif ! $installOrUpgrade; then
-      # We're only updating alreaady installed products
+      if ! $upgradeInstalled && ! $installOrUpgrade && ! $reinstall; then
+        printInfo "$name already installed, skipping. To upgrade, use zopen upgrade."
+        installDependencies "$name" "$dependencies"
+        continue
+      fi
+    elif $upgradeInstalled;  then
       printVerbose "${downloadDir}/${name} will not be upgraded as it is not installed."
+      installDependencies "$name" "$dependencies"
       continue;
     fi
     if [ "${latestTag}" = "${originalTag}" ] && ! $reinstall; then
       printVerbose "${downloadDir}/${name} with latest release tag \"${latestTag}\" already installed. Skipping..."
+      installDependencies "$name" "$dependencies"
       continue;
     fi
     printInfo "New release with tag \"${latestTag}\" found for $repo"
@@ -208,13 +235,7 @@ installPort()
     echo "$name=$version" >> $TMP_DEP_STATS
   fi
 
-  if [ "$dependencies" != "No dependencies" ]; then
-    printHeader "Installing dependencies for $name: $dependencies..."
-    
-    echo "$dependencies" | xargs | tr ' ' '\n' | sort | while read dep; do
-      installPort $dep
-    done
-  fi
+  installDependencies "$name" "$dependencies"
 }
 
 installPorts()
@@ -232,14 +253,11 @@ done
 
 # Main code start here
 args=$*
-if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
-  downloadDir="$ZOPEN_SEARCH_PATH/prod"
-else
-  downloadDir=$PWD
-fi
+specifiedDownloadDir=false
 upgradeInstalled=false
 verbose=false
 reinstall=false
+doNotInstallDeps=false
 downloadAll=false
 installOrUpgrade=false
 if [[ $# -eq 0 ]]; then
@@ -248,7 +266,8 @@ fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     "-d")
-      downloadDir=$2;
+      downloadDir=$2
+      specifiedDownloadDir=true
       shift
       ;;
     "-u" | "--upgrade" | "-upgrade" | "-upgrade" | "--upgrade")
@@ -274,6 +293,9 @@ while [[ $# -gt 0 ]]; do
     "--all")
       downloadAll=true
       ;;
+    "--nodeps")
+      doNotInstallDeps=true
+      ;;
     "-v" | "--v" | "-verbose" | "--verbose")
       verbose=true
       ;;
@@ -283,6 +305,15 @@ while [[ $# -gt 0 ]]; do
   esac
   shift;
 done
+
+if ! $specifiedDownloadDir; then
+  if [ ! -z "$ZOPEN_SEARCH_PATH" ]; then
+    downloadDir="$ZOPEN_SEARCH_PATH/prod"
+  else
+    printWarning "Run zopen init to configure the install location. Using current working directory..."
+    downloadDir=$PWD
+  fi
+fi
 
 if $downloadAll; then
   unset chosenRepos
@@ -319,7 +350,8 @@ repo_results=$(echo "$repo_results" | grep "\"full_name\":" 2>/dev/null | cut -d
 
 if [ ! -d "${downloadDir}" ]; then
   mkdir -p "${downloadDir}"
-  if $?; then
+   
+  if [ $? -gt 0 ]; then
     printError "Could not create install directory: $downloadDir"
   fi
 fi

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -16,7 +16,7 @@ done
 
 touch $TMP_DEP_STATS
 
-# Remove temoraries on exit and report elapsed time
+# Remove temoraries on exit
 cleanupOnExit() {
   rv=$?
   [ -f $TMP_DEP_STATS ] && rm -rf $TMP_DEP_STATS

--- a/cicd/publish.groovy
+++ b/cicd/publish.groovy
@@ -20,7 +20,8 @@ GITHUB_REPO=$RELEASE_PREFIX
 # PAX file should be a copied artifact
 PAX=`find . -name "*zos.pax.Z"`
 BUILD_STATUS=`find . -name "test.status" | xargs cat`
-DEPENDENCIES=`find . -name ".deps" | xargs cat`
+DEPENDENCIES=`find . -name ".runtimedeps" | xargs cat`
+BUILD_DEPENDENCIES=`find . -name ".builddeps" | xargs cat`
 VERSION=`find . -name ".version" | xargs cat`
 
 if [ ! -f "$PAX" ]; then
@@ -30,6 +31,10 @@ fi
 
 if [ -z "$DEPENDENCIES" ]; then
   DEPENDENCIES="No dependencies";
+fi
+
+if [ -z "$BUILD_DEPENDENCIES" ]; then
+  BUILD_DEPENDENCIES="No dependencies";
 fi
 
 if [ ! -z "$VERSION" ]; then
@@ -47,6 +52,7 @@ unset https_proxy
 DESCRIPTION="${PORT_DESCRIPTION}"
 DESCRIPTION="${DESCRIPTION}<br /><b>Test Status:</b> ${BUILD_STATUS}<br />"
 DESCRIPTION="${DESCRIPTION}<b>Runtime Dependencies:</b> ${DEPENDENCIES}<br />"
+DESCRIPTION="${DESCRIPTION}<b>Build Dependencies:</b> ${BUILD_DEPENDENCIES}<br />"
 
 URL_LINE="https://github.com/ZOSOpenTools/${GITHUB_REPO}/releases/download/${GITHUB_REPO}_${BUILD_ID}/$PAX_BASENAME"
 DESCRIPTION="${DESCRIPTION}<br /><b>Command to download and install on z/OS:</b> <pre>pax -rf <(curl -o - -L ${URL_LINE}) && cd $DIR_NAME && . ./.env</pre>"


### PR DESCRIPTION
`zopen install` will now automatically install dependencies based on the .deps contents (which are stored in the body of the releases). 

The next step will be to process dependencies with version requirements.

Performing a `zopen install git` will now download its dependencies as follows:
```
Preparing to download git
Downloading latest release from gitport...
Deleting existing git-2.39.1.20230203_213948.zos...
Extracting git-2.39.1.20230203_213948.zos.pax.Z...
Setting up git...
Setup completed.
Successfully installed git to /home/itodoro/zopen/prod/git/
Installing dependencies for git: perl bash less ncurses......
Installing bash......
Preparing to download bash
Downloading latest release from bashport...
Deleting existing bash-5.2.20230203_164401.zos...
Extracting bash-5.2.20230203_164401.zos.pax.Z...
Setting up bash...
Setup completed.
Successfully installed bash to /home/itodoro/zopen/prod/bash/
Installing less......
Preparing to download less
Downloading latest release from lessport...
Deleting existing less-608.20230203_162213.zos...
Extracting less-608.20230203_162213.zos.pax.Z...
Setting up less...
Setup completed.
Successfully installed less to /home/itodoro/zopen/prod/less/
Installing ncurses......
Preparing to download ncurses
Downloading latest release from ncursesport...
Deleting existing ncurses-6.3.20230123_125516.zos...
Extracting ncurses-6.3.20230123_125516.zos.pax.Z...
Setting up ncurses...
Setup completed.
Successfully installed ncurses to /home/itodoro/zopen/prod/ncurses/
Installing perl......
Preparing to download perl
Downloading latest release from perlport...
Deleting existing perl5-blead.20230129_230130.zos...
Extracting perl5-blead.20230129_230130.zos.pax.Z...
Setting up perl5...
Setup completed.
Successfully installed perl to /home/itodoro/zopen/prod/perl/
```