### PR TITLE
Remove build timestamp in resulting directory for new and existing pax.Z packages

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1303,6 +1303,8 @@ install()
     fi
     asciiecho "$(echo "$buildDeps" | xargs | tr ' ' '\n' | sort -u | xargs)" "${ZOPEN_INSTALL_DIR}/.builddeps"
 
+    asciiecho "$LOG_PFX" "${ZOPEN_INSTALL_DIR}/.buildtimestamp"
+
     if $generatePax; then
       printHeader "Generating pax.Z from ${ZOPEN_INSTALL_DIR}"
       if ! runAndLog "${ZOPEN_PAX_CMD}"; then
@@ -1411,7 +1413,7 @@ resolveCommands()
     esac
     [[ -d ${ZOPEN_ROOT}/install ]] || mkdir -p ${ZOPEN_ROOT}/install
     paxFileName="${ZOPEN_ROOT}/install/${ZOPEN_NAME}.${LOG_PFX}.zos.pax.Z"
-    export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.${LOG_PFX}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""
+    export ZOPEN_PAX_CMD="pax -w -z -x pax \"-s#${ZOPEN_INSTALL_DIR}/#${ZOPEN_NAME}.zos/#\" -f \"${paxFileName}\" \"${ZOPEN_INSTALL_DIR}/\""
     if $generateSymLink; then
       PROJECT_NAME="$(echo ${ZOPEN_NAME} | cut -d'-' -f1)"
       if [ "${PROJECT_NAME}" != "${ZOPEN_NAME}" ]; then

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -203,18 +203,29 @@ installPort()
     printError "${pax} was not actually downloaded?"
   fi
 
-  dirname=${pax%.pax.Z}
+  # get extracted directory
+  dirname=$(pax -vf $pax -o listopt="%(name)s" | head -1 | sed -e "s#/\$##")
+  printVerbose "Directory name: $dirname"
   if [ -d "$dirname" ]; then
     printInfo "Deleting existing $dirname..."
     rm -rf "$dirname"
   fi
-
+  
   printInfo "Extracting $pax..."
   if ! runAndLog "pax -rf $pax -p p ${redirectToDevNull}"; then
     printWarning "Could not extract $pax. Skipping"
     continue;
   fi
   rm -f "${pax}"
+
+  newDir=$(echo "$dirname" | sed -e "s/\.202[0-9]*_[0-9]*\.zos/.zos/g")
+  # Using new directory name
+  if [ "$newDir" != "$dirname" ]; then
+    printVerbose "Moving $dirname to $newDir"
+    rm -rf "$newDir"
+    mv "$dirname" "$newDir"
+    dirname="$newDir"
+  fi
 
   # Remove old symlink and recreate
   if [ -L $name ]; then


### PR DESCRIPTION
* This also modifies existing pax.Z packages that extract to a name.version.timestamp.zos directory and modifes them to name.version.zos.