### PR TITLE
fix: use main as name for primary branch on git init

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -742,11 +742,11 @@ extractTarBall()
   # Perhaps this can be done with a function but be aware of blanks, newlines, etc. in file names
   #
   if [ "${ZOPEN_GIT_SETUP}x" = "Nx" ]; then
-    if ! git init . >/dev/null || ! git commit --allow-empty -m "Create Empty Repository for patch management" >/dev/null; then
+    if ! git init -b main . >/dev/null || ! git commit --allow-empty -m "Create Empty Repository for patch management" >/dev/null; then
       printError "Unable to initialize empty git repository for tarball"
     fi
   else
-    if ! git init . >/dev/null; then
+    if ! git init -b main . >/dev/null; then
       printError "Unable to initialize git repository for tarball"
     fi
 

--- a/patch-utils/bin/applypatch
+++ b/patch-utils/bin/applypatch
@@ -32,7 +32,7 @@ if ! cd "${tarballdir}"; then
 	echo "Extract of tarball ${tarball} did not create ${tarballdir}" >&2
 	exit 4
 fi
-if ! git init || ! git add . || ! git commit -m "main" || ! git checkout -b openssl ; then
+if ! git init -b main || ! git add . || ! git commit -m "main" || ! git checkout -b openssl ; then
 	echo "Unable to initialize a git repository for the tarball" >&2 
 	exit 4
 fi

--- a/patch-utils/bin/genpatch
+++ b/patch-utils/bin/genpatch
@@ -47,7 +47,7 @@ if ! cd "${tarballdir}"; then
         echo "Extract of tarball ${tarball} did not create ${tarballdir}" >&2
         exit 4
 fi
-if ! git init || ! git add . || ! git commit -m "main" || ! git checkout -b patches ; then
+if ! git init -b main || ! git add . || ! git commit -m "main" || ! git checkout -b patches ; then
         echo "Unable to initialize a git repository for the tarball" >&2
         exit 4
 fi


### PR DESCRIPTION
fixes #205 