### PR TITLE
Override global .gitattributes by specifying UTF-8 working tree encoding

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -786,6 +786,7 @@ extractTarBall()
     fi
 
     if ! asciiecho "
+* text  working-tree-encoding=UTF-8
 *.jpg binary
 *.dvi binary
 *.xz binary


### PR DESCRIPTION
Which is the default for git

This addresses https://github.com/ZOSOpenTools/zotsampleport/issues/6