### PR TITLE
Have 'git' generate a MANPATH entry

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1219,7 +1219,7 @@ zz
     echo "LIBPATH=\"\${${projectName}_HOME}/lib:\$LIBPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
     echo "export LIBPATH=\"\$(deleteDuplicateEntries \"\$LIBPATH\" \":\")\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
-  if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ]; then
+  if [ -d "${ZOPEN_INSTALL_DIR}/share/man" ] || [ "${projectName}" = "GIT" ]; then
     echo "MANPATH=\"\${${projectName}_HOME}/share/man:\$MANPATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
     echo "export MANPATH=\"\$(deleteDuplicateEntries \"\$MANPATH\" \":\")\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1337,7 +1337,9 @@ install()
 
     if command -V "${ZOPEN_POST_INSTALL_CODE}" >/dev/null 2>&1; then
       printVerbose "Running ${ZOPEN_POST_INSTALL_CODE}"
-      "${ZOPEN_POST_INSTALL_CODE}" "${ZOPEN_INSTALL_DIR}"
+      if ! "${ZOPEN_POST_INSTALL_CODE}" "${ZOPEN_INSTALL_DIR}" ; then
+        printError "Post install failed.${installlog}"
+      fi
     fi
 
     createReadme

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -84,7 +84,8 @@ User-Provided environment variables:
   ZOPEN_INSTALL        Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
   ZOPEN_INSTALL_OPTS   Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
   ZOPEN_CLEAN          Clean up program to run (defaults to '${ZOPEN_CLEAND}')
-  ZOPEN_CLEAN_OPTS     Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')"
+  ZOPEN_CLEAN_OPTS     Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')
+  ZOPEN_SHELL          Specify an alternate shell to use if -s option specified (defaults to /bin/sh)"
 
 }
 
@@ -1646,7 +1647,11 @@ if command -V "${ZOPEN_INIT_CODE}" >/dev/null 2>&1; then
 fi
 
 if ${startShell}; then
-  exec /bin/sh
+  if [ "${ZOPEN_SHELL}x" != "x" ]; then
+    exec "${ZOPEN_SHELL}"
+  else
+    exec /bin/sh
+  fi
 fi
 
 if $cleanupBuild || $forceRebuild; then


### PR DESCRIPTION
When zopen-build checks to see if there is a man directory, it won't exist because git builds the man pages using a post-install process.
So - this needs to be overridden with a specific check in the code for 'GIT' as a special package.

This fix (or an alternate) needs to be done before the 'man' support for git PR is done otherwise the generated env scripts won't be right.