### PR TITLE
Ignore .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tools/src/hwthic.h
 
 # Vim backup files
 *~
+
+# VSCode settings
+.vscode


### PR DESCRIPTION
My VSCode install keeps creating log files in the workspace.  It would be nice if these were ignored.