### PR TITLE
Clean up syntax help message

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -8,7 +8,6 @@ printSyntax()
   echo "Syntax: zopen <command>" >&2
   echo "where <command> is one of the following:" >&2
   echo "  build          Invokes the build script" >&2
-  echo "  download       Downloads z/OS Open Tools (deprecated)" >&2
   echo "  generate       Generate a zopen project" >&2
   echo "  init           Generate a $HOME/.zopen-config file" >&2
   echo "  install        Downloads and installs z/OS Open Tools" >&2
@@ -25,9 +24,9 @@ printHelp()
   echo "Example usage:" >&2
   echo "  # Build a port" >&2
   echo "  zopen build -v # Build port" >&2
-  echo "  # List available ports to download" >&2
+  echo "  # List available ports to install" >&2
   echo "  zopen install" >&2
-  echo "  # Download binaries from Github" >&2
+  echo "  # Install all the ports from Github" >&2
   echo "  zopen install --all" >&2
   echo "  # Generate a zopen template project" >&2
   echo "  zopen generate" >&2
@@ -42,11 +41,6 @@ while [[ $# -gt 0 ]]; do
     "build")
       shift
       exec "${bindir}/lib/zopen-build" $@
-      ;;
-    "download")
-      shift
-      printWarning "'zopen download' is deprecated and will be removed. Use 'zopen install' instead."
-      exec "${bindir}/lib/zopen-install" $@
       ;;
     "install")
       shift

--- a/bin/zopen
+++ b/bin/zopen
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      printSoftError "Unknown option ${1} specified"
+      printSoftError "Unknown option specified: '${1}'"
       printSyntax "${args}"
       exit 8
       ;;

--- a/bin/zopen
+++ b/bin/zopen
@@ -6,31 +6,31 @@ printSyntax()
 {
   echo "" >&2
   echo "Syntax: zopen <command>" >&2
-  echo "where <command> may be one of the following:" >&2
-  echo " init: generate a $HOME/.zopen-config file." >&2
-  echo " build: invokes the build script." >&2
-  echo " download: downloads z/OS Open Tools (deprecated)" >&2
-  echo " install: downloads and installs z/OS Open Tools" >&2
-  echo " generate: generate a zopen project" >&2
-  echo " update-cacert: update the cacert.pem file" >&2
-  echo " upgrade: upgrades already installed tools" >&2
+  echo "where <command> is one of the following:" >&2
+  echo "  build          Invokes the build script" >&2
+  echo "  download       Downloads z/OS Open Tools (deprecated)" >&2
+  echo "  generate       Generate a zopen project" >&2
+  echo "  init           Generate a $HOME/.zopen-config file" >&2
+  echo "  install        Downloads and installs z/OS Open Tools" >&2
+  echo "  update-cacert  Updates the cacert.pem file" >&2
+  echo "  upgrade        Upgrades already installed tools" >&2
   echo "" >&2
 }
 
-printHelp() 
+printHelp()
 {
   args=$*
   echo "zopen is a general purpose script to be used with the ZOSOpenTools ports." >&2
   printSyntax
   echo "Example usage:" >&2
-  echo " # Build a port" >&2
-  echo " zopen build -v # Build port" >&2
-  echo " # List available ports to download" >&2
-  echo " zopen install" >&2
-  echo " # Download binaries from Github" >&2
-  echo " zopen install --all" >&2
-  echo " # Generate a zopen template project" >&2
-  echo " zopen generate" >&2
+  echo "  # Build a port" >&2
+  echo "  zopen build -v # Build port" >&2
+  echo "  # List available ports to download" >&2
+  echo "  zopen install" >&2
+  echo "  # Download binaries from Github" >&2
+  echo "  zopen install --all" >&2
+  echo "  # Generate a zopen template project" >&2
+  echo "  zopen generate" >&2
 }
 
 export bindir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
@@ -45,7 +45,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     "download")
       shift
-      printWarning "zopen download is deprecated and will be removed March 1, 2023. Please use zopen install instead."
+      printWarning "'zopen download' is deprecated and will be removed. Use 'zopen install' instead."
       exec "${bindir}/lib/zopen-install" $@
       ;;
     "install")


### PR DESCRIPTION
The formatting of the syntax help message was bothering me, so I decided to clean it up a bit.  I also removed the date from the `zopen download` deprecation warning, as we're 45 days past it.  We can probably remove the command altogether soon.