### PR TITLE
docs: added hint for environment variable

### DIFF
--- a/docs/Guides/QuickStart.md
+++ b/docs/Guides/QuickStart.md
@@ -39,7 +39,9 @@ It will be much easier to work with USS using ssh, scp, and sftp.
 
 ### Set up the zopen tools
 
-Your zopen tools environment has been downloaded but not yet set up. To set up the environment:
+Your zopen tools environment has been downloaded but not yet set up. Before starting the setup, make sure that the environment variable `_BPXK_AUTOCVT` is set to ON.
+
+To set up the environment:
 - `cd $HOME/zopen/boot`
 - `. ./.bootenv` # add the tools zopen needs to function, as well as zopen (don't forget the leading '.' which sources the script)
 


### PR DESCRIPTION
Without having the _BPXK_AUTOCVT environment variable set, the .bootenv script execution will stop because some of the files used by the .bootenv script are in ASCII and tagged as ASCII.
The addvice to ensure that _BPXK_AUTOCVT has to be set to ON would prevent these problems.