### PR TITLE
Update zopen-generate

### DIFF
--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -172,6 +172,7 @@ touch "${name}port/.gitignore" && chtag -tc 819 "${name}port/.gitignore"
 cat <<EOT > "${name}port/.gitignore"
 log/
 install/
+${name}/
 EOT
 printInfo "${name}port/.gitignore created"
 

--- a/bin/lib/zopen-generate
+++ b/bin/lib/zopen-generate
@@ -172,7 +172,7 @@ touch "${name}port/.gitignore" && chtag -tc 819 "${name}port/.gitignore"
 cat <<EOT > "${name}port/.gitignore"
 log/
 install/
-${name}/
+${name}*/
 EOT
 printInfo "${name}port/.gitignore created"
 


### PR DESCRIPTION
Update `.gitignore` to not track the soon-to-be-cloned project.
Ex: For a project named `goof`, if `zopen generate` creates `goofport`, this one-line addition will add `goof/` to the `.gitignore` so that the pesky +1 in the end goes away.

![snip](https://github.com/ZOSOpenTools/meta/assets/234149/ff67dad3-4f0a-4bd6-b08e-07aea553c3d0)
