### PR TITLE
fixed #076

### DIFF
--- a/docs/Guides/QuickStart.md
+++ b/docs/Guides/QuickStart.md
@@ -35,7 +35,7 @@ It will be much easier to work with USS using ssh, scp, and sftp.
 ### Running zopen-setup
 
 - `cd $HOME`
-- `./zopen-setup  <file system>` # file system is the location where the zopen tools will be installed
+- `./zopen-setup` # The zopen tools will be installed into `$HOME/zopen`. If a path parameter is specified, the zopen tools will be installed there. The specified path can either be an absolute path or a relative path. If the specified path does not exist, it will be created as part of the setup process.
 
 ### Set up the zopen tools
 

--- a/tools/src/createdirs.c
+++ b/tools/src/createdirs.c
@@ -27,10 +27,9 @@ static int createsubdir(const char* rootdir, const char* subdir) {
   }
 }
 
-
 /*
  * Create the directories needed for a z/OS Open Tools
- * development environment relative to the root directory
+ * development environment including the root directory
  * passed in.
  *
  * If a directory already exists, it will not be modified,
@@ -42,15 +41,36 @@ static int createsubdir(const char* rootdir, const char* subdir) {
 int createdirs(const char* rootdir) {
   struct stat stroot = {0};
   const char* subdir[] = { ZOPEN_DEV, ZOPEN_BOOT, ZOPEN_PROD, NULL };
-  int i,rc;
+  const char *rootsubdir;
+  char dir[ZOPEN_PATH_MAX+1];
+  char dirtokbuf[ZOPEN_PATH_MAX+1];
+  int rc;
+  int i;
 
-  if (stat(rootdir, &stroot) == -1) {
-    fprintf(stderr, "root directory %s does not exist. No directories created\n", rootdir);
-    return ZOPEN_CREATEDIR_ROOT_NOT_EXIST;
+  memset(dir, 0x00, sizeof(dir));
+  sprintf(dir, "%s", ZOPEN_DIR_DELIMITER);
+  strcpy(dirtokbuf, rootdir);
+  rootsubdir=strtok(dirtokbuf, ZOPEN_DIR_DELIMITER);
+
+  /* create root directory tree */
+  while (rootsubdir != NULL) {
+    strcat(dir, rootsubdir);
+    if (stat(dir, &stroot) == -1) {
+      /* root subdirectory doesn't exist - create it */
+      if (rc = createsubdir(dir, "")) {
+        if (rc != ZOPEN_CREATEDIR_DIR_EXISTS) {
+          fprintf(stderr, "Could not create root subdirectory '%s': %s\n", dir, strerror(errno));
+          return rc;
+        }
+      }
+    }
+    strcat(dir, ZOPEN_DIR_DELIMITER);
+    rootsubdir=strtok(NULL, ZOPEN_DIR_DELIMITER);
   }
-
+   
+  /* create predefined subdirectories */
   for (i=0; subdir[i] != NULL; ++i ) {
-    if (rc = createsubdir(rootdir, subdir[i])) {
+    if (rc = createsubdir(dir, subdir[i])) {
       if (rc != ZOPEN_CREATEDIR_DIR_EXISTS) {
         fprintf(stderr, "Could not create subdirectory '%s': %s\n", subdir[i], strerror(errno));
         return rc;

--- a/tools/src/createdirs.h
+++ b/tools/src/createdirs.h
@@ -13,5 +13,7 @@
   #define ZOPEN_DEV  "dev"
   #define ZOPEN_HOME  "$HOME"
   #define ZOPEN_HOME_NAME  "zopen"
+  #define ZOPEN_DIR_DELIMITER "/"
+
   int createdirs(const char* root);
 #endif

--- a/tools/src/zopensetupmain.c
+++ b/tools/src/zopensetupmain.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "download.h"
 #include "zopenio.h"
@@ -35,7 +36,7 @@ static void syntax(const char* pgm, const char** bootpkg) {
     pgm = &base[1];
   }
   fprintf(stderr, "%s : Install the z/OS Open Source Tools 'starter' environment by downloading from %s\n"
-                  "Syntax: %s [-vq] <root>\n"
+                  "Syntax: %s [-vq] [<root>]\n"
                   "  <root> is the root directory where:\n"
                   "    a symbolic link from ${HOME}/zopen to <root> will be created\n"
                   "    boot, prod, and dev directories will be created\n"
@@ -113,10 +114,6 @@ int main(int argc, char* argv[]) {
   elementsbootpkg = (sizeof(bootpkg)/sizeof(bootpkg[0]))-1;
   sortbootpkg(bootpkg, elementsbootpkg);
 
-  if (argc < 2) {
-    syntax(argv[0], bootpkg);
-    return 4;
-  }
   for (i=1; i<argc; ++i) {
     if (!strcmp(argv[i], "-v")) {
       verbose = 1;
@@ -132,26 +129,32 @@ int main(int argc, char* argv[]) {
       return 8;
     } else {
       parmsok=1;
+      if (strncmp(argv[i], ZOPEN_DIR_DELIMITER, 1) != 0) {
+        /* relative root directory was specified */
+        char currentworkingdir[ZOPEN_PATH_MAX+1];
+        getcwd(currentworkingdir, sizeof(currentworkingdir));
+        snprintf(root, ZOPEN_PATH_MAX, "%s/%s", currentworkingdir, argv[i]);
+      } else {
+        /* absolute root directory was specified */
+        strcpy(root, argv[i]);
+      }
     }
   }
-  if (!parmsok) {
-    fprintf(stderr, "Specify a directory to install into\n");
-    syntax(argv[0], bootpkg);
-    return 8;
-  }
+  
   if (!zopen_c_home_var) {
-    fprintf(stderr, "Unable to determine $HOME location - this is required to create the symbolic link\n");
+    fprintf(stderr, "Unable to determine $HOME location - this is required to create the default root directory or the symbolic link\n");
     return 8;
   }
-  if (!realpath(argv[argc-1], root)) {
-    fprintf(stderr, "Directory %s does not exist, or is not writable\n", argv[argc-1]);
-    syntax(argv[0], bootpkg);
-    return 4;
+  if (!parmsok) {
+    /* no root directory was specified - defaults to $HOME/zopen */
+    strcpy(root, ZOPEN_HOME_NAME);
+    if (genfilename(zopen_c_home_var, ZOPEN_HOME_NAME, root, ZOPEN_PATH_MAX)) {
+      return 4;
+    }
   }
   if (genfilename(zopen_c_home_var, ZOPEN_HOME_NAME, zopenhome, ZOPEN_PATH_MAX)) {
     return 4;
   }
-
   if (realpath(zopenhome, realpathhome)) {
     if (strcmp(root, realpathhome)) {
       fprintf(stderr, "File or directory %s exists. Please move this file before running since a symbolic link will be created\n", zopenhome);
@@ -165,6 +168,14 @@ int main(int argc, char* argv[]) {
     symlink=1;
   }
 
+  if (verbose) {
+    fprintf(STDTRC, "Creating directories under %s\n", root);
+  }
+  if (rc = createdirs(root)) {
+    fprintf(stderr, "error creating directories: %d\n", rc);      
+    return rc;
+  }
+
   if (gentmpfilename("pem", tmppem, ZOPEN_PATH_MAX)) {
     /* gentmpfilename issues specific errors */
     return 4;
@@ -172,16 +183,6 @@ int main(int argc, char* argv[]) {
   if (gentmpfilename("pem2", tmppem2, ZOPEN_PATH_MAX)) {
     /* gentmpfilename issues specific errors */
     return 4;
-  }
-
-
-  if (verbose) {
-    fprintf(STDTRC, "Creating directories under %s\n", root);
-  }
-
-  if (rc = createdirs(root))  {
-    fprintf(stderr, "error creating directories: %d\n", rc);
-    return rc;
   }
 
   if (rc = createpem(pemdata, tmppem)) {


### PR DESCRIPTION
The way how `zopen-setup` works now is as follows:

1. `zopen-setup` can be invoked without specifiying a root-directory for the zopen tools. In this case, the setup process creates a `$HOME/zopen` directory and installs the zopen tools there.
2. `zopen-setup` can be invoked by specifiying a root-directory for the zopen tools to be installed. 
The root directory doesn't have to exist. If it's there it will be taken, if not it is going to be created. 
Thereby the root directory can be either as an absolute path or as a relative path, for example: 
\- absolute root-directory: `zopen-setup /home/user/projects/dev/zopen`
\- relative root-directory: `zopen-setup projects/test/zopen` 
In either case, the missing parts of the root-directory (if there are any) are created as part of the setup process (if the permissions allow to do so).