### PR TITLE
Modify zopen-build to generate the .depsenv rather than zopen-install

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1239,6 +1239,42 @@ touch \".installed\"
 rm \".installing\"
 zz
 
+if [ ! -z "$ZOPEN_RUNTIME_DEPS" ]; then
+cat <<ZZ >> "${ZOPEN_INSTALL_DIR}/.env"
+if [ -f ".depsenv" ] && [ -z "\$ZOPEN_SOURCING_DEPS" ] ; then
+  ZOPEN_SOURCING_DEPS=1
+  . ./.depsenv
+fi
+if [ ! -z "\$ZOPEN_SOURCING_DEPS" ]; then
+  unset ZOPEN_SOURCING_DEPS
+fi
+ZZ
+  printHeader "Install dependencies: $ZOPEN_RUNTIME_DEPS"
+  varName=$(echo "$projectName" | sed -e "s/-/_/g")
+    cat <<ZZ >> "${ZOPEN_INSTALL_DIR}/.depsenv"
+${varName}_originalDir="\$OLDPWD"
+ZZ
+  echo "$ZOPEN_RUNTIME_DEPS" | xargs | tr ' ' '\n' | sort | while read dep; do
+    if ! runAndLog "PATH=\"$curlpath:$PATH\" zopen install $dep -v --nodeps"; then
+      printError "Failed to install dependencies"
+    fi
+    cat <<ZZ >> "${ZOPEN_INSTALL_DIR}/.depsenv"
+if [ -f "../${dep}/.env" ]; then
+  if [[ \$(type echo) == 'echo is a shell builtin' ]]; then
+    pushd "../${dep}" >/dev/null
+    . ./.env
+    popd >/dev/null
+  else
+    cd "../${dep}" && . ./.env; cd - >/dev/null
+  fi
+fi
+ZZ
+   done
+   cat <<ZZ >> "${ZOPEN_INSTALL_DIR}/.depsenv"
+OLDPWD="\$${varName}_originalDir"
+ZZ
+fi
+
 # Add call to setup.sh
 cat <<zz >>"${ZOPEN_INSTALL_DIR}/.env"
 # Run setup.sh if it hasn't been run yet

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -68,7 +68,7 @@ getContentsFromGithub()
 
 printListEntries()
 {
-  printf "${NC}${UNDERLINE}${1}%-20s %-20s %-20s %-30s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Dependencies" "Status" "Quality"
+  printf "${NC}${UNDERLINE}${1}%-20s %-35s %-35s %-25s %-10s %-25s\n${NC}" "Repo" "Your version" "Latest Tag" "Dependencies" "Status" "Quality"
   echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
     name=${repo%port}
     if ! contents="$(getContentsFromGithub "https://api.github.com/repos/ZOSOpenTools/${repo}/releases/latest")"; then
@@ -100,7 +100,7 @@ printListEntries()
     else
       originalTag="Not installed"
     fi
-    printf '%-20s %-20s %-20s %-30s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$dependencies" "$buildQuality" "$testStatus"
+    printf '%-20s %-35s %-35s %-25s %-10s %-25s\n' "$repo" "$originalTag" "$latestTag" "$dependencies" "$buildQuality" "$testStatus"
     continue;
   done
 }
@@ -265,16 +265,6 @@ installPort()
     (cd "${name}" && . ./.env)
   fi
 
-  # Append deps env include
-    cat <<ZZ >> "${name}/.env"
-if [ -f ".depsenv" ] && [ -z "\$ZOPEN_SOURCING_DEPS" ] ; then
-  ZOPEN_SOURCING_DEPS=1
-  . ./.depsenv
-fi
-  if [ ! -z "\$ZOPEN_SOURCING_DEPS" ]; then
-    unset ZOPEN_SOURCING_DEPS
-  fi
-ZZ
   versionPath="$name/.version"
   if [ -r "$versionPath" ]; then
     version=$(cat "$versionPath");


### PR DESCRIPTION
Reasons for doing this:
* sourcing of .depsenv is currently appended via the zopen-install, but this is an issue if we want to use the variables or tools from the dependencies in the setup.sh script.
The current flow is: (program is sourced)->(setup.sh is run)->(dependencies are sourced)
The new flow will be (program is sourced)->(dependencies are sourced)->(setup.sh is run)
* It will also allow individual .pax.Z downloads to potentially pick up dependencies