### PR TITLE
docs page octocat link does not work

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
       plugins: [
         EditOnGithubPlugin.create('https://github.com/ZOSOpenTools/meta/blob/main/docs/', null, 'Edit this page'),
       ],
-      repo: 'https://github.com/ZOSOpenTools/meta/docs',
+      repo: 'https://github.com/ZOSOpenTools/meta',
       search: 'auto',
       maxLevel: 4,
       subMaxLevel: 4,


### PR DESCRIPTION
![image](https://github.com/ZOSOpenTools/meta/assets/1266441/084061a2-a7ab-4e83-be82-94f737b8b0e9)

goes to https://github.com/ZOSOpenTools/meta/docs and a 404.