### PR TITLE
Optimize .env and .zopen-config processing

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1268,9 +1268,12 @@ zz
   if command -V "${ZOPEN_APPEND_TO_ENV_CODE}" >/dev/null 2>&1; then
     printVerbose "Appending additional environment variables..."
     append_to_env="$(${ZOPEN_APPEND_TO_ENV_CODE})"
-    echo "$append_to_env" > "${ZOPEN_INSTALL_DIR}/.appenv"
-    echo ". ./.appenv" >> "${ZOPEN_INSTALL_DIR}/.env"
+  else
+    append_to_env="# nothing to do"
   fi
+
+  echo "$append_to_env" > "${ZOPEN_INSTALL_DIR}/.appenv"
+  echo ". ./.appenv" >> "${ZOPEN_INSTALL_DIR}/.env"
 
   cat <<zz >>"${ZOPEN_INSTALL_DIR}/.env"
 if \$dropTagRedirEnvar; then

--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1268,7 +1268,8 @@ zz
   if command -V "${ZOPEN_APPEND_TO_ENV_CODE}" >/dev/null 2>&1; then
     printVerbose "Appending additional environment variables..."
     append_to_env="$(${ZOPEN_APPEND_TO_ENV_CODE})"
-    echo "$append_to_env" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "$append_to_env" > "${ZOPEN_INSTALL_DIR}/.appenv"
+    echo ". ./.appenv" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
 
   cat <<zz >>"${ZOPEN_INSTALL_DIR}/.env"

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -288,12 +288,6 @@ ZOPEN_LOG_PATH=\$ZOPEN_ROOTFS/var/log
 export ZOPEN_LOG_PATH
 
 # Environment variables
-PATH=\$ZOPEN_ROOTFS/usr/bin:\$ZOPEN_ROOTFS/bin:\$ZOPEN_ROOTFS/boot:\$(sanitizeEnvVar \"\$PATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
-PATH=\$(deleteDuplicateEntries \"\$PATH\" \":\")
-LIBPATH=\$ZOPEN_ROOTFS/usr/lib:\$(sanitizeEnvVar "\$LIBPATH" ":" "^\$ZOPEN_PKGINSTALL/.*\$")
-LIBPATH=\$(deleteDuplicateEntries \"\$LIBPATH\" \":\")
-MANPATH=\$ZOPEN_ROOTFS/usr/share/man:\$ZOPEN_ROOTFS/usr/share/man/\%L:\$(sanitizeEnvVar \"\$MANPATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
-MANPATH=\$(deleteDuplicateEntries \"\$MANPATH\" \":\")
 
 if [ -z "\$ZOPEN_QUICK_LOAD" ]; then
   if [ -e "\$ZOPEN_ROOTFS/etc/profiled" ]; then
@@ -314,12 +308,6 @@ if [ -z "\$ZOPEN_QUICK_LOAD" ]; then
         /bin/echo "Processing \$zot configuration...: \${pct}% (\${filecnt}/\${dotenvcnt})"
       fi
       [ -e \$FILE ] && . \$FILE
-      PATH=\$ZOPEN_ROOTFS/usr/bin:\$ZOPEN_ROOTFS/bin:\$ZOPEN_ROOTFS/boot:\$(sanitizeEnvVar \"\$PATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
-      PATH=\$(deleteDuplicateEntries \"\$PATH\" \":\")
-      LIBPATH=\$ZOPEN_ROOTFS/usr/lib:\$(sanitizeEnvVar "\$LIBPATH" ":" "^\$ZOPEN_PKGINSTALL/.*\$")
-      LIBPATH=\$(deleteDuplicateEntries \"\$LIBPATH\" \":\")
-      MANPATH=\$ZOPEN_ROOTFS/usr/share/man:\$ZOPEN_ROOTFS/usr/share/man/\%L:\$(sanitizeEnvVar \"\$MANPATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
-      MANPATH=\$(deleteDuplicateEntries \"\$MANPATH\" \":\")
     done < \$TMP_FIFO_PIPE
     [ ! -p \$TMP_FIFO_PIPE ] || rm -f \$TMP_FIFO_PIPE
     if [ ! "\${_BPX_TERMPATH-x}" = "OMVS" ];  then
@@ -330,10 +318,12 @@ if [ -z "\$ZOPEN_QUICK_LOAD" ]; then
     unset dotenvs dotenvcnt filecnt
   fi
 fi
-MANPATH="\$MANPATH:"
-export MANPATH
-export LIBPATH
-export PATH
+PATH=\$ZOPEN_ROOTFS/usr/bin:\$ZOPEN_ROOTFS/bin:\$ZOPEN_ROOTFS/boot:\$(sanitizeEnvVar \"\$PATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
+export PATH=\$(deleteDuplicateEntries \"\$PATH\" \":\")
+LIBPATH=\$ZOPEN_ROOTFS/usr/lib:\$(sanitizeEnvVar "\$LIBPATH" ":" "^\$ZOPEN_PKGINSTALL/.*\$")
+export LIBPATH=\$(deleteDuplicateEntries \"\$LIBPATH\" \":\")
+MANPATH=\$ZOPEN_ROOTFS/usr/share/man:\$ZOPEN_ROOTFS/usr/share/man/\%L:\$(sanitizeEnvVar \"\$MANPATH\" \":\" \"^\$ZOPEN_PKGINSTALL/.*\$\")
+export MANPATH=\$(deleteDuplicateEntries \"\$MANPATH\" \":\")
 
 unset tmp TMP_FIFO_PIPE
 

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -398,7 +398,10 @@ handlePackageInstall(){
         cat << EOF > "$ZOPEN_ROOTFS/etc/profiled/$name/dotenv"
 curdir=\$(pwd)
 cd "$baseinstalldir/$name/$name" >/dev/null 2>&1
-if [ -f ".env" ]; then
+# If .appenv exists, source it as it's quicker
+if [ -f ".appenv" ]; then
+  . ./.appenv
+elif [ -f ".env" ]; then
   . ./.env
 fi
 cd \$curdir  >/dev/null 2>&1


### PR DESCRIPTION
Since the new zopen symlinks all binaries, libraries, and man pages under a common bin, lib, share location, we no longer need to set the PATH, LIBPATH and MANPATH environment variables for each tool.

However, if someone downloads the tool manually, then we should still retain the existing .env logic. So this change allows for both cases to work.

The idea is that we would decouple the required tool environment variables away from the .env into a .appenv, which zopen-config would source. This would greatly speed up the .zopen-config processing.

This would require a new build of all tools that have zopen_append_to_env logic.

There's currently a fallback in place, such that if .appenv doesn't exist, it will source .env.

If there's any environment variables that are used within the application process, they should use `zopen_append_to_zoslib_env` (as in the case of Git):
```
zopen_append_to_zoslib_env() {
cat <<EOF
GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
EOF
}
```

But variables that are needed by other tools or processes should go into `zopen_append_to_env` (we might need to change the name) as in the case of autoconf:
```
zopen_append_to_env()
{
cat <<EOF
export autom4te_perllibdir=\${PWD}/share/autoconf
export AC_MACRODIR=\${PWD}/share/autoconf


#To set M4 variable path
if [ -z "${M4_HOME}"  ]; then
    echo "Ensure M4_HOME is set and re-source the .env"
else
    export M4="\$M4_HOME/bin/m4"
fi
EOF
}
```

