### PR TITLE
Add GH Actions action.yml

### DIFF
--- a/actions/action.yml
+++ b/actions/action.yml
@@ -1,0 +1,42 @@
+name: 'Bump versions'
+description: 'Use bump to create version update pull requests'
+author: 'ZOSOpenTools'
+branding:
+  icon: 'chevrons-up'
+  color: 'green'
+runs:
+  using: 'docker'
+  image: 'docker://mwader/bump'
+inputs:
+  bumpfile:
+    description: 'Bumpfile to read'
+    required: false
+    default: 'Bumpfile'
+  bump_files:
+    description: 'Files with embedded configuration or versions to update'
+    required: false
+    default: 'buildenv'
+  title_template:
+    description: 'Commit and pull request title template'
+    required: false
+    default: 'Update {{.Name}} to {{.Latest}} from {{join .Current ", "}}'
+  commit_body_template:
+    description: 'Commit body template'
+    required: false
+    default: '{{range .Messages}}{{.}}{{"\n\n"}}{{end}}{{range .Links}}{{.Title}} {{.URL}}{{"\n"}}{{end}}'
+  pr_body_template:
+    description: 'Pull request body template'
+    required: false
+    default: '{{range .Messages}}{{.}}{{"\n\n"}}{{end}}{{range .Links}}[{{.Title}}]({{.URL}})  {{"\n"}}{{end}}'
+  branch_template:
+    description: 'Pull requests branch name template'
+    required: false
+    default: 'bump-{{.Name}}-{{.Latest}}'
+  user_name:
+    description: 'Commit user name'
+    required: false
+    default: 'bump'
+  user_email:
+    description: 'Commit user email'
+    required: false
+    default: 'bump-action@github'


### PR DESCRIPTION
Instead of creating custom actions in each repo, the action can live in `meta`, and can be reference in repo-specific workflow files like so - https://github.com/ZOSOpenTools/duckdbport/blob/main/.github/workflows/bump.yml

```yaml
name: 'Automatic version updates'

on:
  schedule:
    # minute hour dom month dow (UTC)
    - cron: '00 15 * * *'
  # enable manual trigger of version updates
  workflow_dispatch:
jobs:
  bump:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master
      - uses: zosopentools/duckdbport/action@main
        env:
          GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}
```

Reference to an automatically generated PR: https://github.com/ZOSOpenTools/duckdbport/pull/2

Additionally, it would be great if an org-wide secret called `BUMP_TOKEN` can be created and populated with a Personal Access Token that has the `repo` check boxes checked for repo read access.
Also would be best if the PAT belonged to the `ZOSOpenTools` ID.

Feel free to change `user.name`, `user.email` or anything else in the `action.yml` as required.

The action finishes within 20s, which is great.
It's currently setup to run every day at 1500 UTC.

**EDIT:**
Can also add a neat little badge to the participating repos like so:
![image](https://github.com/ZOSOpenTools/meta/assets/234149/9219c3db-ca9d-42f7-a43d-410cd87baa1b)
