### PR TITLE
426 zopen clean  a groff didnt do what i expected

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -15,6 +15,15 @@ cleanupFunction() {
 }
 trap "cleanupFunction" EXIT INT TERM QUIT HUP
 
+isPackageActive(){
+  pkg="$1"
+  printDebug "Checking if '$pkg' is installed and active"
+  installedPackage=$(cd "$ZOPEN_PKGINSTALL" && zosfind . -name ".active" | grep "/$pkg/")
+  cmdrc=$?
+  # Return 1 for true/Package is Active, 0 for false/Package is not active
+  [ $cmdrc -eq 0 ] && return 1 || return 0
+}
+
 curlCmd(){
   # Take the list of parameters and concat them with  
   # any custom parameters the user requires in ZOPEN_CURL_PARAMS

--- a/bin/lib/zopen-alt
+++ b/bin/lib/zopen-alt
@@ -5,33 +5,97 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
 . "${utildir}/common.inc"
 
-printSyntax() 
-{
-  args=$*
-  echo "zopen alt is a utility for z/OS Open Tools to switch package versions for currently installed packages" >&2
-  echo "Syntax: zopen-alt [<option>]* [<package]" >&2
-  echo "  where <option> may be one or more of:" >&2
-  echo "  -s | --set: set version" >&2
-  echo "  -v | --v | -verbose | --verbose: run in verbose mode." >&2
-  echo "  -h | --h | -help | --help | -? | -syntax: print this information" >&2
-  echo "  -d: specify default option for an alternative" >&2
-  echo " and <package> is a package name." >&2
+printHelp(){
+cat << HELPDOC
+zopen alt is a utility for z/OS Open Tools to switch package versions 
+for currently installed packages.
+
+Usage: zopen alt [OPTION] [PACKAGE] [PARAMETERS]...
+
+Options:
+  -s, --set [PACKAGE] [VERSION]
+                    set the active version for PACKAGE to VERSION 
+      --select [PACKAGE] 
+                    select the active version for PACKAGE from a list
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+Examples:
+  zopen alt foo     list the available alternatives for package 'foo'
+  zopen alt --select foo
+                    list the available alternatives for package 'foo'
+                    and allow the user to select an alternative version
+  zopen alt --set foo foo-1.2.3.19700101_012345.zos
+                    set the active version of package 'foo' to version
+                    foo-1.2.3.19700101_012345.zos if available
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
+}
+
+mergeNewVersion(){
+  package="$1"
+  newver="$2"
+  [ -d "$ZOPEN_PKGINSTALL/$package/$newver" ] || printError "Version '$newver' was not available to set as current"
+  if [ -e "$ZOPEN_PKGINSTALL/$package/$package" ]; then
+    printVerbose "Removing main link"
+    rm -rf "$ZOPEN_PKGINSTALL/$package/$package"
+  fi
+  mergeIntoSystem "$package" "$ZOPEN_PKGINSTALL/$package/$newver" "$ZOPEN_ROOTFS" 
+  printVerbose "New version merged; checking for orphaned files from previous version"
+  # This will remove any old symlinks or dirs that might have changed in an up/downgrade
+  # as the merge process overwrites existing files to point to different version. If there was
+  # no other version, then $deref will be empty so nothing to uninstall
+  if [ -n "$deref" ]; then
+    unsymlinkFromSystem "$package" "$ZOPEN_ROOTFS" "${ZOPEN_PKGINSTALL}/$package/$deref/.links"
+  else
+    printVerbose "No previous version found (no .links) - no unlinking performed"
+  fi 
+  
+  misrc=$?
+  printVerbose "The merge completed with: $misrc"
+  printVerbose "Generating main link from $package to version: $newver"
+  if ! ln -sf "$newver" "$ZOPEN_PKGINSTALL/$package/$package"; then
+    printError "Could not create symbolic link name"
+  fi
+  touch "${ZOPEN_PKGINSTALL}/${package}/${package}/.active"
+  version="unknown"
+  if [ -e "${ZOPEN_PKGINSTALL}/${package}/${package}/.releaseinfo" ]; then
+    version=$(cat "${ZOPEN_PKGINSTALL}/${package}/${package}/.releaseinfo")
+  fi
+  syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_PACKAGE" "ALT" "setAlt" "Set '${package}' to version:$version;"
 }
 
 setAlt(){
+  package="$1"
+  newver="$2"
+  if [ -e "$ZOPEN_PKGINSTALL/$package/" ]; then
+    printVerbose "$package is either installed or has been previously"
+    found=$(zosfind "$ZOPEN_PKGINSTALL/$package/" -type l -prune -o -type d -print | sed -e "s#$ZOPEN_PKGINSTALL/$package/\([^/]*\).*#\1#" | uniq)
+  else
+    printVerbose "$package has never been installed on the system"
+  fi
+  if [ -z "$found" ]; then
+    printInfo "No available versions of package '${package}'"
+    exit 4
+  fi
+  if [ -e "$ZOPEN_PKGINSTALL/$package/$package" ]; then
+    deref=$(ls -l "$ZOPEN_PKGINSTALL/$package/$package" | awk '{ print $(NF) }')
+    printVerbose "Current version: ${deref#$ZOPEN_PKGINSTALL/}"
+  fi
+  mergeNewVersion "$package" "$newver"
+}
+
+selectAlt(){
   i=$1
-  needle=$2
-  printVerbose "Setting alternative"
+  package=$2
+  printVerbose "Selecting alternative"
     valid=false
     while ! $valid; do
-      if [ -n "$defaultoption" ]; then
-        selection="$defaultoption"
-        defaultoption="" # Only try it once
-      else 
-        echo "Enter alternative version to use (1-$i): "
-        selection=$(getInput)
-      fi
-      if [[ ! -z "$(echo $selection | sed -e 's/[0-9]*//')" ]]; then
+      echo "Enter alternative version to use (1-$i): "
+      selection=$(getInput)
+      if [ ! -z "$(echo $selection | sed -e 's/[0-9]*//')" ]; then
         echo "Invalid input, must be a number between 1 and $i"
       elif [ "$selection" -ge 1 ] && [ "$selection" -le "$i" ]; then
         valid=true
@@ -42,38 +106,8 @@ setAlt(){
         BEGIN {count=0}
               {count = count + 1; if (count=selection) { print $(selection)} }
       ')"
-      printInfo "Setting alternative: $selection: $newver"
-      [ -d "$ZOPEN_PKGINSTALL/$needle/$newver" ] || printError "Mismatch found, no version directory at $newver" 
-      [ -n "$needle" ] || printError "$ZOPEN_PKGINSTALL/$needle not found"
-      if [ -e "$ZOPEN_PKGINSTALL/$needle/$needle" ]; then
-        printVerbose "Removing main link"
-        
-        rm -rf "$ZOPEN_PKGINSTALL/$needle/$needle"
-      fi
-
-      mergeIntoSystem "$needle" "$ZOPEN_PKGINSTALL/$needle/$newver" "$ZOPEN_ROOTFS" 
-      printVerbose "New version merged; checking for orphaned files from previous version"
-      # This will remove any old symlinks or dirs that might have changed in an up/downgrade
-      # as the merge process overwrites existing files to point to different version. If there was
-      # no other version, then $deref will be empty so nothing to uninstall
-      if [ -n "$deref" ]; then
-        unsymlinkFromSystem "$needle" "$ZOPEN_ROOTFS" "${ZOPEN_PKGINSTALL}/$needle/$deref/.links"
-      else
-        printVerbose "No previous version found (no .links) - no unlinking performed"
-      fi 
-      
-      misrc=$?
-      printVerbose "The merge completed with: $misrc"
-      printVerbose "Generating main link from $needle to version: $newver"
-      if ! ln -sf "$newver" "$ZOPEN_PKGINSTALL/$needle/$needle"; then
-        printError "Could not create symbolic link name"
-      fi
-      touch "${ZOPEN_PKGINSTALL}/${needle}/${needle}/.active"
-      version="unknown"
-      if [ -e "${ZOPEN_PKGINSTALL}/${needle}/${needle}/.releaseinfo" ]; then
-        version=$(cat "${ZOPEN_PKGINSTALL}/${needle}/${needle}/.releaseinfo")
-      fi
-      syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_PACKAGE" "ALT" "setAlt" "Set '${needle}' to version:$version;"
+      printInfo "selecting alternative: $selection: $newver"
+      mergeNewVersion "$package" "$newver"
     else
       printInfo "Selection is already current version."
       exit 0
@@ -81,23 +115,23 @@ setAlt(){
 }
 
 listAlts(){
-  sett=$1
-  needle="$2"
+  select=$1
+  package="$2"
 
-  printVerbose "Checking for the existence of the '$needle' package directory within PKGINSTALL"
-  needle=$(echo "$needle" | awk '{$1=$1};1')
-  if [ -e "$ZOPEN_PKGINSTALL/$needle/" ]; then
-    printVerbose "$needle is either installed or has been previously"
-    found=$(zosfind "$ZOPEN_PKGINSTALL/$needle/" -type l -prune -o -type d -print | sed -e "s#$ZOPEN_PKGINSTALL/$needle/\([^/]*\).*#\1#" | uniq)
+  printVerbose "Checking for the existence of the '$package' package directory within PKGINSTALL"
+  package=$(echo "$package" | awk '{$1=$1};1')
+  if [ -e "$ZOPEN_PKGINSTALL/$package/" ]; then
+    printVerbose "$package is either installed or has been previously"
+    found=$(zosfind "$ZOPEN_PKGINSTALL/$package/" -type l -prune -o -type d -print | sed -e "s#$ZOPEN_PKGINSTALL/$package/\([^/]*\).*#\1#" | uniq)
   else
-    printVerbose "$needle has never been installed on the system"
+    printVerbose "$package has never been installed on the system"
   fi
-  if [[ -z "$found" ]]; then
-    printInfo "No currently available version of package '${needle}'"
+  if [ -z "$found" ]; then
+    printInfo "No currently available version of package '${package}'"
     exit 4
   fi
-  if [ -e "$ZOPEN_PKGINSTALL/$needle/$needle" ]; then
-    deref=$(ls -l "$ZOPEN_PKGINSTALL/$needle/$needle" | awk '{ print $(NF) }')
+  if [ -e "$ZOPEN_PKGINSTALL/$package/$package" ]; then
+    deref=$(ls -l "$ZOPEN_PKGINSTALL/$package/$package" | awk '{ print $(NF) }')
     printVerbose "Current version: ${deref#$ZOPEN_PKGINSTALL/}"
   fi
 
@@ -106,27 +140,27 @@ listAlts(){
 # just the below would be simpler, but creates a subshell so can't get the number of entries outside!  
 #  echo "$found" | xargs | tr ' ' '\n' | while read repo; do
   TMP_FIFO_PIPE="$HOME/altselect.pipe"
-  [[ ! -p "$TMP_FIFO_PIPE" ]] || rm -f "$TMP_FIFO_PIPE"
+  [ ! -p "$TMP_FIFO_PIPE" ] || rm -f "$TMP_FIFO_PIPE"
   mkfifo $TMP_FIFO_PIPE
   echo "$found" | xargs | tr ' ' '\n' >> "$TMP_FIFO_PIPE" &
   while read repo; do
     printVerbose "Parsing repo: '$repo' as '${repo#$ZOPEN_PKGINSTALL/}'"
     i=$(expr $i + 1)
-    if [[ "${deref#$ZOPEN_PKGINSTALL/}" = "${repo#$ZOPEN_PKGINSTALL/}" ]]; then
+    if [ "${deref#$ZOPEN_PKGINSTALL/}" = "${repo#$ZOPEN_PKGINSTALL/}" ]; then
       current=$i
       printInfo "${NC}${GREEN}$i: ${repo#$ZOPEN_PKGINSTALL/}  <-  current${NC}"
     else
-      printInfo "$i: ${repo#$ZOPEN_PKGINSTALL/}"
+      printInfo "$i: ${repo#"$ZOPEN_PKGINSTALL"/}"
     fi
   done < "$TMP_FIFO_PIPE"
-  [[ ! -p $TMP_FIFO_PIPE ]] || rm -rf "$TMP_FIFO_PIPE"
+  [ ! -p $TMP_FIFO_PIPE ] || rm -rf "$TMP_FIFO_PIPE"
 
-  if $sett; then
+  if $select; then
     mutexReq "zopen" "zopen"
-    setAlt "$i" "$needle" "$deref"
-    unset sett
+    selectAlt "$i" "$package" "$deref"
+    unset select
     mutexFree "zopen"
-    listAlts false "$needle"
+    listAlts false "$package"
   fi
   exit 0
 }
@@ -135,33 +169,53 @@ listAlts(){
 # Main code start here
 args=$*
 verbose=false
-sett=false
-defaultoption=""
-if [[ $# -eq 0 ]]; then
-  printError "No option provided for query"
+debug=false
+sett=false  #sett to distinguish from "set" command
+select=false
+if [ $# -eq 0 ]; then
+  printError "Missing program argument"
 fi
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   printVerbose "Parsing option: $1"
   case "$1" in
     "-s" | "--set")
+      shift
+      [ $# -lt 2 ] && printError "Missing argument(s) for set option. Check program arguments"
       sett=true
+      select=false
+      package="$1"
+      newver="$2"
+      shift
+    ;;
+    "--select")
+      select=true
+      sett=false
+      shift
+      [ $# -lt 1 ] && printError "Missing argument for select option."
+      package="$1"
       ;;
-    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-      printSyntax "${args}"
+    "-h" | "--help" | "-?")
+      printHelp "${args}"
       exit 4
       ;;
-    "-v" | "--v" | "-verbose" | "--verbose")
+    "-v" | "--verbose")
       verbose=true
       ;;
-    "-d") defaultoption="$2"
-          shift
-          ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
     *)
-      packageList="$packageList $1";
+      package="$1"; # Multiple packages will result in the last package only
       ;;
   esac
   shift;
 done
 
-[[ -z "$packageList" ]] || listAlts $sett "$packageList"
-printError "No action verb specified"
+if $sett; then
+  setAlt "$package" "$newver"
+elif [ -n "$package" ]; then
+  listAlts $select "$package"
+else
+  printError "No action verb specified. Run zopen alt --help for command syntax"
+fi

--- a/bin/lib/zopen-clean
+++ b/bin/lib/zopen-clean
@@ -5,33 +5,48 @@ export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 
 . "${utildir}/common.inc"
 
-printSyntax() 
-{
-  args=$*
-  echo "zopen clean is a utility for z/OS Open Tools to switch package versions for currently installed packages" >&2
-  echo "Syntax: zopen-clean [<option>]* [<package]" >&2
-  echo "  where <option> may be one or more of:" >&2
-  echo "      -u : --unused: removes unused package versions" >&2
-  echo "      -d : --dangling: removes dangling symlinks" >&2
-  echo "      -c : --cache: cleans package cache" >&2
-  echo "      -a : --all:  equivalent to -u -d -c" 
-  echo "  -v: run in verbose mode." >&2
-  echo "TODO and <package> is a package name." >&2
+printHelp(){
+cat << HELPDOC
+zopen clean is a utility for z/OS Open Tools to clean uneeded resources
+from the system to save space and prevent clutter
+
+Usage: zopen clean [OPTION] [PACKAGE]
+
+Options:
+  -c, --cache       cleans the downloaded package cache; packages will be re-downloaded if needed
+  -d, --dangling    removes dangling symlinks from the zopen file system in case of issues during
+                    package maintenance
+  -u, --unused [PACKAGE]     
+                    remove versions of PACKAGE that are available as alternatives, leaving only the 
+                    currently active version
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+Examples:
+  zopen clean -c    clear the package download cache
+  zopen clean -d    analyse the zopen file system and remove any dangling symlinks
+  zopen clean -u [PACKAGE]
+                    remove unused versions for PACKAGE
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
 }
 
 
 cleanUnused(){
   needle=$1
-  found=$(zosfind $ZOPEN_PKGINSTALL -name "*/${needle}-*" -prune -type d  | grep "/${needle}-[^/]*")
-  if [[ -z $found ]]; then
-    printInfo "No currently installed version of package '${needle}'"
+  found=$(zosfind "$ZOPEN_PKGINSTALL" -name "*/${needle}-*" -prune -type d )
+  if [ -z "$found" ]; then
+    printInfo "No versions of package '${needle}' found for removal"
     return
   fi
-  if [ -e "$ZOPEN_PKGINSTALL/$needle" ]; then
-    deref=$(ls -l $ZOPEN_PKGINSTALL/$needle | awk '{ print $(NF) }')
-    printVerbose "Current version: ${deref#$ZOPEN_PKGINSTALL/}"
+
+  if isPackageActive "$needle"; then
+    printVerbose "Getting the current versions directory [if any]"
+    deref=$(cd "$ZOPEN_PKGINSTALL/$needle/$needle" && pwd -P)
   else
-    printInfo "No current version of $needle installed. Removing all unused versions"
+    printInfo "No currently installed version of package '${needle}'. Removing all versions"
   fi
 
   i=0
@@ -39,12 +54,12 @@ cleanUnused(){
 # the below would be simpler, but creates a subshell so can't get the number of entries outside!  
 #  echo "$found" | xargs | tr ' ' '\n' | while read repo; do
   TMP_FIFO_PIPE="$HOME/altselect.pipe"
-  [[ ! -p $TMP_FIFO_PIPE ]] || rm -f $TMP_FIFO_PIPE
-  mkfifo $TMP_FIFO_PIPE
-  echo "$found" | xargs | tr ' ' '\n'>> $TMP_FIFO_PIPE &
+  [ ! -p "$TMP_FIFO_PIPE" ] || rm -f "$TMP_FIFO_PIPE"
+  mkfifo "$TMP_FIFO_PIPE"
+  echo "$found" | xargs | tr ' ' '\n'>> "$TMP_FIFO_PIPE" &
   while read repo; do
     printVerbose "Parsing repo: '$repo' as '${repo#$ZOPEN_PKGINSTALL/}'"
-    if [[ "${repo}" = "${repo#$ZOPEN_PKGINSTALL/}" ]]; then
+    if [ "${repo}" = "${repo#$ZOPEN_PKGINSTALL/}" ]; then
       printVerbose "Working around possible bug in FIFO that converts initial char to alert/bell 0x07/'\a'"
       if ! $(type od); then
         printVerbose "Displaying erroneous string"
@@ -53,29 +68,35 @@ cleanUnused(){
       fi
       repo="/$(echo $repo | cut -b 2-)"
       printVerbose "Repo:='$repo'"
-      syslog $ZOPEN_LOG_PATH/audit.log $LOG_W "$CAT_FILE,$CAT_SYS" "CLEAN" "cleanUnused" "FIFO character issue while reading from $TMP_FIFO_PIPE. Workaround applied"
+      syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_W" "$CAT_FILE,$CAT_SYS" "CLEAN" "cleanUnused" "FIFO character issue while reading from $TMP_FIFO_PIPE. Workaround applied"
     fi
     i=$(expr $i + 1)
-    if [[ "${deref#$ZOPEN_PKGINSTALL/}" = "${repo#$ZOPEN_PKGINSTALL/}" ]]; then
+    if [ "${deref#$ZOPEN_PKGINSTALL/}" = "${repo#$ZOPEN_PKGINSTALL/}" ]; then
       current=$i
       printInfo "${NC}${GREEN}$i: ${repo#$ZOPEN_PKGINSTALL/}  <-  current${NC}"
     else
       rm -rf "$repo" >/dev/null 2>&1 
       printInfo "$i: ${repo#$ZOPEN_PKGINSTALL/} <- Removed"
-      syslog $ZOPEN_LOG_PATH/audit.log $LOG_A "$CAT_FILE,$CAT_PACKAGE,$CAT_REMOVE" "CLEAN" "cleanUnused" "Removed unused package at ${repo#$ZOPEN_PKGINSTALL/} "
+      syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_FILE,$CAT_PACKAGE,$CAT_REMOVE" "CLEAN" "cleanUnused" "Removed unused package at ${repo#$ZOPEN_PKGINSTALL/} "
     fi
-  done < $TMP_FIFO_PIPE
-  [[ ! -p $TMP_FIFO_PIPE ]] || rm -f $TMP_FIFO_PIPE
+  done < "$TMP_FIFO_PIPE"
+  [ ! -p "$TMP_FIFO_PIPE" ] || rm -f "$TMP_FIFO_PIPE"
   printInfo "- Removal of unused package versions complete" 
 }
+
 cleanDangling(){
   printVerbose "Removing dangling symlinks from the file structure"
+  # As packages can install to any subfolder of the zopen filesystem, need to traverse
+    # along every path under that filesystem
   if [ "$ZOPEN_ROOTFS" = "/." ]; then
-    printWarning "With zopen's root set as '/', traversal to find dangling symlinks"
+    printWarning "With zopen's root configured as '/', traversal to find dangling symlinks"
     printWarning "will occur on ALL mounted file systems, ALL sub-directories and will"
     printWarning "attempt to remove any dangling symlinks it finds, regardless of how they"
     printWarning "were created or which package/product/install mechanism was used and if "
     printWarning "the user has permission to do so (errors will be reported if not)."
+    printWarning "This is due to individual packages potentially installing to any location"
+    printWarning "within the zopen file structure so all locations need to be considered"
+    printWarning "and analysed."
     printWarning "Are you absolutely sure you want to run this option (y/N)?"
     read absolutely < /dev/tty
     if [ -n "$absolutely" ] && [ "y" = "${absolutely}" ]; then
@@ -89,65 +110,75 @@ cleanDangling(){
   killph="kill -HUP $ph"
   addCleanupTrapCmd "$killph"
   flecnt=0
-  zosfind $ZOPEN_ROOTFS -type l -exec test ! -e {} \; -print | while read sl; do
+  zosfind "$ZOPEN_ROOTFS" -type l -exec test ! -e {} \; -print | while read sl; do
     printVerbose "Removing symlink '$sl'"
     rm -f $sl
     flecnt=$(expr $flecnt + 1)
   done
   $killph 2>/dev/null  # if the timer is not running, the kill will fail
-  syslog $ZOPEN_LOG_PATH/audit.log $LOG_A "$CAT_FILE" "CLEAN" "cleanDangling" "zopen system scanned for dangling symlinks; $flecnt link(s) removed"
+  syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_FILE" "CLEAN" "cleanDangling" "zopen system scanned for dangling symlinks; $flecnt link(s) removed"
 }
+
 cleanCache(){
   printVerbose "Cleaning $ZOPEN_ROOTFS/var/cache/zopen"
-  rm -rf $ZOPEN_ROOTFS/var/cache/zopen/*
-  syslog $ZOPEN_LOG_PATH/audit.log $LOG_A "$CAT_FILE" "CLEAN" "cleanCache" "Main cache in $ZOPEN_ROOTFS/var/cache/zopen cleaned"
+  rm -rf "$ZOPEN_ROOTFS/var/cache/zopen/*"
+  syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_FILE" "CLEAN" "cleanCache" "Main cache in $ZOPEN_ROOTFS/var/cache/zopen cleaned"
   printInfo "- Cache at '$ZOPEN_ROOTFS/var/cache/zopen' cleaned"
 }
 
 # Main code start here
 args=$*
 verbose=false
+debug=false
 unused=false
 dangling=false
 cache=false
 package=""
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   printError "No option provided for cleaning"
 fi
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   printVerbose "Parsing option: $1"
   case "$1" in
       "-u" | "--unused")
+      shift
+      [ $# -lt 1 ] && printError "Missing parameter for 'clean unused' option"
       unused=true
+      dangling=false
+      cache=false
+      package="$1"
       ;;
       "-d" | "--dangling")
+      unused=false
       dangling=true
+      cache=false
       ;;
       "-c" | "--cache")
+      unused=false
+      dangling=false
       cache=true
       ;;
-      "-a" | "--all")
-      unsed=true
-      dangling=true
-      cache=true
-      ;;
-    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-      printSyntax "${args}"
+    "-h" | "--help" | "-?" )
+      printHelp "${args}"
       exit 4
       ;;
-    "-v" | "--v" | "-verbose" | "--verbose")
+    "-v" | "--verbose")
       verbose=true
       ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
     *)
-      package="$1";
+      package="$1"; # Use the last unrecognised parameter as the package
       ;;
   esac
   shift;
 done
 
 if $unused; then 
-  cleanUnused $package
+  cleanUnused "$package"
 fi
 if $dangling; then 
   cleanDangling

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -33,6 +33,7 @@ printSyntax()
 args=$*
 
 verbose=false
+debug=false
 yesToPrompts=false
 reinitExisting=false
 clone=false
@@ -63,6 +64,9 @@ while [ $# -gt 0 ]; do
       ;;
     "-v" | "--v" | "-verbose" | "--verbose")
       verbose=true
+      ;;
+    "--debug") 
+      debug=true
       ;;
     "--yes" | "-y")
       yesToPrompts=true  # Automatically answer 'yes' to any questions
@@ -491,51 +495,11 @@ else
 
   printInfo "- Sourcing environment"
   . "$configFile"
-  printInfo "- Using bootstrapped curl and jq to install latest release of itself (if available)"
-  curlInstall=$(runAndLog "${utildir}/zopen-install -y curl jq")
-  curlInstall=$?
-  [ $curlInstall -ne 0 ] && printError "Unable to install curl and jq; see previous errors and retry the initilisation using the '--re-init' parameter"
+  printInfo "- Using bootstrapped curl and jq to install updated versions (if available)"
+  toolInstall=$(runAndLog "${utildir}/zopen-install -y curl jq meta")
+  toolInstall=$?
+  [ $toolInstall -ne 0 ] && printError "Unable to install curl, jq and/or meta; see previous errors and retry the initilisation using the '--re-init' parameter"
   . "$configFile"
-
-  # Code to use this version of meta as "official" install - pin to ensure no overwriting
-  printInfo "- Installing and pinning currently running version of meta" 
-  printVerbose "Current dir: $utildir"
-  metadtInstDir="$ZOPEN_ROOTFS/$zopen_pkginstall/meta/meta-dt"
-  printVerbose "Meta will be installed to $metadtInstDir"
-  mkdir -p "$metadtInstDir"
-
-  if [ -L "$0" ]; then
-    printVerbose "Found a link"
-    # We are running zopen from within a zopen-environment already
-    # De-reference symlinks to get the actual meta location. On a re-init,
-    # this might correlate to the existing location so we can reuse it; otherwise
-    # we need to copy the existing meta to the new location
-    physical="$(ls -l "$0" | sed -e "s/.*-> //")" 
-    full="$(dirname $0)/$physical"
-    real="$(dirname $full)"
-    deref="$( cd "$real/../.." >/dev/null 2>&1 && pwd -P )"
-    
-    if [ "$deref" = "$metadtInstDir" ]; then
-      printInfo "- Re-initialising target is current; no action required"
-    else
-      printInfo "- Copying existing meta to re-initialised location"
-      cp -fRT "$deref/"  "$metadtInstDir"
-    fi
-    
-  else
-    printVerbose "Copying local meta; work out where to find all files"
-    cp -fRT "${utildir}/../../"  "$metadtInstDir" 
-  fi
-
-  printInfo "- Running alternative utility to force selection of forked meta"
-  # Can use "1" as the default since there should be no other options during init!
-  metaInstall=$(runAndLog "${utildir}/zopen-alt meta -s -d 1")
-  metaInstall=$?
-  [ $metaInstall -ne 0 ] && printError "Unable to install meta; see previous errors and retry the initilisation using the '--re-init' parameter"
-
-  #TODO: Reinstate following code should this fork merge
-  #printInfo "- Installing latest version of meta package into zopen system"
-  #runAndLog "${utildir}/zopen-install meta"
 
   printInfo "- zopen bootstrapping complete"
 


### PR DESCRIPTION
Should resolve #426 
Removed the -a option as it was confusing [how does -u work for a -a when needs a parameter and the cache/symlinks are zopen-system-wide and not package-specific so having them combinable doesn't make sense.  
Improved the help with examples
Improved package detection logic