### PR TITLE
Always add a -suffix to ZOPEN_NAME 

### DIFF
--- a/bin/lib/zopen-build
+++ b/bin/lib/zopen-build
@@ -1559,6 +1559,11 @@ resolveCommands()
       ZOPEN_NAME="${dir}-${branch}"
     fi
   fi
+  # Check if ZOPEN_NAME contains a "-"
+  if [ -z "$(echo "$ZOPEN_NAME" | grep '-')" ]; then
+    # If not, add the '-DEV' suffix so as not to collide with zopen installed packages
+    ZOPEN_NAME="${ZOPEN_NAME}-DEV"
+  fi
   if [ "${ZOPEN_INSTALL_DIR}x" = "x" ]; then
     PROJECT_NAME="$(echo ${ZOPEN_NAME} | cut -d'-' -f1)"
     export ZOPEN_INSTALL_DIR="$ZOPEN_PKGINSTALL/${PROJECT_NAME}/${ZOPEN_NAME}" # Install into dev location


### PR DESCRIPTION
* even if it does not contain one so as not to conflict with zopen installed paths
* This is why we were seeing such issues:
```
- Expanding comp_xlclang.20230921_001414.zos.pax.Z
ln: FSUM6245 link to target "/jenkins/zopen/usr/local/zopen/comp_xlclang/comp_xlclang/comp_xlclang.20230921_001414.zos" failed: EDC5117I File exists.
```