### PR TITLE
add version and have zopen know about itself to eliminate need for .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,10 @@
 #
-# Setup no longer required. 'zopen' finds itself
+# Setup no longer required if you are just 'using' tools 
+# It may be convenient if you are 'developing' tools
 #
-echo "Note: No need to source .env any more. No action performed."
+if ! [ -f ./.env ]; then
+	echo "Need to source from the .env directory" >&2
+	return 0
+fi
+mydir="${PWD}"
+export PATH="${mydir}/bin:$PATH"

--- a/.env
+++ b/.env
@@ -1,9 +1,4 @@
 #
-# Setup meta in a similar way to the 'port' packages 
+# Setup no longer required. 'zopen' finds itself
 #
-if ! [ -f ./.env ]; then
-	echo "Need to source from the .env directory" >&2
-	return 0
-fi
-mydir="${PWD}"
-export PATH="${mydir}/bin:$PATH"
+echo "Note: No need to source .env any more. No action performed."

--- a/bin/lib/zopen-version
+++ b/bin/lib/zopen-version
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "zopen 1.0.1"

--- a/bin/lib/zopen-version
+++ b/bin/lib/zopen-version
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "zopen 1.0.1"
+echo "zopen 0.7.0"

--- a/bin/zopen
+++ b/bin/zopen
@@ -5,7 +5,10 @@
 printSyntax()
 {
   printInfo "" >&2
-  printInfo "Syntax: ${NC}${BOLD}zopen <command>${NC}" >&2
+  printInfo "Syntax: ${NC}${BOLD}zopen [options] <command>${NC}" >&2
+  printInfo "where ${NC}${BOLD}<options>${NC} may be one of the following:" >&2
+  printInfo "  ${NC}${BOLD}--version    ${NC}   print product version" >&2
+  printInfo "  ${NC}${BOLD}--help       ${NC}   print this help" >&2
   printInfo "where ${NC}${BOLD}<command>${NC} may be one of the following:" >&2
   printInfo "  ${NC}${BOLD}init         ${NC}   generate \$rootfs/etc/zopen-config, creates file structure and bootstraps" >&2
   printInfo "  ${NC}${BOLD}build        ${NC}   invokes the build script." >&2
@@ -40,6 +43,8 @@ printHelp()
 }
 
 export bindir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+
+export PATH="${bindir}:${PATH}"
 ZOPEN_DONT_PROCESS_CONFIG=1
 . "${bindir}/lib/common.inc"
 
@@ -110,6 +115,9 @@ while [[ $# -gt 0 ]]; do
     "upgrade" | "up")
       shift
       exec "${bindir}/lib/zopen-install" -u $@
+      ;;
+    "--version")
+      exec "${bindir}/lib/zopen-version" 
       ;;
     *)
       printSoftError "Unknown option ${1} specified"


### PR DESCRIPTION
@IgorTodorovskiIBM and @DevonianTeuchter please review. 
Looking to simplify steps to get started with zopen

I also bumped the version to 1.0.1 so there isn't any confusion about what is 'better' since we have an old 1.0.0