### PR TITLE
Use the ID zosopentoolsmain for user_name in the action

### DIFF
--- a/actions/action.yml
+++ b/actions/action.yml
@@ -35,7 +35,7 @@ inputs:
   user_name:
     description: 'Commit user name'
     required: false
-    default: 'bump'
+    default: 'zosopentoolsmain'
   user_email:
     description: 'Commit user email'
     required: false


### PR DESCRIPTION
Use the ID `zosopentoolsmain` instead of the non-existent `bump` for `user_name` in the action.

Can also update `user_email` to a zosopentools-specific mailbox if one exists.