### PR TITLE
restrict tools that perform an update to writable zopen tool chains

### DIFF
--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -15,6 +15,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 printHelp(){
 cat << HELPDOC

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -16,6 +16,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 printHelp(){
 cat << HELPDOC

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -16,6 +16,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 printSyntax() 
 {

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -15,6 +15,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 printSyntax() 
 {

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -15,6 +15,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 printSyntax() 
 {

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -17,6 +17,7 @@ setupMyself()
         . "${INCDIR}/common.sh"
 }
 setupMyself
+checkWritable
 
 # Temporary files
 for tmp in "$TMPDIR" "$TMP" /tmp

--- a/include/common.sh
+++ b/include/common.sh
@@ -890,4 +890,22 @@ initDefaultEnvironment()
   export STEPLIB=none
 }
 
+#
+# checkWritable prints a message and exits if the directory above INCDIR
+# is not writable. This is a safe location to check for and should be 
+# writable on a 'dev' environment 
+#
+checkWritable()
+{
+  if [ "x$INCDIR" = "x" ]; then
+    echo "Internal error. Caller has to have set INCDIR" >&2
+    exit 16
+  fi
+  ROOTDIR="$( cd "${INCDIR}/../" >/dev/null 2>&1 && pwd -P )"
+  if ! [ -w "${ROOTDIR}" ]; then
+    printError "Tried to run an update operation (${ME}) in a read-only tools distribution" >&2
+    exit 8
+  fi
+}
+
 zopenInitialize


### PR DESCRIPTION
Restrict alt, clean, init, install, remove, update-cacert to zopen tool chains that can be updated
fixes #463 