### PR TITLE
Fix replaceHardcodedPath regexp

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1211,10 +1211,10 @@ replaceHardcodedPath()
       isWriteable=false
       chmod "+w" $f
     fi
-    cp $f $f.tmp && \
+    cp $f $f.old && \
     # replace hardcoded path and strip out the -suffix in name to match active
-    sed -e "s#\(${orig}\)/\([^/]*\)[^-]*-[^/]*#${replaced}/\2/\2#g" $f.tmp > $f && \
-    rm $f.tmp;
+    sed -e "s#\(${orig}\)/\([^/]*\)/[^/]*#${replaced}/\2/\2#g" $f.old > $f &&
+    rm $f.old
     if ! $isWriteable; then
       chmod "-w" $f
     fi

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1213,7 +1213,7 @@ replaceHardcodedPath()
     fi
     cp $f $f.old && \
     # replace hardcoded path and strip out the -suffix in name to match active
-    sed -e "s#\(${orig}\)/\([^/]*\)/[^/]*#${replaced}/\2/\2#g" $f.old > $f &&
+    sed -e "s#${orig}/\([^/]\+\)/[^/\n ]*#${replaced}/\1/\1#g" $f.old > $f &&
     rm $f.old
     if ! $isWriteable; then
       chmod "-w" $f


### PR DESCRIPTION
The current regexp was merging multiple directories together.

Test input:
```
/home/itodorov/zopen/ncurses/ncurses-2.9.12/bin/lib /home/itodroov/zopen/ncurses/ncurses/bin/lib /home/itodorov/zopen/ncurses/ncurses-2.9.12/bin/lib
/home/itodorov/zopen/ncurses/ncurses-2.9.12/ 
/home/itodorov/zopen/ncurses/ncurses-2.9.12
/home/itodorov/zopen/ncurses/ncurses /home/itodroov/zopen/ncurses/ncurses
```

Result:
```
PREFIX/ncurses/ncurses/bin/lib PREFIX/ncurses/ncurses/bin/lib PREFIX/ncurses/ncurses/bin/lib
PREFIX/ncurses/ncurses/ 
PREFIX/ncurses/ncurses
PREFIX/ncurses/ncurses PREFIX/ncurses/ncurses
```