### PR TITLE
More fixes to replaceHardcodedPath logic, add sed as a dep

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -486,6 +486,8 @@ checkEnv()
     fi
   fi
 
+  implicitDeps="sed" # for replaceHardcodedPaths logic
+
   if [ "${ZOPEN_COMP}x" = "x" ]; then
     implicitDeps="$implicitDeps comp_xlclang"  
   else
@@ -1213,7 +1215,7 @@ replaceHardcodedPath()
     fi
     cp $f $f.old && \
     # replace hardcoded path and strip out the -suffix in name to match active
-    sed -e "s#${orig}/\([^/]\+\)/[^/\n ]*#${replaced}/\1/\1#g" $f.old > $f &&
+    sed -e "s#${orig}/\([^/]\+\)/[^/\n '\";]*#${replaced}/\1/\1#g" $f.old > $f &&
     rm $f.old
     if ! $isWriteable; then
       chmod "-w" $f


### PR DESCRIPTION
This fixes the issues found in texinfo (makeinfo). The z/OS /bin/sed has limitations in the regexp substitution, so I've added sed as a implicit dependency.

