### PR TITLE
Fix zoslib env hook so that it only avoids implicitly setting envars for tool it is building

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1807,7 +1807,11 @@ char* value_str;
 char* pos;
 long size;
 
-// Do not use when building itself to avoid test failures to incorrect paths
+// Avoid setting environment variables during build time because they do not hold correct values
+// and should only be used from the installed location.
+// To avoid setting environment variables during build time, we need to guard it
+// by checking if ZOPEN_IN_ZOPEN_BUILD is set to the current build process setting.
+But this also meant that any dependent tools that set envars via zoslib env hooks would avoid setting those environment variables, effectively breaking them.
 if ((envar_value = getenv("ZOPEN_IN_ZOPEN_BUILD")) &&
     strcmp(envar_value, "${ZOPEN_IN_ZOPEN_BUILD}") == 0) {
   return 0;

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1908,7 +1908,7 @@ zz
   if [ "${CC}" = "xlclang" ]; then
     extraOptions="-qexportall"
   fi
-  cat ${output}
+
   if ! runAndLog "${CC} ${CFLAGS} ${CPPFLAGS} -DPATH_MAX=1024 ${extraOptions} -c ${output} -o ${output}.o"; then
     printError "Compiler command for ${output} failed to compile"
   fi

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1766,7 +1766,7 @@ generateZOSLIBHooks()
   # GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
   # GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
   # GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
-  #  The first field is the environment variable. The second field is the action, which is one of set, unset, or prepend.
+  #  The first field is the environment variable. The second field is the action, which is one of set (if unset), unset, overrideset or prepend.
   #  The last field is the value. For unset, this is left empty. PROJECT_ROOT is replaced by the root directory of where the project is installed to.
 
   zoslib_env=""
@@ -1811,7 +1811,7 @@ long size;
 // and should only be used from the installed location.
 // To avoid setting environment variables during build time, we need to guard it
 // by checking if ZOPEN_IN_ZOPEN_BUILD is set to the current build process setting.
-But this also meant that any dependent tools that set envars via zoslib env hooks would avoid setting those environment variables, effectively breaking them.
+// But this also meant that any dependent tools that set envars via zoslib env hooks would avoid setting those environment variables, effectively breaking them.
 if ((envar_value = getenv("ZOPEN_IN_ZOPEN_BUILD")) &&
     strcmp(envar_value, "${ZOPEN_IN_ZOPEN_BUILD}") == 0) {
   return 0;
@@ -1826,10 +1826,14 @@ zz
     var=$(echo ${line} | cut -d '|' -f 1)
     action=$(echo ${line} | cut -d '|' -f 2)
     value=$(echo ${line} | cut -d '|' -f 3)
-
+  
     if [ "${action}" = "unset" ]; then
       echo "unsetenv(\"${var}\");" >> "${output}"
-    elif [ "${action}" = "set" ]; then
+    elif [ "${action}" = "set" -o "${action}" = "overrideset" ]; then
+      forceset="0"
+      if [ "${action}" = "overrideset" ]; then
+        forceset="1";
+      fi
       cat << zz >> "${output}"
     value_str = "${value}";
     size = PATH_MAX;
@@ -1849,7 +1853,7 @@ zz
       }
     }
 
-    if (!getenv("${var}")) {
+    if (!getenv("${var}") || ${forceset}) {
       if (getenv("__ZOPEN_DEBUG"))
         fprintf(stderr, "Setting variable %s=%s\n", "${var}", envar_value);
       if (setenv("${var}", envar_value, 1) != 0) {
@@ -1904,6 +1908,7 @@ zz
   if [ "${CC}" = "xlclang" ]; then
     extraOptions="-qexportall"
   fi
+  cat ${output}
   if ! runAndLog "${CC} ${CFLAGS} ${CPPFLAGS} -DPATH_MAX=1024 ${extraOptions} -c ${output} -o ${output}.o"; then
     printError "Compiler command for ${output} failed to compile"
   fi

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -368,7 +368,7 @@ loadBuildEnv()
   fi
 
   # Indicates to .env script that we're in zopen build
-  export ZOPEN_IN_ZOPEN_BUILD=1
+  export ZOPEN_IN_ZOPEN_BUILD="$LOGNAME.$$.$RANDOM"
 
   . ${buildEnvFile}
 
@@ -1792,7 +1792,6 @@ generateZOSLIBHooks()
   output="zoslib_env_hook.c"
 
   # Defines zoslib_env_hook
-
   cat << zz > "${output}"
 #include <stdio.h>
 #include <stdlib.h>
@@ -1808,9 +1807,9 @@ char* value_str;
 char* pos;
 long size;
 
-// Do not use when running under zopen
-// To avoid test specific settings
-if (getenv("ZOPEN_IN_ZOPEN_BUILD")) {
+// Do not use when building itself to avoid test failures to incorrect paths
+if ((envar_value = getenv("ZOPEN_IN_ZOPEN_BUILD")) &&
+    strcmp(envar_value, "${ZOPEN_IN_ZOPEN_BUILD}") == 0) {
   return 0;
 }
 zz

--- a/docs/Guides/Porting.md
+++ b/docs/Guides/Porting.md
@@ -132,7 +132,7 @@ ZOPEN_STABLE_DEPS/ZOPEN_STABLE_DEPS are used to identify the non-standard z/OS O
 Similarly, `zopen_append_to_zoslib_env()` can be used to set program specific environment variables.
 It accepts the following format:
   envar|action|value
-Where envar is the environment variable, action is either set, unset, or prepend, and value is the environment variable value.
+Where envar is the environment variable, action is either set (if unset), overrideset, unset, or prepend, and value is the environment variable value.
 The string `PROJECT_HOME` represents a special value and is replaced with the root path of the project"
 
 To help gauge the build quality of the port, a zopen_check_results() function needs to be provided inside the buildenv. This function should process the test results and emit a report of the failures, total number of tests, expected number of failures and expected number of tests to stdout as in the following format:


### PR DESCRIPTION
The issue is that the zoslib env hook logic wasn't active when we're doing a zopen build. We added this logic because at check/test time, the tests were failing because the environment variables were pointing to bad paths.

But this also meant that any dependent tools that set envars via zoslib env hooks would avoid setting those environment variables, effectively breaking them.

----

Also adds overrideset action to force set environment variables which should not be customized