### PR TITLE
Add zoslib as an implicit dep

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -87,6 +87,7 @@ Optional:
   ZOPEN_INSTALL_OPTS   Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
   ZOPEN_CLEAN          Clean up program to run (defaults to '${ZOPEN_CLEAND}')
   ZOPEN_CLEAN_OPTS     Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')
+  ZOPEN_DONT_ADD_ZOSLIB_DEP Set it to avoid adding zoslib as a dependency
 
 Restricted Usage - only SET by metaport, otherwise READ ONLY:
   ZOPEN_INSTALL_DIR    Installation directory to pass to configuration (defaults to '\${ZOPEN_PKGINSTALL}/<pkg>/<pkg>')

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -525,6 +525,11 @@ checkEnv()
     implicitDeps="${implicitDeps} comp_${ZOPEN_COMP}"
   fi
 
+  if [ -z "${ZOPEN_DONT_ADD_ZOSLIB_DEP}" ]; then
+    # Add zoslib as an implicit library
+    implicitDeps="${implicitDeps} zoslib"
+  fi
+
   if [ "${ZOPEN_TYPE}x" = "TARBALLx" ]; then
     if [ -z "${ZOPEN_URL}" ]; then
       printError "ZOPEN_STABLE_URL, ZOPEN_DEV_URL, ZOPEN_URL or ZOPEN_TARBALL_URL needs to be defined"

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -87,6 +87,8 @@ Optional:
   ZOPEN_INSTALL_OPTS   Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
   ZOPEN_CLEAN          Clean up program to run (defaults to '${ZOPEN_CLEAND}')
   ZOPEN_CLEAN_OPTS     Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')
+
+Restricted Usage - only set in ports if necessary
   ZOPEN_DONT_ADD_ZOSLIB_DEP Set it to avoid adding zoslib as a dependency
 
 Restricted Usage - only SET by metaport, otherwise READ ONLY:


### PR DESCRIPTION
If we encounter builds that don't work well with zoslib, we can set ZOPEN_DONT_ADD_ZOSLIB_DEP.