### PR TITLE
Fix zopen clean -c

### DIFF
--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -138,7 +138,7 @@ cleanDangling()
 cleanCache()
 {
   printVerbose "Cleaning ${ZOPEN_ROOTFS}/var/cache/zopen"
-  rm -rf "${ZOPEN_ROOTFS}/var/cache/zopen/*"
+  rm -rf "${ZOPEN_ROOTFS}/var/cache/zopen/"*
   syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Main cache in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned"
   printInfo "- Cache at '${ZOPEN_ROOTFS}/var/cache/zopen' cleaned"
 }


### PR DESCRIPTION
Issue with `zopen clean -c` identified by @ccw-1 
The * should not be surrounded by quotes