### PR TITLE
Update common.sh to allow for a "light mode"

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -232,7 +232,10 @@ defineANSI()
   ERASELINE="${ESC}[2K"
   CRSRHIDE="${ESC}[?25l"
   CRSRSHOW="${ESC}[?25h"
-
+  
+  
+  
+  
   # Color-type codes, needs explicit terminal settings
   if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
     esc="\047"
@@ -262,6 +265,18 @@ defineANSI()
     BOLD=''
     UNDERLINE=''
     NC=''
+  fi
+
+  darkbackground
+  bg=$?
+  if [ $bg -ne 0 ]; then 
+    #if the background was set to black or unknown the header and warning color will be yellow
+    HEADERCOLOR="${YELLOW}"
+    WARNINGCOLOR="${YELLOW}"
+  else
+    #else the header and warning color will become magenta
+    HEADERCOLOR="${MAGENTA}"
+    WARNINGCOLOR="${MAGENTA}"
   fi
 }
 
@@ -663,19 +678,11 @@ printVerbose()
 
 printHeader()
 {
-  darkbackground
-  dark=$?
-  if [ $dark -eq -1 ] || [ $dark -eq 1]; then
-    [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-    printColors "${NC}${YELLOW}${BOLD}${UNDERLINE}${1}${NC}" >&2
-    [ ! -z "${xtrc}" ] && set -x
-    return 0
-  fi
-  
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-  printColors "${NC}${MAGENTA}${BOLD}${UNDERLINE}${1}${NC}" >&2
+  printColors "${NC}${HEADERCOLOR}${BOLD}${UNDERLINE}${1}${NC}" >&2
   [ ! -z "${xtrc}" ] && set -x
   return 0
+
 }
 
 runAndLog()
@@ -819,16 +826,8 @@ printError()
 
 printWarning()
 {
-  darkbackground
-  dark=$?
-  if [ $dark -eq -1 ] || [ $dark -eq 1]; then
-    [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-    printColors "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
-    [ -n "${xtrc}" ] && set -x
-    return 0
-  fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-  printColors "${NC}${MAGENTA}${BOLD}***WARNING: ${NC}${MAGENTA}${1}${NC}" >&2
+  printColors "${NC}${WARNINGCOLOR}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
   [ -n "${xtrc}" ] && set -x
   return 0
 }

--- a/include/common.sh
+++ b/include/common.sh
@@ -211,6 +211,20 @@ deref()
   fi
 }
 
+#return 1 if brightness is dark, 0 if light, and -1 if unknown (considered to be dark as default)
+darkbackground() {
+  if [ "${#COLORFGBG}" -ge 3 ]; then
+    bg=${COLORFGBG##*;}
+    if [ ${bg} -lt 7 ]; then
+      return 1
+    else
+      return 0
+    fi
+  else
+    return -1
+  fi
+}
+
 defineANSI()
 {
   # Standard tty codes
@@ -649,8 +663,17 @@ printVerbose()
 
 printHeader()
 {
+  darkbackground
+  dark=$?
+  if [ $dark -eq -1 ] || [ $dark -eq 1]; then
+    [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
+    printColors "${NC}${YELLOW}${BOLD}${UNDERLINE}${1}${NC}" >&2
+    [ ! -z "${xtrc}" ] && set -x
+    return 0
+  fi
+  
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-  printColors "${NC}${YELLOW}${BOLD}${UNDERLINE}${1}${NC}" >&2
+  printColors "${NC}${MAGENTA}${BOLD}${UNDERLINE}${1}${NC}" >&2
   [ ! -z "${xtrc}" ] && set -x
   return 0
 }
@@ -796,8 +819,16 @@ printError()
 
 printWarning()
 {
+  darkbackground
+  dark=$?
+  if [ $dark -eq -1 ] || [ $dark -eq 1]; then
+    [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
+    printColors "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
+    [ -n "${xtrc}" ] && set -x
+    return 0
+  fi
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
-  printColors "${NC}${YELLOW}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
+  printColors "${NC}${MAGENTA}${BOLD}***WARNING: ${NC}${MAGENTA}${1}${NC}" >&2
   [ -n "${xtrc}" ] && set -x
   return 0
 }

--- a/include/common.sh
+++ b/include/common.sh
@@ -233,9 +233,6 @@ defineANSI()
   CRSRHIDE="${ESC}[?25l"
   CRSRSHOW="${ESC}[?25h"
   
-  
-  
-  
   # Color-type codes, needs explicit terminal settings
   if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
     esc="\047"


### PR DESCRIPTION
This allows people with white backgrounds to read warnings and headers by exporting their COLORFGBG in bash to change them to magenta instead of yellow. 

example: 
export COLORFGBG="0;15" for light backgrounds
export COLORFGBG="0;0" for dark backgrounds

I left the colors readable in both dark and light mode unchanged.

This closes issue #202