### PR TITLE
Tag and encode .env as IBM-1047

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,9 @@
-# Setup no longer required if you are just 'using' tools 
-# It may be convenient if you are 'developing' tools
+# Must be sourced as follows: . ./.env
+# This file is encoded in IBM-1047, enabling shells (/bin/sh, /bin/zsh) that have auto-conversion disabled by default to process it.
+# This script ensures the required auto-conversion environment variables are set for zopen to function properly.
 #
+# Note: Setup no longer required if you are just 'using' tools 
+# It may be convenient if you are 'developing' tools
 if ! [ -f ./.env ]; then
 	echo "Need to source from the .env directory" >&2
 	return 0

--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-#
 # Setup no longer required if you are just 'using' tools 
 # It may be convenient if you are 'developing' tools
 #
@@ -6,5 +5,9 @@ if ! [ -f ./.env ]; then
 	echo "Need to source from the .env directory" >&2
 	return 0
 fi
-mydir="${PWD}"
-export PATH="${mydir}/bin:$PATH"
+export _BPXK_AUTOCVT=ON
+export _CEE_RUNOPTS="$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+export _TAG_REDIR_ERR=txt
+export _TAG_REDIR_IN=txt
+export _TAG_REDIR_OUT=txt
+export PATH="${PWD}/bin:$PATH"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
-*	text	zos-working-tree-encoding=ISO8859-1
-*.pem   text zos-working-tree-encoding=UTF-8
+*	      text	zos-working-tree-encoding=ISO8859-1
+.env    text  zos-working-tree-encoding=IBM-1047
+*.pem   text  zos-working-tree-encoding=UTF-8
 *.png   binary
-*.gif binary
+*.gif   binary
 *.pax.Z binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 *	      text	zos-working-tree-encoding=ISO8859-1
-# Sourcing of files tagged as IBM-1047 works universally across all shells/system setups:
 .env    text  zos-working-tree-encoding=IBM-1047
 *.pem   text  zos-working-tree-encoding=UTF-8
 *.png   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *	      text	zos-working-tree-encoding=ISO8859-1
+# Sourcing of files tagged as IBM-1047 works universally across all shells/system setups:
 .env    text  zos-working-tree-encoding=IBM-1047
 *.pem   text  zos-working-tree-encoding=UTF-8
 *.png   binary


### PR DESCRIPTION
The .env is the entry point for any consumer/developer and as such, should be encoded in the default encoding (IBM-1047). This way we can also add the required auto-conversion environment variables