### PR TITLE
Handle pax install

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -80,16 +80,16 @@ version=false
 for arg in $*; do
   case "${arg}" in
     "alt"|"build"|"clean"|"generate"|"init"|"install"|\
-    "query"|"remove"|"update-cacert")
+    "query"|"remove"|"update-cacert"|"upgrade")
       subcmd="zopen-${arg}"
       ;;
     "list")
       subcmd='zopen-query'
       subopts="${subopts} --list"
       ;;
-    "upgrade")
-      subcmd='zopen-install'
-      subopts="${subopts} -u"
+    "search")
+      subcmd='zopen-query'
+      subopts="${subopts} --remote-search"
       ;;
     "--version")
       version=true

--- a/bin/zopen
+++ b/bin/zopen
@@ -16,6 +16,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -61,9 +61,9 @@ mergeNewVersion()
   printVerbose "New version merged; checking for orphaned files from previous version"
   # This will remove any old symlinks or dirs that might have changed in an up/downgrade
   # as the merge process overwrites existing files to point to different version. If there was
-  # no other version, then ${deref} will be empty so nothing to uninstall
+  # no other version, then $deref will be empty so nothing to uninstall
   if [ -n "${deref}" ]; then
-    unsymlinkFromSystem "${package}" "${ZOPEN_ROOTFS}" "${ZOPEN_PKGINSTALL}/${package}/${deref}/.links"
+    unsymlinkFromSystem "${package}" "${ZOPEN_ROOTFS}" "${ZOPEN_PKGINSTALL}/$package/$deref/.links" "${ZOPEN_PKGINSTALL}/${package}/${package}/.links"
   else
     printVerbose "No previous version found (no .links) - no unlinking performed"
   fi

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -62,7 +62,7 @@ mergeNewVersion()
   printVerbose "New version merged; checking for orphaned files from previous version"
   # This will remove any old symlinks or dirs that might have changed in an up/downgrade
   # as the merge process overwrites existing files to point to different version. If there was
-  # no other version, then $deref will be empty so nothing to uninstall
+  # no other version, then ${deref} will be empty so nothing to uninstall
   if [ -n "${deref}" ]; then
     unsymlinkFromSystem "${package}" "${ZOPEN_ROOTFS}" "${ZOPEN_PKGINSTALL}/$package/$deref/.links" "${ZOPEN_PKGINSTALL}/${package}/${package}/.links"
   else

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -12,6 +12,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -61,7 +62,7 @@ mergeNewVersion()
   printVerbose "New version merged; checking for orphaned files from previous version"
   # This will remove any old symlinks or dirs that might have changed in an up/downgrade
   # as the merge process overwrites existing files to point to different version. If there was
-  # no other version, then $deref will be empty so nothing to uninstall
+  # no other version, then ${deref} will be empty so nothing to uninstall
   if [ -n "${deref}" ]; then
     unsymlinkFromSystem "${package}" "${ZOPEN_ROOTFS}" "${ZOPEN_PKGINSTALL}/$package/$deref/.links" "${ZOPEN_PKGINSTALL}/${package}/${package}/.links"
   else
@@ -171,7 +172,7 @@ listAlts()
       printInfo "${i}: ${repo#"${ZOPEN_PKGINSTALL}"/}"
     fi
   done < "${TMP_FIFO_PIPE}"
-  [ ! -p ${TMP_FIFO_PIPE} ] || rm -rf "${TMP_FIFO_PIPE}"
+  [ ! -p "${TMP_FIFO_PIPE}" ] || rm -rf "${TMP_FIFO_PIPE}"
 
   if ${select}; then
     mutexReq "zopen" "zopen"

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -62,7 +62,7 @@ mergeNewVersion()
   printVerbose "New version merged; checking for orphaned files from previous version"
   # This will remove any old symlinks or dirs that might have changed in an up/downgrade
   # as the merge process overwrites existing files to point to different version. If there was
-  # no other version, then ${deref} will be empty so nothing to uninstall
+  # no other version, then $deref will be empty so nothing to uninstall
   if [ -n "${deref}" ]; then
     unsymlinkFromSystem "${package}" "${ZOPEN_ROOTFS}" "${ZOPEN_PKGINSTALL}/$package/$deref/.links" "${ZOPEN_PKGINSTALL}/${package}/${package}/.links"
   else

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -13,6 +13,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -41,6 +41,9 @@ Options:
                     globally configure the release line for package
                     installs to enable Development (DEV) packages; the
                     default is for a system to use STABLE packages
+      --paxrepodir <RPEO>
+                    configure a global location for pax file
+                    installation source
   -f, --fs-layout <LAYOUT>
                     The filesystem structure to use for installed 
                     packages on disk; packages will be installed to 
@@ -104,6 +107,10 @@ while [ $# -gt 0 ]; do
     "--releaseline-dev" )
       releaselineDev=true
       ;;
+    "--paxrepodir")
+      shift
+      paxrepodir="$1" # Only support single repo directory
+    ;;
     "-h" | "--help" | "-?")
       printHelp
       exit 0
@@ -272,8 +279,10 @@ else
   releaseLine="STABLE"
   printInfo "- Configured zopen to use stable releaseline packages"
 fi
-echo "${releaseLine}" > "${rootfs}/etc/zopen/releaseline"
-
+echo "$releaseLine" > "$rootfs/etc/zopen/releaseline"
+if [ -n "$paxrepodir" ]; then
+  echo "dir:$paxrepodir" > "$rootfs/etc/zopen/paxrepodir"
+fi
 printInfo "- Check for shipped curl pax"
 curlpax="packages/curl-8.4.0.20231011_155722.zos.pax.Z"
 

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -42,10 +42,7 @@ Options:
                     globally configure the release line for package
                     installs to enable Development (DEV) packages; the
                     default is for a system to use STABLE packages
-      --paxrepodir <RPEO>
-                    configure a global location for pax file
-                    installation source
-      --paxrepodir <RPEO>
+      --paxrepodir <REPO>
                     configure a global location for pax file
                     installation source
   -f, --fs-layout <LAYOUT>
@@ -120,13 +117,15 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     "-v" | "--verbose")
+      # shellcheck disable=SC2034
       verbose=true
       ;;
     "--version")
-      zopen-version $ME
+      zopen-version "${ME}"
       exit 0
       ;;
     "--debug") 
+      # shellcheck disable=SC2034
       debug=true
       ;;
     "--yes" | "-y")
@@ -388,6 +387,7 @@ jqdir=$(ls "${rootfs}/boot" | grep jq | head -1)
 chmod -R 755 "${rootfs}/boot/${jqdir}"
 curwd="${PWD}"
 cd "${rootfs}/boot/${jqdir}/" || printError "Could not access jq bootstrap in directory '${rootfs}/boot/${jqdir}/'. Re-run 'zopen init' to retry"
+# shellcheck disable=SC1091
 . ./.env
 cd "${curwd}"  || printError "Could not change to ${curwd}. Re-run 'zopen init' to retry"
 
@@ -399,11 +399,13 @@ runAndLog "${MYDIR}/zopen-update-cacert -f ${ZOPEN_CA} -v"
 export ZOPEN_CA="${ZOPEN_CA}/cacert.pem"
 
 printInfo "- Sourcing environment"
+# shellcheck disable=SC1090
 . "${configFile}"
 printInfo "- Using bootstrapped curl and jq to install updated versions (if available)"
 toolInstall=$(runAndLog "${MYDIR}/zopen-install -y curl jq meta")
 toolInstall=$?
 [ ${toolInstall} -ne 0 ] && printError "Unable to install curl, jq and/or meta; see previous errors and retry the initilisation using the '--re-init' parameter"
+# shellcheck disable=SC1090
 . "${configFile}"
 
 printInfo "- zopen bootstrapping complete"

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -12,14 +12,15 @@ ZOPEN_DONT_PROCESS_CONFIG=1
 #
 setupMyself()
 {
-        ME=$(basename "$0")
-        MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
-        INCDIR="${MYDIR}/../include"
-        if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-                echo "Internal Error. Unable to find common.sh file to source" >&2
-                exit 8
-        fi
-        . "${INCDIR}/common.sh"
+  ME=$(basename "$0")
+  MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source" >&2
+    exit 8
+  fi
+  # shellcheck source=/dev/null
+  . "${INCDIR}/common.sh"
 }
 setupMyself
 checkWritable
@@ -110,7 +111,7 @@ while [ $# -gt 0 ]; do
     "--paxrepodir")
       shift
       paxrepodir="$1" # Only support single repo directory
-    ;;
+      ;;
     "-h" | "--help" | "-?")
       printHelp
       exit 0
@@ -279,9 +280,9 @@ else
   releaseLine="STABLE"
   printInfo "- Configured zopen to use stable releaseline packages"
 fi
-echo "$releaseLine" > "$rootfs/etc/zopen/releaseline"
-if [ -n "$paxrepodir" ]; then
-  echo "dir:$paxrepodir" > "$rootfs/etc/zopen/paxrepodir"
+echo "${releaseLine}" > "${rootfs}/etc/zopen/releaseline"
+if [ -n "${paxrepodir}" ]; then
+  echo "dir:${paxrepodir}" > "${rootfs}/etc/zopen/paxrepodir"
 fi
 printInfo "- Check for shipped curl pax"
 curlpax="packages/curl-8.4.0.20231011_155722.zos.pax.Z"

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -45,6 +45,9 @@ Options:
       --paxrepodir <RPEO>
                     configure a global location for pax file
                     installation source
+      --paxrepodir <RPEO>
+                    configure a global location for pax file
+                    installation source
   -f, --fs-layout <LAYOUT>
                     The filesystem structure to use for installed 
                     packages on disk; packages will be installed to 
@@ -111,7 +114,7 @@ while [ $# -gt 0 ]; do
     "--paxrepodir")
       shift
       paxrepodir="$1" # Only support single repo directory
-      ;;
+    ;;
     "-h" | "--help" | "-?")
       printHelp
       exit 0

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -5,13 +5,14 @@
 #
 setupMyself()
 {
-  ME=$(basename $0)
+  ME=$(basename "$0")
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -80,17 +81,6 @@ Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 
 HELPDOC
 }
-
-installPorts()( # Note the subshell '()'
-  ports="$1"
-  printDebug "Ports to install: $ports"
-  sessionList="" # Track the packages installed during this session to prevent repeats
-  mutexReq "zopen" "zopen"
-  for port in $ports; do
-    handlePackageInstall "$port"
-  done
-  mutexFree "zopen"
-)
 
 # Main code start here
 # Need to set a number of variables for use in the install function
@@ -190,7 +180,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-$xdebug && set -x && printVerbose "Enabled command execution trace" 
+${xdebug} && set -x && printVerbose "Enabled command execution trace" 
 
 if [ -z "${chosenRepos}" ]; then
   if ! ${all} && ! ${upgradeInstalled}; then
@@ -202,7 +192,7 @@ if [ -z "${chosenRepos}" ]; then
     printInfo "- Querying for installed packages."
     progressHandler "spinner" "- Query complete." &
     ph=$!
-    killph="kill -HUP ${ph}"
+    killph="kill -HUP ${ph} 2>/dev/null"
     addCleanupTrapCmd "${killph}"
     chosenRepos="$(${MYDIR}/zopen-query --list --installed --no-header --no-version 2>&1)"
     zqrc=$?
@@ -220,16 +210,16 @@ export SSL_CERT_FILE="${ZOPEN_CA}"
 export GIT_SSL_CAINFO="${ZOPEN_CA}"
 export CURL_CA_BUNDLE="${ZOPEN_CA}"
 
-if $downloadOnly; then
-  downloadDir="$PWD"
-  printDebug "Downloading pax to current directory '$downloadDir'"
-elif $localInstall; then
-  downloadDir="$PWD"
-  printDebug "Installing to current directory '$downloadDir'"
+if ${downloadOnly}; then
+  downloadDir="${PWD}"
+  printDebug "Downloading pax to current directory '${downloadDir}'"
+elif ${localInstall}; then
+  downloadDir="${PWD}"
+  printDebug "Installing to current directory '${downloadDir}'"
 else
-  printDebug "Installing to zopen file system: $ZOPEN_ROOTFS"
-  if [ -z "$ZOPEN_ROOTFS" ]; then
-    printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined."
+  printDebug "Installing to zopen file system: ${ZOPEN_ROOTFS}"
+  if [ -z "${ZOPEN_ROOTFS}" ]; then
+    printError "Unable to locate zopen file system, \${ZOPEN_ROOTFS} is undefined."
   fi
   downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
 fi
@@ -241,17 +231,17 @@ if [ ! -d "${downloadDir}" ]; then
   fi
 fi
 
-printDebug "Checking if installing from pax files: $paxinstall"
-if ! $paxinstall; then
+printDebug "Checking if installing from pax files: ${paxinstall}"
+if ! ${paxinstall}; then
   # Parse passed in repositories and check if valid zopen framework repos
   printVerbose "Querying remote repo for latest package information"
   getReposFromGithub
   grfgRc=$?
-  $killph 2>/dev/null  # if the timer is not running, the kill will fail
-  [ 0 -ne $grfgRc ] && exit $grfgRc;
+  ${killph} 2>/dev/null  # if the timer is not running, the kill will fail
+  [ 0 -ne ${grfgRc} ] && exit ${grfgRc};
 else
   printDebug "Using pax files for install"
-  [ -n "$paxrepodir" ] && printDebug "Using '$paxrepodir' to locate pax files"
+  [ -n "${paxrepodir}" ] && printDebug "Using '${paxrepodir}' to locate pax files"
 fi
 installArray=""
 
@@ -279,41 +269,48 @@ if $all; then
   installArray=$(strtrim "${installArray}")
   else
     printDebug "Checking for system default repo directory"
-    [ -r "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ] && usepaxrepodir=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
+    [ -r "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir" ] && usepaxrepodir=$(cat "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir")
     printDebug "Checking for override parameter"
-    [ -z "$paxrepodir" ] && usepaxrepodir="./" || usepaxrepodir="$paxrepodir" # default to current directory
-    case "$usepaxrepodir" in
+    [ -z "${paxrepodir}" ] && usepaxrepodir="./" || usepaxrepodir="${paxrepodir}" # default to current directory
+    case "${usepaxrepodir}" in
       */) printDebug "String terminated with '/' already" ;;
-      *)  usepaxrepodir="$usepaxrepodir/";;
+      *)  usepaxrepodir="${usepaxrepodir}/";;
     esac
 
-    printDebug "Locating all pax files in repo at '$usepaxrepodir'"
-    installArray=$(zosfind "$usepaxrepodir" ! -name "$usepaxrepodir"  -prune | grep ".pax.Z")
-    [ -z "$installArray" ] && printInfo "No packages found to install'" && exit 1
+    printDebug "Locating all pax files in repo at '${usepaxrepodir}'"
+    installArray=$(zosfind "${usepaxrepodir}" ! -name "${usepaxrepodir}"  -prune | grep ".pax.Z")
+    [ -z "${installArray}" ] && printInfo "No packages found to install'" && exit 1
   fi
-elif $paxinstall; then
-  printDebug "Installing from pax files as listed in arguments: '$chosenRepos'"
-  installArray="$chosenRepos"
+elif ${paxinstall}; then
+  printDebug "Installing from pax files as listed in arguments: '${chosenRepos}'"
+  installArray="${chosenRepos}"
 else
   printDebug "Parsing list of packages to install and verifying validity"
 
   badportlist=""
   for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' '); do
-    printVerbose "Processing repo: $chosenRepo"
+    printVerbose "Processing repo: ${chosenRepo}"
     printDebug "Stripping any version (%), tag (#) or port suffixes and trim"
-    toolrepo=$(echo "$chosenRepo" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
+    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
 
-    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 == toolrepo {print}') 
-    if [ "$toolfound" = "$toolrepo" ]; then
-      printVerbose "Adding '$chosenRepo' to the install queue"
-      installArray=$(printf "%s\n%s" "$installArray" "$chosenRepo")
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}') 
+    if [ "${toolfound}" = "${toolrepo}" ]; then
+      printVerbose "Adding '${chosenRepo}' to the install queue"
+      installArray=$(printf "%s\n%s" "${installArray}" "${chosenRepo}")
     else
-      badportlist=$(printf "%s %s" "$badportlist" "$toolrepo")
+      badportlist=$(printf "%s %s" "${badportlist}" "${toolrepo}")
     fi
   done
-  if [ -n "$badportlist" ]; then
-    printError "The following requested port(s) do not exist:\n\t$badportlist"
+  if [ -n "${badportlist}" ]; then
+    printError "The following requested port(s) do not exist:\n\t${badportlist}"
   fi
 fi
 
-installPorts "${installArray}"
+printDebug "Ports to install: ${installArray}"
+sessionList="" # Track the packages installed during this session to prevent repeats
+mutexReq "zopen" "zopen"
+for port in ${installArray}; do
+  handlePackageInstall "${port}"
+done
+mutexFree "zopen"
+

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -170,7 +170,7 @@ while [ $# -gt 0 ]; do
       xdebug=true
     ;;
   "--version")
-    zopen-version ${ME}
+    zopen-version "${ME}"
     exit 0
     ;;
   *)
@@ -192,7 +192,7 @@ if [ -z "${chosenRepos}" ]; then
     printInfo "- Querying for installed packages."
     progressHandler "spinner" "- Query complete." &
     ph=$!
-    killph="kill -HUP ${ph} 2>/dev/null"
+    killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
     chosenRepos="$(${MYDIR}/zopen-query --list --installed --no-header --no-version 2>&1)"
     zqrc=$?
@@ -237,7 +237,6 @@ if ! ${paxinstall}; then
   printVerbose "Querying remote repo for latest package information"
   getReposFromGithub
   grfgRc=$?
-  ${killph} 2>/dev/null  # if the timer is not running, the kill will fail
   [ 0 -ne ${grfgRc} ] && exit ${grfgRc};
 else
   printDebug "Using pax files for install"

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -17,470 +17,91 @@ setupMyself()
 setupMyself
 checkWritable
 
-printSyntax()
-{
-  args=$*
-  echo "zopen install is a utility to download/install a z/OS Open Tools package."
-  echo "Usage: zopen install [OPION] [PACKAGE]"
-  echo "  [PACKAGE] is a package to install. Multiple packages can be specified."
-  echo "Options:"
-  echo "  --help                   print this help."
-  echo "  --version                print version"
-  echo "  -u, --update, --upgrade  updates installed z/OS Open Tools packages."
-  echo "  --install-or-upgrade     installs the package if not installed, or upgrades the package if installed."
-  echo "  --reinstallx             reinstall already installed z/OS Open Tools packages."
-  echo "  --nosymlink              do not integrate into filesystem through symlink redirection."
-  echo "  --release-line [stable, dev] the release line to build off of."
-  echo "  --no-deps                do not install dependencies."
-  echo "  --cache-only             do not install dependencies."
-  echo "  --no-set-active          do not change the pinned version"
-  echo "  --skip-upgrade           do not upgrade."
-  echo "  --yes, -y                automatically answer yes to prompts."
-  echo "  --select                 select a version to install."
-  echo "  -v                       run in verbose mode"
-  echo "  --download-only          download package to current directory"
-  echo "  --local-install          download and unpackage to current directory"
-  echo "  --all                    download/install all z/OS Open Tools packages"
+printHelp(){
+  cat << HELPDOC
+zopen install is a utility for z/OS Open Tools to install and update
+packages
+
+Usage: zopen install [OPTION] [PARAMETERS] [PACKAGES]
+
+Options:
+  -u, --upgrade     check for package updates and apply
+      --reinstall   reinstall currently installed package(s)
+      --paxrepodir  a directory location to locate pax files
+      --paxinstall  list of pax files to install
+  -y, --yes         automatically answer yes to prompts
+      --select      select a version to install from available versions
+      --release-line [stable|dev]
+                    the release line to install from
+      --no-deps     do not install dependencies
+      --install-or-upgrade
+                    installs the package if not installed, or upgrades
+                    the package if installed
+      --nosymlink   do not integrate into filesystem through symlink 
+                    redirection
+
+      --cache-only  download installable package to the install cache
+      --no-set-active
+                    do not change the currently active version
+      --skip-upgrade
+                    do not upgrade existing packages
+      --download-only
+                    download installable package with no install
+      --local-install
+                    download and unpackage to current directory
+      --all         download all available packages and install
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+
+Examples:
+  zopen install foo 
+                    install package foo if not already installed
+  zopen install --release-line DEV foo
+                    install package foo from the DEV releaseline if
+                    available
+  zopen upgrade     upgrade all packages to latest version on their
+                    releaseline
+  zopen install -y foo bar --no-deps
+                    install packages foo and bar without asking for
+                    user confirmation and without installing any
+                    dependencies
+  zopen install --paxinstall foo
+                    locate the pax file for foo in the current
+                    directory or the system-configured paxdir and
+                    install
+  zopen install --paxinstall /tmp/foo-1.2.3-4.zos.pax.Z
+                    install package foo from the specified location
+  zopen install -y --paxinstall --paxrepodir /tmp foo-1.2.3-4.zos.pax.Z
+                    check for the named package in /tmp and install
+                    package foo if found
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
 }
 
-installDependencies()
-(
-  name=$1
-  printVerbose "List of dependencies to install: ${dependencies}"
-  skipupgrade_lcl=${skipupgrade}
-  skipupgrade=true
-  echo "${dependencies}" | xargs | tr ' ' '\n' | sort | while read dep; do
-    printVerbose "Removing '${dep}' from dependency queue '${dependencies}'"
-    dependencies=$(echo "${dependencies}" | sed -e "s/${dep}//" | tr -s ' ')
-    handlePackageInstall "${dep}"
-  done
-  skipupgrade=${skipupgrade_lcl}
-)
-
-handlePackageInstall()
-{
-
-  fullname="$1"
-  printVerbose "Name to install: ${fullname}, parsing any version ('=') or tag ('%') has been specified"
-  name=$(echo "${fullname}" | sed -e 's#[=%].*##')
-  repo="${name}"
-  versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
-  tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
-  printVerbose "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
-  printHeader "Installing package: ${name}"
-
-  getAllReleasesFromGithub "${repo}"
-
-  if ${localInstall}; then
-    printVerbose "Local install to current directory"
-    rootInstallDir="${PWD}"
-  else
-    printVerbose "Setting install root to: ${ZOPEN_PKGINSTALL}"
-    rootInstallDir="${ZOPEN_PKGINSTALL}"
-  fi
-
-  originalFileVersion=""
-  printVerbose "Checking for meta files in '${rootInstallDir}/${name}/${name}'"
-  printVerbose "Finding version/release information."
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseinfo" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.releaseinfo")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
-  elif [ -e "${rootInstallDir}/${name}/${name}/.version" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.version")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
-  else
-    printVerbose "Could not detect existing installation at ${rootInstallDir}/${name}/${name}"
-  fi
-
-  printVerbose "Finding releaseline information."
-  installedReleaseLine=""
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseline" ]; then
-    installedReleaseLine=$(cat "${rootInstallDir}/${name}/${name}/.releaseline")
-    printVerbose "Installed product from releaseline: ${installedReleaseLine}"
-  else
-    printVerbose "No current releaseline for package."
-  fi
-
-  releaseMetadata=""
-  downloadURL=""
-  # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
-  # either for a previous package install or system default
-  if [ -n "${versioned}" ]; then
-    printVerbose "Specific version ${versioned} requested - checking existence and URL."
-    requestedMajor=$(echo "${versioned}" | awk -F'.' '{print $1}')
-    requestedMinor=$(echo "${versioned}" | awk -F'.' '{print $2}')
-    requestedPatch=$(echo "${versioned}" | awk -F'.' '{print $3}')
-    requestedSubrelease=$(echo "${versioned}" | awk -F'.' '{print $4}')
-    requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
-    printVerbose "Finding URL for latest release matching version prefix: requestedVersion: ${requestedVersion}"
-    releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.assets[].name | test("'${requestedVersion}'")))[0]')
-  elif [ -n "${tagged}" ]; then
-    printVerbose "Explicit tagged version '${tagged}' specified. Checking for match."
-    releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '.[] | select(.tag_name == "'${tagged}'")')
-    printVerbose "Use quick check for asset to check for existence of metadata for specific messages."
-    asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
-    if [ $? -ne 0 ]; then
-      printError "Could not find release tagged '${tagged}' in repo '${repo}'"
-    fi
-  elif ${selectVersion}; then
-    # Explicitly allow the user to select a release to install; useful if there are broken installs
-    # as a known good release can be found, selected and pinned!
-    printVerbose "List individual releases and allow selection."
-    i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
-    printInfo "Versions available for install:"
-    /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
-
-    printVerbose "Getting user selection."
-    valid=false
-    while ! ${valid}; do
-      echo "Enter version to install (0-${i}): "
-      read selection < /dev/tty
-      if [[ ! -z $(echo "${selection}" | sed -e 's/[0-9]*//') ]]; then
-        echo "Invalid input, must be a number between 0 and ${i}."
-      elif [ "${selection}" -ge 0 ] && [ "${selection}" -le "${i}" ]; then
-        valid=true
-      fi
-    done
-    printVerbose "Selecting item ${selection} from array"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[${selection}]")"
-
-  elif [ ! -z "${releaseLine}" ]; then
-    printVerbose "Install from release line '${releaseLine}' specified"
-    validatedReleaseLine=$(validateReleaseLine "${releaseLine}")
-    if [ -z "${validatedReleaseLine}" ]; then
-      printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE."
-    fi
-    printVerbose "Finding latest asset on the release line"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${releaseLine}'")))[0]')"
-    printVerbose "Use quick check for asset to check for existence of metadata."
-    asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-    if [ $? -ne 0 ]; then
-      printError "Could not find release-line ${releaseLine} for repo: ${repo}."
-    fi
-
-  else
-    printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline."
-    if [ -n "${installedReleaseLine}" ]; then
-      printVerbose "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline."
-      validatedReleaseLine="${installedReleaseLine}" # Already validated when stored
-    else
-      printVerbose "Checking for system-configured releaseline."
-      sysrelline=$(cat "${ZOPEN_ROOTFS}/etc/zopen/releaseline" | awk ' {print toupper($1)}')
-      printVerbose "Validating value: ${sysrelline}"
-      validatedReleaseLine=$(validateReleaseLine "${sysrelline}")
-      if [ -n "${validatedReleaseLine}" ]; then
-        printVerbose "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline."
-      else
-        printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages."
-        printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message."
-        printWarning "Valid values are: DEV | STABLE."
-        validatedReleaseLine="STABLE"
-      fi
-    fi
-    # We have some situations that could arise
-    # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
-    # 2. system is configured for STABLE but only has DEV stream available
-    # 3. system is configured for DEV but only has DEV stream available
-    # 4. the port being installed has got full releaseline tagging
-    # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
-    # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
-    # then that specific releaseline will be used
-    printVerbose "Finding any releases tagged with ${validatedReleaseLine} and getting the first (newest/latest)"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${validatedReleaseLine}'")))[0]')"
-    printVerbose "Use quick check for asset to check for existence of metadata"
-    asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-    if [ $? -eq 0 ]; then
-      # Case 4...
-      printVerbose "Found a specific '${validatedReleaseLine}' release-line tagged version; installing..."
-    else
-      # Case 2 & 3
-      printVerbose "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline."
-      alt=$(echo "${validatedReleaseLine}" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
-      releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${alt}'")))[0]')"
-      printVerbose "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-      if [ $? -eq 0 ]; then
-        printVerbose "Found a release on the '${alt}' release line so release tagging is active."
-        if [ "DEV" = "${validatedReleaseLine}" ]; then
-          # The system will be configured to use DEV packages where available but if none, use latest
-          printInfo "No specific DEV releaseline package, using latest available"
-          releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
-        else
-          printVerbose "The system is configured to only use STABLE releaseline packages but there are none."
-          printInfo "No release available on the '${validatedReleaseLine}' releaseline."
-        fi
-      else
-        # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
-        printVerbose "Installing latest release"
-        releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
-      fi
-    fi
-  fi
-
-  printVerbose "Getting specific asset details from metadata: ${releaseMetadata}"
-  if [ -z "${asset}" ] || [ "null" = "${asset}" ]; then
-    printVerbose "Asset not found during previous logic; setting now."
-    asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
-  fi
-  if [ -z "${asset}" ]; then
-    printError "Unable to determine download asset for ${name}"
-  fi
-
-  tagname=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
-  installedReleaseLine=$(validateReleaseLine "${tagname}")
-
-  downloadURL=$(/bin/printf "%s" "${asset}" | jq -e -r '.url')
-  size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
-
-  if [ -z "${downloadURL}" ]; then
-    printError "Unable to determine download location for ${name}"
-  fi
-  downloadFile=$(basename "${downloadURL}")
-  downloadFileVer=$(echo "${downloadFile}" | sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
-  printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
-
-  if ${downloadOnly}; then
-    printVerbose "Skipping installation, downloading only."
-  else
-    printVerbose "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
-    if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
-      if ! ${reinstall}; then
-        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC} and due to the absence of the 'reinstall' flag, will not be reinstalled."
-        return
-      fi
-      printInfo "- Reinstalling version '${downloadFileVer}' of ${name}..."
-    fi
-
-    printVerbose "Checking if package is not installed but scheduled for upgrade."
-    if [ -z "${originalFileVersion}" ]; then
-      printVerbose "No previous version found."
-      if ${installOrUpgrade}; then
-        printVerbose "Package ${name} was not installed, so installing instead of upgrading."
-      elif ${upgradeInstalled}; then
-        printError "Package ${name} can not be upgraded as it is not installed."
-        continue
-      fi
-      unInstallOldVersion=false
-      printInfo "- Installing ${name}..."
-    elif ${skipupgrade}; then
-      printInfo "Package ${name} has a newer release '${downloadFileVer}' but was not specified for an upgrade."
-      continue
-    elif ! ${setactive}; then
-      printVerbose "Current version '${originalFileVersion}' will remain active."
-      unInstallOldVersion=false
-    else
-      printVerbose "Previous version '${originalFileVersion}' installed."
-      if [ -e "${rootInstallDir}/${name}/${name}/.pinned" ]; then
-        printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped."
-        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_INSTALL}" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped."
-        continue
-      else
-        printInfo "- Replacing ${name} version '${originalFileVersion}' with '${downloadFileVer}'"
-        unInstallOldVersion=true
-        currentversiondir=$(cd "${rootInstallDir}/${name}/${name}" && pwd -P)
-        currentlinkfile="${currentversiondir}/.links"
-      fi
-    fi
-  fi
-
-  printVerbose "Ensuring we are in the correct working download location '${downloadDir}'"
-  cd "${downloadDir}" || exit
-  if [ ! -n "${downloadOnly}" ] || [ ! -n "${localInstall}" ]; then
-    printVerbose "Checking current directory for already downloaded package [file name comparison]."
-    location="current directory"
-  else
-    printVerbose "Checking cache for already downloaded package [file name comparison]."
-    location="zopen package cache"
-  fi
-
-  pax=${downloadFile}
-  if [ -f "${pax}" ]; then
-    printInfo "- Found existing file '${pax}' in ${location}"
-  else
-    printInfo "- Downloading ${pax} file from remote to ${location}..."
-    if ! ${verbose}; then
-      redirectToDevNull="2>/dev/null"
-    fi
-
-    progressHandler "network" "- Downloaded ${pax} file from remote to ${location}." &
-    ph=$!
-    killph="kill -HUP ${ph}"
-    addCleanupTrapCmd "${killph}"
-
-    if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
-      printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
-      continue
-    fi
-    ${killph} 2> /dev/null # if the timer is not running, the kill will fail
-    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_NETWORK},${CAT_PACKAGE},${CAT_FILE}" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '${pax}'"
-  fi
-  if [ ! -f "${pax}" ]; then
-    printError "${pax} was not found after download!?"
-  fi
-
-  if ${downloadOnly}; then
-    printVerbose "Pax was downloaded to local dir '${downloadDir}'"
-  elif ${cacheOnly}; then
-    printVerbose "Pax was downloaded to zopen cache '${downloadDir}'"
-  else
-    printVerbose "Installing ${pax}"
-    installdirname="${name}/${pax%.pax.Z}" # Use full pax name as default
-
-    printInfo "- Processing ${pax}..."
-    baseinstalldir="."
-    paxredirect=""
-    if ! ${localInstall}; then
-      baseinstalldir="${rootInstallDir}"
-      paxredirect="-s %[^/]*/%${rootInstallDir}/${installdirname}/%"
-      printVerbose "Non-local install, extracting with '${paxredirect}'"
-    else
-      printInfo "- Local install specified."
-      paxredirect="-s %[^/]*/%${installdirname}/%"
-      printVerbose "Non-local install, extracting with '${paxredirect}'"
-    fi
-
-    megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
-    printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
-    if ! ${yesToPrompts}; then
-      while true; do
-        printInfo "Do you want to continue? [y/n]"
-        read continueInstall < /dev/tty
-        if [ "y" = "${continueInstall}" ]; then
-          break
-        fi
-        if [ "n" = "${continueInstall}" ]; then
-          mutexFree "zopen"
-          printInfo "Exiting..."
-          exit 0
-        fi
-      done
-    fi
-
-    printVerbose "Check for existing directory for version '${installdirname}'"
-    if [ -d "${baseinstalldir}/${installdirname}" ]; then
-      printInfo "- Clearing existing directory and contents"
-      rm -rf "${baseinstalldir}/${installdirname}"
-    fi
-
-    if ! runLogProgress "pax -rf ${pax} -p p ${paxredirect} ${redirectToDevNull}" "Expanding ${pax}" "Expanded"; then
-      printWarning "Errors unpaxing, package directory state unknown."
-      printInfo "Use zopen alt to select previous version."
-      continue
-    fi
-    if ${localInstall}; then
-      rm -f "${pax}"
-    fi
-
-    if ${setactive}; then
-      if [ -L "${baseinstalldir}/${name}/${name}" ]; then
-        printVerbose "Removing old symlink '${baseinstalldir}/${name}/${name}'"
-        rm -f "${baseinstalldir}/${name}/${name}"
-      fi
-      if ! ln -s "${baseinstalldir}/${installdirname}" "${baseinstalldir}/${name}/${name}"; then
-        printError "Could not create symbolic link name."
-      fi
-    fi
-
-    printVerbose "Adding version '${downloadFileVer}' to info file."
-    # Add file version information as a .releaseinfo file
-    echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.releaseinfo"
-
-    # Check for a .version file from the pax - if present good, if not
-    # generate one from the file name as the tag isn't granular enough to really
-    # be used in dependency checks
-    if [ ! -f "${baseinstalldir}/${installdirname}/.version" ]; then
-      echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.version"
-    fi
-
-    printVerbose "Adding releaseline '${installedReleaseLine}' metadata to ${baseinstalldir}/${installdirname}/.releaseline"
-    echo "${installedReleaseLine}" > "${baseinstalldir}/${installdirname}/.releaseline"
-
-    if ${setactive}; then
-      if ! ${nosymlink}; then
-        mergeIntoSystem "${name}" "${baseinstalldir}/${installdirname}" "${ZOPEN_ROOTFS}"
-        misrc=$?
-        printVerbose "The merge completed with: ${misrc}"
-      fi
-
-      printInfo "- Checking for env file."
-      if [ -f "${baseinstalldir}/${name}/${name}/.env" ] || [ -f "${baseinstalldir}/${name}/${name}/.appenv" ]; then
-        printInfo "- .env file found, adding to profiled processing."
-        mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
-        cat << EOF > "${ZOPEN_ROOTFS}/etc/profiled/${name}/dotenv"
-curdir=\$(pwd)
-cd "\${ZOPEN_ROOTFS}${ZOPEN_PKGINSTALL##"${ZOPEN_ROOTFS}"}/${name}/${name}" >/dev/null 2>&1
-# If .appenv exists, source it as it's quicker
-if [ -f ".appenv" ]; then
-  . ./.appenv
-elif [ -f ".env" ]; then
-  . ./.env
-fi
-cd \${curdir}  >/dev/null 2>&1
-EOF
-        printInfo "- Sourcing environment to run any setup."
-        cd "${baseinstalldir}/${name}/${name}" && ./setup.sh
-      fi
-    fi
-    if ${unInstallOldVersion}; then
-      printVerbose "New version merged; checking for orphaned files from previous version."
-      # This will remove any old symlinks or dirs that might have changed in an upgrade
-      # as the merge process overwrites existing files to point to different version
-      unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}"
-    fi
-
-    if ${setactive}; then
-      printVerbose "Marking this version as installed."
-      touch "${baseinstalldir}/${name}/${name}/.active"
-      installedList="${name} ${installedList}"
-      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
-    fi
-
-    if ${doNotInstallDeps}; then
-      printInfo "- Skipping dependency installation."
-    elif ${reinstall}; then
-      printVerbose "- Reinstalling so no dependency reinstall (unless explicitly listed)."
-    else
-      printInfo "- Checking for runtime dependencies."
-      printVerbose "Checking for .runtimedeps file."
-      if [ -e "${baseinstalldir}/${name}/${name}/.runtimedeps" ]; then
-        dependencies=$(cat "${baseinstalldir}/${name}/${name}/.runtimedeps")
-      fi
-      printVerbose "Checking for runtime dependencies from the git metadata."
-      if echo "${statusline}" | grep "Runtime Dependencies:" > /dev/null; then
-        gitmetadependencies="$(echo "${statusline}" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
-        if [ ! "${gitmetadependencies}" = "No dependencies" ]; then
-          dependencies="${dependencies} ${gitmetadependencies}"
-        fi
-      fi
-      dependencies=$(deleteDuplicateEntries "${dependencies}" " ")
-      if [ -n "${dependencies}" ]; then
-        printInfo "- ${name} depends on: ${dependencies}"
-        printInfo "- Installing dependencies."
-        installDependencies "${name}" "${dependencies}"
-      else
-        printInfo "- No runtime dependencies found."
-      fi
-    fi
-    printInfo "${NC}${GREEN}Successfully installed: ${name}${NC}"
-  fi # (download only)
-}
-
-installPorts()
-(
+installPorts()( # Note the subshell '()'
   ports="$1"
-  printVerbose "Ports to install: ${ports}"
+  printDebug "Ports to install: $ports"
+  sessionList="" # Track the packages installed during this session to prevent repeats
   mutexReq "zopen" "zopen"
-  echo "${ports}" | xargs | tr ' ' '\n' | while read port; do
-    handlePackageInstall "${port}"
+  for port in $ports; do
+    handlePackageInstall "$port"
   done
   mutexFree "zopen"
 )
 
 # Main code start here
+# Need to set a number of variables for use in the install function
+# which is common between install & upgrade
 args=$*
 upgradeInstalled=false
 verbose=false
 debug=false
+xdebug=false
+paxrepodir=""
+paxinstall=false
 selectVersion=false
 setActive=true
 cacheOnly=false
@@ -496,59 +117,67 @@ yesToPrompts=false
 chosenRepos=""
 while [ $# -gt 0 ]; do
   case "$1" in
-  "-u" | "--update" | "-update" | "-upgrade" | "--upgrade")
-    upgradeInstalled=true # Upgrade packages
-    ;;
-  "-r" | "-reinstall" | "--reinstall")
-    reinstall=true # If package already installed, reinstall
-    ;;
-  "--install-or-upgrade")
-    installOrUpgrade=true # Upgrade package or install if not present
-    ;;
-  "--local-install")
-    localInstall=true # Install the package into current directory
-    ;;
-  "--no-symlink")
-    nosymlink=true # Do not mesh the package into the file system; leave as stand-alone
-    ;;
-  "--no-deps")
-    doNotInstallDeps=true
-    ;;
-  "--cache-only")
-    cacheOnly=true # Download remote pax file to cache only (no install)
-    ;;
-  "--release-line")
-    shift
-    releaseLine=$(echo "$1" | awk '{print toupper($0)}')
-    ;;
-  "--yes" | "-y")
-    yesToPrompts=true # Automatically answer 'yes' to any questions
-    ;;
-  "--download-only")
-    downloadOnly=true # Download remote pax file to current directory only
-    ;;
-  "--no-set-active")
-    setactive=false # Install package as normal but keep existing installation as active
-    ;;
-  "--skip-upgrade")
-    skipupgrade=true # Do not upgrade any packages
-    ;;
-  "--all")
-    all=true # Install all packages
-    ;;
-  "--select")
-    selectVersion=true # Display a selction table to allow version picking
-    ;;
-  "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-    printSyntax "${args}"
-    exit 0
-    ;;
-  "--debug")
-    verbose=true
-    debug=true
-    ;;
-  "-v" | "--v" | "-verbose" | "--verbose")
-    verbose=true
+    "-r" | "-reinstall" | "--reinstall")
+      reinstall=true  # If package already installed, reinstall
+      ;;
+    "--install-or-upgrade")
+      installOrUpgrade=true  # Upgrade package or install if not present
+      ;;
+    "--local-install")
+      localInstall=true # Install the package into current directory
+      ;;
+    "--no-symlink")
+      nosymlink=true  # Do not mesh the package into the file system; leave as stand-alone
+      ;;
+    "--no-deps")
+      doNotInstallDeps=true
+      ;;
+    "--cache-only")
+      cacheOnly=true  # Download remote pax file to cache only (no install)
+      ;;
+    "--release-line")
+      shift
+      releaseLine=$(echo "$1" | awk '{print toupper($0)}')
+      ;;
+    "--yes" | "-y")
+      yesToPrompts=true  # Automatically answer 'yes' to any questions
+      ;;
+    "--download-only")
+      downloadOnly=true  # Download remote pax file to current directory only
+      ;;
+    "--no-set-active")
+      setactive=false  # Install package as normal but keep existing installation as active
+      ;;
+    "--skip-upgrade")
+      skipupgrade=true  # Do not upgrade any packages
+      ;;
+    "--all")
+      all=true  # Install all packages
+      ;;
+    "--select")
+      selectVersion=true  # Display a selction table to allow version picking
+      ;;
+    "--paxinstall")
+      paxinstall=true # Use pax files to install
+      ;;
+    "--paxrepodir")
+      [ $# -lt 2 ] && printError "Missing parameter"
+      shift
+      paxrepodir=$(echo "$1" )
+      ;;
+    "-h" | "--help" | "-?")
+      printHelp "${args}"
+      exit 0
+      ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
+    "-v" | "--verbose")
+      verbose=true
+      ;;
+    "--xdebug")
+      xdebug=true
     ;;
   "--version")
     zopen-version ${ME}
@@ -560,6 +189,8 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+$xdebug && set -x && printVerbose "Enabled command execution trace" 
 
 if [ -z "${chosenRepos}" ]; then
   if ! ${all} && ! ${upgradeInstalled}; then
@@ -589,15 +220,15 @@ export SSL_CERT_FILE="${ZOPEN_CA}"
 export GIT_SSL_CAINFO="${ZOPEN_CA}"
 export CURL_CA_BUNDLE="${ZOPEN_CA}"
 
-if ${downloadOnly}; then
-  downloadDir="${PWD}"
-  printVerbose "Downloading pax to current directory '${downloadDir}'"
-elif ${localInstall}; then
-  downloadDir="${PWD}"
-  printVerbose "Installing to current directory '${downloadDir}'"
+if $downloadOnly; then
+  downloadDir="$PWD"
+  printDebug "Downloading pax to current directory '$downloadDir'"
+elif $localInstall; then
+  downloadDir="$PWD"
+  printDebug "Installing to current directory '$downloadDir'"
 else
-  printVerbose "Installing to zopen file system: ${ZOPEN_ROOTFS}"
-  if [ -z "${ZOPEN_ROOTFS}" ]; then
+  printDebug "Installing to zopen file system: $ZOPEN_ROOTFS"
+  if [ -z "$ZOPEN_ROOTFS" ]; then
     printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined."
   fi
   downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
@@ -610,23 +241,23 @@ if [ ! -d "${downloadDir}" ]; then
   fi
 fi
 
-if [ -n "${downloadDir}" ] && [ -d "${downloadDir}" ]; then
-  cd "${downloadDir}" || exit
+printDebug "Checking if installing from pax files: $paxinstall"
+if ! $paxinstall; then
+  # Parse passed in repositories and check if valid zopen framework repos
+  printVerbose "Querying remote repo for latest package information"
+  getReposFromGithub
+  grfgRc=$?
+  $killph 2>/dev/null  # if the timer is not running, the kill will fail
+  [ 0 -ne $grfgRc ] && exit $grfgRc;
+else
+  printDebug "Using pax files for install"
+  [ -n "$paxrepodir" ] && printDebug "Using '$paxrepodir' to locate pax files"
 fi
-
-printVerbose "Working directory: ${downloadDir}"
-# Parse passed in repositories and check if valid zopen framework repos
-printInfo "- Querying remote repo for latest package information."
-getReposFromGithub
-grfgRc=$?
-${killph} 2> /dev/null # if the timer is not running, the kill will fail
-[ 0 -ne "${grfgRc}" ] && exit "${grfgRc}"
-
-foundPort=false
 installArray=""
 
-if ${all}; then
-  if ! ${yesToPrompts}; then
+if $all; then
+  if ! $paxinstall; then
+      if ! ${yesToPrompts}; then
     # Sum up the pax size + expanded size of the latest releases of each port
     spaceRequiredBytes=$(jq '.release_data | to_entries | map(select(.value | length > 0)) | map(.value[0].assets[0]) | reduce .[] as $item ({}; . + {($item.name): ($item.size + $item.expanded_size)}) | [.[]] | add' ${JSON_CACHE})
     spaceRequiredMB=$(echo "scale=0; ${spaceRequiredBytes} / (1024 * 1024)" | bc)
@@ -646,25 +277,43 @@ if ${all}; then
     installArray="${installArray} ${repo}"
   done
   installArray=$(strtrim "${installArray}")
+  else
+    printDebug "Checking for system default repo directory"
+    [ -r "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ] && usepaxrepodir=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
+    printDebug "Checking for override parameter"
+    [ -z "$paxrepodir" ] && usepaxrepodir="./" || usepaxrepodir="$paxrepodir" # default to current directory
+    case "$usepaxrepodir" in
+      */) printDebug "String terminated with '/' already" ;;
+      *)  usepaxrepodir="$usepaxrepodir/";;
+    esac
+
+    printDebug "Locating all pax files in repo at '$usepaxrepodir'"
+    installArray=$(zosfind "$usepaxrepodir" ! -name "$usepaxrepodir"  -prune | grep ".pax.Z")
+    [ -z "$installArray" ] && printInfo "No packages found to install'" && exit 1
+  fi
+elif $paxinstall; then
+  printDebug "Installing from pax files as listed in arguments: '$chosenRepos'"
+  installArray="$chosenRepos"
 else
-  for chosenRepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
-    printVerbose "Processing repo: ${chosenRepo}."
-    printVerbose "Stripping any version (%), tag (#) or port suffixes."
-    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
-    printVerbose "Adding prefix and 'port' suffix." # quicker than testing for presence!
-    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}')
-    if [ "${toolfound}" = "${toolrepo}" ]; then
-      printVerbose "Adding '${chosenRepo}' to the install queue."
-      installArray="${installArray} ${chosenRepo}"
-      printVerbose "Removing valid port from input list."
-      chosenRepos=$(echo "${chosenRepos}" | sed -e "s#${chosenRepo}##")
+  printDebug "Parsing list of packages to install and verifying validity"
+
+  badportlist=""
+  for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' '); do
+    printVerbose "Processing repo: $chosenRepo"
+    printDebug "Stripping any version (%), tag (#) or port suffixes and trim"
+    toolrepo=$(echo "$chosenRepo" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
+
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 == toolrepo {print}') 
+    if [ "$toolfound" = "$toolrepo" ]; then
+      printVerbose "Adding '$chosenRepo' to the install queue"
+      installArray=$(printf "%s\n%s" "$installArray" "$chosenRepo")
+    else
+      badportlist=$(printf "%s %s" "$badportlist" "$toolrepo")
     fi
   done
-fi
-printVerbose "Checking whether any ports remain in the input list."
-chosenRepos=$(strtrim "${chosenRepos}")
-if [ -n "${chosenRepos}" ]; then
-  printError "The following requested port(s) do not exist:\n\t$(echo ${chosenRepos} | tr -s '[:space:]')"
+  if [ -n "$badportlist" ]; then
+    printError "The following requested port(s) do not exist:\n\t$badportlist"
+  fi
 fi
 
 installPorts "${installArray}"

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -12,6 +12,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -211,7 +211,7 @@ printInstalledEntries()
   printVerbose "Packages: ${installedPackages}"
   echo "${installedPackages}" | xargs | tr ' ' '\n' | sort | while read repo; do
     repo="${repo##*/}"
-    pkghome="${ZOPEN_PKGINSTALL}/${repo}/${repo}"
+        pkghome="${ZOPEN_PKGINSTALL}/${repo}/${repo}"
     if [ ! -e "${pkghome}/.active" ]; then
       printVerbose "Symlink '${repo}' in '${ZOPEN_PKGINSTALL}' is not active; skipping"
       continue

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -17,19 +17,25 @@ setupMyself()
 setupMyself
 checkWritable
 
-printSyntax()
-{
-  args=$*
-  echo "${ME} - remove installed z/OS Open Tools packages."
-  echo "Usage: zopen remove [OPTION] PACKAGE"
-  echo "  PACKAGE is a list of one or more projects to uninstall"
-  echo "Options:"
-  echo "  --help       print this help"
-  echo "  --version    print version"
-  echo "  -p, --purge  remove package, the versioned directory and any cached file"
-  echo "  -v           run in verbose mode"
-  echo "Examples:"
-  echo "  ${ME} man-db    Remove the man-db package" 
+printHelp(){
+cat << HELPDOC
+${ME} is a utility to remove installed z/OS Open Tools packages
+
+Usage: zopen remove [OPTION] [PACKAGES]
+
+Options:
+  -p, --purge       remove package, the versioned directory and any 
+                    cached file
+      --version     display the program version
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+Examples:
+  ${ME} man-db    Remove the man-db package
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
 }
 
 removePackages()
@@ -39,7 +45,7 @@ removePackages()
   echo "${pkglist}" | xargs | tr ' ' '\n' | sort | while read pkg; do
     printHeader "Removing package: ${pkg}"
     printInfo "- Checking status of package '${pkg}'"
-    if [ ! -f ${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active ]; then
+    if [ ! -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active" ]; then
       printInfo "${NC}${YELLOW}Package '${pkg}' is not installed${NC}"
     else
       printInfo "- Package installed, unmeshing from system"
@@ -70,15 +76,13 @@ removePackages()
       printInfo "- Removing profiled entry"
       [ -d "${ZOPEN_ROOTFS}/etc/profiled/${pkg}" ] && rm -rf "${ZOPEN_ROOTFS}/etc/profiled/${pkg}"
 
-      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Removed package:'${needle};version:${version};"
+      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Removed package:'${pkg};version:${version};"
       printInfo "${NC}${GREEN}Successfully removed: ${pkg}${NC}"
     fi
   done
 }
 
 # Main code start here
-args=$*
-
 verbose=false
 debug=false
 purge=false

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -12,6 +12,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -93,7 +94,7 @@ while [ $# -gt 0 ]; do
     purge=true
     ;;
   "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-    printSyntax "${args}"
+    printHelp
     exit 0
     ;;
   "--version")

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -58,20 +58,23 @@ removePackages()
       if [ -e "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" ]; then
         deref=$(cd "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" && pwd -P | awk -F/ '{ print $(NF)}')
         installedlinksfile="${ZOPEN_PKGINSTALL}/${pkg}/${deref}/.links"
+        printVerbose "Main symlink removed, removing dangling symlinks"
+        unsymlinkFromSystem "${pkg}" "${ZOPEN_ROOTFS}" "${installedlinksfile}"
         if ${purge}; then
           printInfo "- Purging package"
           printVerbose "Checking if we are currently in a directory that is to be purged"
-          [ "${PWD##"${ZOPEN_PKGINSTALL}"/"${pkg}"/"${pkg}"}" != "${PWD}" ] && cd ${ZOPEN_PKGINSTALL} || exit
-          rm -rf $(cd "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" && pwd -P)
-          syslog ${ZOPEN_LOG_PATH}/audit.log ${LOG_A} "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Purging package:'${needle};version:${version};"
+          [ "${PWD##"${ZOPEN_PKGINSTALL}"/"${pkg}"/"${pkg}"}" != "${PWD}" ] && cd "${ZOPEN_PKGINSTALL}"
+          purgeDir="$(cd "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" && pwd -P)"
+          [ "${purgeDir}" = "/" ] && printError "Directory to remove resolved to '/'"
+          printVerbose "Purging versioned directory: '${purgeDir}'"
+          rm -rf "${purgeDir}"
+          syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Purging package:'${needle};version:${version};"
         else
           printInfo "- Removing metadata file to mark uninstall"
           rm -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active"
-          printInfo "- Breaking link from current to versioned"
-          rm -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}"
         fi
-        printVerbose "Main symlink removed, removing dangling symlinks"
-        unsymlinkFromSystem "${pkg}" "${ZOPEN_ROOTFS}" "${installedlinksfile}"
+        printInfo "- Breaking link from current to versioned"
+        [ -e "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" ] && rm -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}"
       fi
 
       printInfo "- Removing profiled entry"

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -93,7 +93,7 @@ while [ $# -gt 0 ]; do
   "-p" | "--purge")
     purge=true
     ;;
-  "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+  "-h" | "--help" | "-?")
     printHelp
     exit 0
     ;;

--- a/bin/zopen-upgrade
+++ b/bin/zopen-upgrade
@@ -58,16 +58,7 @@ Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 HELPDOC
 }
 
-upgradePackages()( # Note the subshell '()'
-  packages="$1"
-  printDebug "Packages to upgrade: $packages"
-  sessionList="" # Track the packages installed during this session to prevent repeats
-  mutexReq "zopen" "zopen"
-  for pkg in $packages; do
-    handlePackageInstall "$pkg"
-  done
-  mutexFree "zopen"
-)
+
 
 # Main code start here
 # Need to set a number of variables for use in the install function
@@ -128,17 +119,17 @@ while [ $# -gt 0 ]; do
       xdebug=true
     ;;
     "--version")
-      zopen --version $ME
+      zopen --version "${ME}"
       exit 0
       ;;
     *)
-      chosenRepos=" $chosenRepos $1 ";
+      chosenRepos=" ${chosenRepos} $1 ";
       ;;
   esac
   shift;
 done
 
-$xdebug && set -x && printVerbose "Enabled command execution trace" 
+${xdebug} && set -x && printVerbose "Enabled command execution trace" 
 
 if [ -z "${chosenRepos}" ]; then
 
@@ -146,10 +137,10 @@ if [ -z "${chosenRepos}" ]; then
     printInfo "- Querying for installed packages"
     progressHandler "spinner" "- Query complete" &
     ph=$!
-    killph="kill -HUP $ph"
-    addCleanupTrapCmd "$killph"
+    killph="kill -HUP ${ph} 2>/dev/null"
+    addCleanupTrapCmd "${killph}"
     chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-versions)"
-    $killph 2>/dev/null  # if the timer is not running, the kill will fail
+    ${killph} # if the timer is not running, the kill will fail
 fi
 
 checkIfConfigLoaded
@@ -158,57 +149,63 @@ export SSL_CERT_FILE="${ZOPEN_CA}"
 export GIT_SSL_CAINFO="${ZOPEN_CA}"
 export CURL_CA_BUNDLE="${ZOPEN_CA}"
 
-printDebug "Installing to zopen file system: $ZOPEN_ROOTFS"
-if [ -z "$ZOPEN_ROOTFS" ]; then
-  printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined"
+printDebug "Installing to zopen file system: ${ZOPEN_ROOTFS}"
+if [ -z "${ZOPEN_ROOTFS}" ]; then
+  printError "Unable to locate zopen file system, \${ZOPEN_ROOTFS} is undefined"
 fi
-downloadDir="$ZOPEN_ROOTFS/var/cache/zopen"
+downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
 
 
 if [ ! -d "${downloadDir}" ]; then
   mkdir -p "${downloadDir}"
   if [ $? -gt 0 ]; then
-    printError "Could not create download directory: $downloadDir"
+    printError "Could not create download directory: ${downloadDir}"
   fi
 fi
 
-printDebug "Checking if installing from pax files: $paxinstall"
-if ! $paxinstall; then
+printDebug "Checking if installing from pax files: ${paxinstall}"
+if ! ${paxinstall}; then
   # Parse passed in repositories and check if valid zopen framework repos
   printVerbose "Querying remote repo for latest package information"
   getReposFromGithub
   grfgRc=$?
-  $killph 2>/dev/null  # if the timer is not running, the kill will fail
-  [ 0 -ne $grfgRc ] && exit $grfgRc;
+  ${killph} # if the timer is not running, the kill will fail
+  [ 0 -ne ${grfgRc} ] && exit ${grfgRc};
 else
   printDebug "Using pax files for install, not GH"
-  [ -n "$paxrepodir" ] && printDebug "Using '$paxrepodir' to locate pax files"
+  [ -n "${paxrepodir}" ] && printDebug "Using '${paxrepodir}' to locate pax files"
 fi
 installArray=""
 
-if $paxinstall; then
-  printDebug "Installing from pax files as listed in arguments: '$chosenRepos'"
-  installArray="$chosenRepos"
+if ${paxinstall}; then
+  printDebug "Installing from pax files as listed in arguments: '${chosenRepos}'"
+  installArray="${chosenRepos}"
 else
   printDebug "Parsing list of packages to install and verifying validity"
 
   badportlist=""
   for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' '); do
-    printVerbose "Processing repo: $chosenRepo"
+    printVerbose "Processing repo: ${chosenRepo}"
     printDebug "Stripping any version (%), tag (#) or port suffixes and trim"
-    toolrepo=$(echo "$chosenRepo" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
+    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
 
-    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 == toolrepo {print}') 
-    if [ "$toolfound" = "$toolrepo" ]; then
-      printVerbose "Adding '$chosenRepo' to the install queue"
-      installArray=$(printf "%s\n%s" "$installArray" "$chosenRepo")
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}') 
+    if [ "${toolfound}" = "${toolrepo}" ]; then
+      printVerbose "Adding '${chosenRepo}' to the install queue"
+      installArray=$(printf "%s\n%s" "${installArray}" "${chosenRepo}")
     else
-      badportlist=$(printf "%s %s" "$badportlist" "$toolrepo")
+      badportlist=$(printf "%s %s" "${badportlist}" "${toolrepo}")
     fi
   done
-  if [ -n "$badportlist" ]; then
-    printError "The following requested port(s) do not exist:\n\t$badportlist"
+  if [ -n "${badportlist}" ]; then
+    printError "The following requested port(s) do not exist:\n\t${badportlist}"
   fi
 fi
 
-upgradePackages "$installArray"
+printDebug "Packages to upgrade: ${installArray}"
+sessionList="" # Track the packages installed during this session to prevent repeats
+mutexReq "zopen" "zopen"
+for pkg in ${installArray}; do
+  handlePackageInstall "${pkg}"
+done
+mutexFree "zopen"

--- a/bin/zopen-upgrade
+++ b/bin/zopen-upgrade
@@ -1,0 +1,214 @@
+#!/bin/sh
+# Upgrade utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+# All zopen-* scripts MUST start with this code to maintain consistency
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source" >&2
+    exit 8
+  fi
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+checkWritable
+
+printHelp(){
+  cat << HELPDOC
+zopen upgrade is a utility for z/OS Open Tools to upgrade packages to
+a later release
+
+Usage: zopen upgrade [OPTION] [PARAMETERS] [PACKAGES]
+
+Options:
+      --paxrepodir  a directory location to locate pax files
+      --paxinstall  list of pax files to install
+  -y, --yes         automatically answer yes to prompts
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+Examples:
+  zopen install foo 
+                    install package foo if not already installed
+  zopen install --release-line DEV foo
+                    install package foo from the DEV releaseline if
+                    available
+  zopen upgrade     upgrade all packages to latest version on their
+                    releaseline
+  zopen install -y foo bar --no-deps
+                    install packages foo and bar without asking for
+                    user confirmation and without installing any
+                    dependencies
+  zopen install --paxinstall foo
+                    locate the pax file for foo in the current
+                    directory or the system-configured paxdir and
+                    install
+  zopen install --paxinstall /tmp/foo-1.2.3-4.zos.pax.Z
+                    install package foo from the specified location
+  zopen install -y --paxinstall --paxrepodir /tmp foo-1.2.3-4.zos.pax.Z
+                    check for the named package in /tmp and install
+                    package foo if found
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
+}
+
+upgradePackages()( # Note the subshell '()'
+  packages="$1"
+  printDebug "Packages to upgrade: $packages"
+  sessionList="" # Track the packages installed during this session to prevent repeats
+  mutexReq "zopen" "zopen"
+  for pkg in $packages; do
+    handlePackageInstall "$pkg"
+  done
+  mutexFree "zopen"
+)
+
+# Main code start here
+# Need to set a number of variables for use in the install function
+# which is common between install & upgrade
+args=$*
+upgradeInstalled=true
+verbose=false
+debug=false
+xdebug=false
+paxrepodir=""
+paxinstall=false
+selectVersion=false
+setActive=true
+cacheOnly=false
+downloadOnly=false
+localInstall=false
+reinstall=false
+installOrUpgrade=false
+nosymlink=false
+skipupgrade=false
+doNotInstallDeps=true
+yesToPrompts=false
+chosenRepos=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    "--yes" | "-y")
+      yesToPrompts=true  # Automatically answer 'yes' to any questions
+      ;;
+    "--no-set-active")
+      setactive=false  # Install package as normal but keep existing installation as active
+      ;;
+    "--paxinstall")
+      paxinstall=true # Use pax files to install
+      ;;
+    "--paxrepodir")
+      [ $# -lt 2 ] && printError "Missing parameter"
+      shift
+      paxrepodir=$(echo "$1" )
+      ;;
+    "-h" | "--help" | "-?")
+      printHelp "${args}"
+      exit 0
+      ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
+    "-v" | "--verbose")
+      verbose=true
+      ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
+    "--xdebug")
+      verbose=true
+      debug=true
+      xdebug=true
+    ;;
+    "--version")
+      zopen --version $ME
+      exit 0
+      ;;
+    *)
+      chosenRepos=" $chosenRepos $1 ";
+      ;;
+  esac
+  shift;
+done
+
+$xdebug && set -x && printVerbose "Enabled command execution trace" 
+
+if [ -z "${chosenRepos}" ]; then
+
+    printVerbose "No specific port to upgrade, upgrade all installed packages"
+    printInfo "- Querying for installed packages"
+    progressHandler "spinner" "- Query complete" &
+    ph=$!
+    killph="kill -HUP $ph"
+    addCleanupTrapCmd "$killph"
+    chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-versions)"
+    $killph 2>/dev/null  # if the timer is not running, the kill will fail
+fi
+
+checkIfConfigLoaded
+
+export SSL_CERT_FILE="${ZOPEN_CA}"
+export GIT_SSL_CAINFO="${ZOPEN_CA}"
+export CURL_CA_BUNDLE="${ZOPEN_CA}"
+
+printDebug "Installing to zopen file system: $ZOPEN_ROOTFS"
+if [ -z "$ZOPEN_ROOTFS" ]; then
+  printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined"
+fi
+downloadDir="$ZOPEN_ROOTFS/var/cache/zopen"
+
+
+if [ ! -d "${downloadDir}" ]; then
+  mkdir -p "${downloadDir}"
+  if [ $? -gt 0 ]; then
+    printError "Could not create download directory: $downloadDir"
+  fi
+fi
+
+printDebug "Checking if installing from pax files: $paxinstall"
+if ! $paxinstall; then
+  # Parse passed in repositories and check if valid zopen framework repos
+  printVerbose "Querying remote repo for latest package information"
+  getReposFromGithub
+  grfgRc=$?
+  $killph 2>/dev/null  # if the timer is not running, the kill will fail
+  [ 0 -ne $grfgRc ] && exit $grfgRc;
+else
+  printDebug "Using pax files for install, not GH"
+  [ -n "$paxrepodir" ] && printDebug "Using '$paxrepodir' to locate pax files"
+fi
+installArray=""
+
+if $paxinstall; then
+  printDebug "Installing from pax files as listed in arguments: '$chosenRepos'"
+  installArray="$chosenRepos"
+else
+  printDebug "Parsing list of packages to install and verifying validity"
+
+  badportlist=""
+  for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' '); do
+    printVerbose "Processing repo: $chosenRepo"
+    printDebug "Stripping any version (%), tag (#) or port suffixes and trim"
+    toolrepo=$(echo "$chosenRepo" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
+
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 == toolrepo {print}') 
+    if [ "$toolfound" = "$toolrepo" ]; then
+      printVerbose "Adding '$chosenRepo' to the install queue"
+      installArray=$(printf "%s\n%s" "$installArray" "$chosenRepo")
+    else
+      badportlist=$(printf "%s %s" "$badportlist" "$toolrepo")
+    fi
+  done
+  if [ -n "$badportlist" ]; then
+    printError "The following requested port(s) do not exist:\n\t$badportlist"
+  fi
+fi
+
+upgradePackages "$installArray"

--- a/bin/zopen-upgrade
+++ b/bin/zopen-upgrade
@@ -12,6 +12,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck disable=SC1091
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -32,26 +33,10 @@ Options:
   -h,-?, --help     display this help and exit
 
 Examples:
-  zopen install foo 
-                    install package foo if not already installed
-  zopen install --release-line DEV foo
-                    install package foo from the DEV releaseline if
-                    available
-  zopen upgrade     upgrade all packages to latest version on their
+  zopen upgrade foo 
+                    upgrade package foo if installed
+  zopen upgrade -y  upgrade all packages to latest version on their
                     releaseline
-  zopen install -y foo bar --no-deps
-                    install packages foo and bar without asking for
-                    user confirmation and without installing any
-                    dependencies
-  zopen install --paxinstall foo
-                    locate the pax file for foo in the current
-                    directory or the system-configured paxdir and
-                    install
-  zopen install --paxinstall /tmp/foo-1.2.3-4.zos.pax.Z
-                    install package foo from the specified location
-  zopen install -y --paxinstall --paxrepodir /tmp foo-1.2.3-4.zos.pax.Z
-                    check for the named package in /tmp and install
-                    package foo if found
 
 Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 
@@ -102,11 +87,7 @@ while [ $# -gt 0 ]; do
       printHelp "${args}"
       exit 0
       ;;
-    "--debug")
-      verbose=true
-      debug=true
-      ;;
-    "-v" | "--verbose")
+     "-v" | "--verbose")
       verbose=true
       ;;
     "--debug")
@@ -119,7 +100,7 @@ while [ $# -gt 0 ]; do
       xdebug=true
     ;;
     "--version")
-      zopen --version "${ME}"
+      zopen-version "${ME}"
       exit 0
       ;;
     *)
@@ -137,10 +118,10 @@ if [ -z "${chosenRepos}" ]; then
     printInfo "- Querying for installed packages"
     progressHandler "spinner" "- Query complete" &
     ph=$!
-    killph="kill -HUP ${ph} 2>/dev/null"
+    killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
     chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-versions)"
-    ${killph} # if the timer is not running, the kill will fail
+    ${killph} 2>/dev/null # if the timer is not running, the kill will fail
 fi
 
 checkIfConfigLoaded
@@ -169,7 +150,6 @@ if ! ${paxinstall}; then
   printVerbose "Querying remote repo for latest package information"
   getReposFromGithub
   grfgRc=$?
-  ${killph} # if the timer is not running, the kill will fail
   [ 0 -ne ${grfgRc} ] && exit ${grfgRc};
 else
   printDebug "Using pax files for install, not GH"

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -11,6 +11,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -34,7 +35,7 @@ freesw="This is free software: you are free to change and redistribute it."
 warranty="There is NO WARRANTY, to the extent permitted by law."
 authors="Written by contributors to the z/OS Open Tools Community <https://github.com/ZOSOpenTools/meta/graphs/contributors>."
 
-if [[ $# -eq 1 ]]; then
+if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
     printSyntax
     exit 0

--- a/bin/zopen-versions
+++ b/bin/zopen-versions
@@ -11,6 +11,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source" >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself

--- a/include/common.sh
+++ b/include/common.sh
@@ -218,6 +218,15 @@ EOF
 
 }
 
+isPackageActive(){
+  pkg="$1"
+  printDebug "Checking if '${pkg}' is installed and active"
+  installedPackage=$(cd "${ZOPEN_PKGINSTALL}" && zosfind . -name ".active" | grep "/${pkg}/")
+  cmdrc=$?
+  # Return 1 for true/Package is Active, 0 for false/Package is not active
+  [ "${cmdrc}" -eq 0 ] && return 1 || return 0
+}
+
 curlCmd()
 {
   # Take the list of parameters and concat them with

--- a/include/common.sh
+++ b/include/common.sh
@@ -436,7 +436,7 @@ mutexReq()
       [ ! "${lockedpid}" = "${mypid}" ] && [ ! "${lockedpid}" = "${PPID}" ]
     } && kill -0 "${lockedpid}" 2> /dev/null && echo "Aborting, Active process '${lockedpid}' holds the '$2' lock: '${mutex}'" && exit -1
   fi
-  addCleanupTrapCmd "rm -rf ${mutex}"
+  addCleanupTrapCmd "rm -rf $mutex 2>/dev/null"
   echo "${mypid}" > ${mutex}
 }
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -92,10 +92,10 @@ diffFile()
 {
   haystackfile="$1"
   needlesfile="$2"
-  [ -s "$needlesfile" ] || printError "Internal error; needle file was empty/non-existent."
+  [ -s "${needlesfile}" ] || printError "Internal error; needle file was empty/non-existent."
   diff=$(awk 'NR==FNR{needles[$0];next} 
-    !($0 in needles) {print}' "$needlesfile" "$haystackfile")
-  echo "$diff"
+    !($0 in needles) {print}' "${needlesfile}" "${haystackfile}")
+  echo "${diff}"
 }
 
 # Given two input lists (with \n delimiters), return those lines in  
@@ -105,10 +105,10 @@ diffList()
   haystack="$1"
   needles="$2"
   haystackfile=$(mktempfile "haystack")
-  cat "$haystack" >"$haystackfile"
+  cat "${haystack}" >"${haystackfile}"
   needlesfile=$(mktempfile "needles")
-  cat "$needles"  >"$needlesfile"
-  diffFile "$needlesfile" "$haystackfile"
+  cat "${needles}" >"${needlesfile}"
+  diffFile "${needlesfile}" "${haystackfile}"
 }
 
 # getCurrentVersionDir
@@ -188,7 +188,7 @@ mktempfile()
 mktempdir()
 {
   tempdir=$(mktempfile "$1")
-  [ ! -e "$tempdir" ] && mkdir "$tempdir" && addCleanupTrapCmd "rm -rf $tempdir 2>/dev/null" && echo "$tempdir"
+  [ ! -e "${tempdir}" ] && mkdir "${tempdir}" && addCleanupTrapCmd "rm -rf ${tempdir}" && echo "${tempdir}"
 }
 
 isPermString()
@@ -549,8 +549,8 @@ mergeIntoSystem()
   currentDir="${PWD}"
 
   printDebug "Calculating the offset path to store from root"
-  offset=$(dirname "${versioneddir#$rootfs/}")
-  version=$(basename "$versioneddir")
+  offset=$(dirname "${versioneddir#"${rootfs}"/}")
+  version=$(basename ${versioneddir})
   tmptime=$(date +%Y%m%d%H%M%S)
   processingDir="${rootfs}/tmp/zopen.${tmptime}"
   printDebug "Temporary processing dir evaluated to: ${processingDir}"

--- a/include/common.sh
+++ b/include/common.sh
@@ -86,6 +86,60 @@ isPackageActive(){
   getCurrentVersionDir "$needle"
 }
 
+# getCurrentVersionDir
+# returns the version directory that has been set as active/installed
+# indicating that the $needle is active.
+# inputs: $1 - package to get currently active version of
+# return: 0  for success (output of pwd -P command)
+#         4  if unable to access version directory (eg. not installed)
+#         !0 cd or pwd -P failed
+getCurrentVersionDir(){
+  needle="$1"
+  [ ! -L "${ZOPEN_PKGINSTALL}/${needle}/${needle}" ] \
+    && echo ""\
+    && return 4
+  cd "${ZOPEN_PKGINSTALL}/${needle}/${needle}" 2> /dev/null \
+    && pwd -P 2> /dev/null
+}
+
+# isPackageActive
+# returns whether the package is active ie. has a symlink from 
+#  $PKGINSTALL/pkg/pkg to a versioned directory
+# inputs: $1 - package to get currently active version of
+# return: 0  for active
+#         !0 for not active
+isPackageActive(){
+  needle="$1"
+  getCurrentVersionDir "$needle"
+}
+
+# getCurrentVersionDir
+# returns the version directory that has been set as active/installed
+# indicating that the $needle is active.
+# inputs: $1 - package to get currently active version of
+# return: 0  for success (output of pwd -P command)
+#         4  if unable to access version directory (eg. not installed)
+#         !0 cd or pwd -P failed
+getCurrentVersionDir(){
+  needle="$1"
+  [ ! -L "${ZOPEN_PKGINSTALL}/${needle}/${needle}" ] \
+    && echo ""\
+    && return 4
+  cd "${ZOPEN_PKGINSTALL}/${needle}/${needle}" 2> /dev/null \
+    && pwd -P 2> /dev/null
+}
+
+# isPackageActive
+# returns whether the package is active ie. has a symlink from 
+#  $PKGINSTALL/pkg/pkg to a versioned directory
+# inputs: $1 - package to get currently active version of
+# return: 0  for active
+#         !0 for not active
+isPackageActive(){
+  needle="$1"
+  getCurrentVersionDir "$needle"
+}
+
 # Given two input files, return those lines in haystack file that are 
 # not in needles file
 diffFile()
@@ -216,15 +270,6 @@ MANPATH=\${ZOPEN_ROOTFS}/usr/local/share/man:\${ZOPEN_ROOTFS}/usr/local/share/ma
 export MANPATH=\$(deleteDuplicateEntries \"\${MANPATH}\" \":\")
 EOF
 
-}
-
-isPackageActive(){
-  pkg="$1"
-  printDebug "Checking if '${pkg}' is installed and active"
-  installedPackage=$(cd "${ZOPEN_PKGINSTALL}" && zosfind . -name ".active" | grep "/${pkg}/")
-  cmdrc=$?
-  # Return 1 for true/Package is Active, 0 for false/Package is not active
-  [ "${cmdrc}" -eq 0 ] && return 1 || return 0
 }
 
 curlCmd()

--- a/include/common.sh
+++ b/include/common.sh
@@ -92,10 +92,10 @@ diffFile()
 {
   haystackfile="$1"
   needlesfile="$2"
-  [ -s "$needlesfile" ] || printError "Internal error; needle file was empty/non-existent."
+  [ -s "${needlesfile}" ] || printError "Internal error; needle file was empty/non-existent."
   diff=$(awk 'NR==FNR{needles[$0];next} 
-    !($0 in needles) {print}' "$needlesfile" "$haystackfile")
-  echo "$diff"
+    !($0 in needles) {print}' "${needlesfile}" "${haystackfile}")
+  echo "${diff}"
 }
 
 # Given two input lists (with \n delimiters), return those lines in  
@@ -105,10 +105,10 @@ diffList()
   haystack="$1"
   needles="$2"
   haystackfile=$(mktempfile "haystack")
-  cat "$haystack" >"$haystackfile"
+  cat "${haystack}" >"${haystackfile}"
   needlesfile=$(mktempfile "needles")
-  cat "$needles"  >"$needlesfile"
-  diffFile "$needlesfile" "$haystackfile"
+  cat "${needles}" >"${needlesfile}"
+  diffFile "${needlesfile}" "${haystackfile}"
 }
 # Generate a file name that has a high probability of being unique for
 # use as a temporary filename - the filename should be unique in the
@@ -136,7 +136,7 @@ mktempfile()
 mktempdir()
 {
   tempdir=$(mktempfile "$1")
-  [ ! -e "$tempdir" ] && mkdir "$tempdir" && addCleanupTrapCmd "rm -rf $tempdir 2>/dev/null" && echo "$tempdir"
+  [ ! -e "${tempdir}" ] && mkdir "${tempdir}" && addCleanupTrapCmd "rm -rf ${tempdir}" && echo "${tempdir}"
 }
 
 isPermString()
@@ -379,7 +379,7 @@ findrev()
 {
   haystack="$1"
   needle="$2"
-  while [ "$haystack" != "" && "$haystack" != "/" && "$haystack" != "./" && ! -e "$haystack/$needle" ]; do
+  while [ "${haystack}" != "" ] && [ "${haystack}" != "/" ] && [ "${haystack}" != "./" ] && [ ! -e "${haystack}/${needle}" ]; do
     haystack=${haystack%/*}
   done
   echo "${haystack}"
@@ -436,8 +436,8 @@ mutexReq()
       [ ! "${lockedpid}" = "${mypid}" ] && [ ! "${lockedpid}" = "${PPID}" ]
     } && kill -0 "${lockedpid}" 2> /dev/null && echo "Aborting, Active process '${lockedpid}' holds the '$2' lock: '${mutex}'" && exit -1
   fi
-  addCleanupTrapCmd "rm -rf $mutex 2>/dev/null"
-  echo "$mypid" > $mutex
+  addCleanupTrapCmd "rm -rf ${mutex}"
+  echo "${mypid}" > ${mutex}
 }
 
 mutexFree()
@@ -494,11 +494,11 @@ mergeIntoSystem()
 
   [ -z "${rebaseusr}" ] && rebaseusr="usr/local"
 
-  currentDir="$PWD"
+  currentDir="${PWD}"
 
   printDebug "Calculating the offset path to store from root"
-  offset=$(dirname "${versioneddir#$rootfs/}")
-  version=$(basename "$versioneddir")
+  offset=$(dirname "${versioneddir#"${rootfs}"/}")
+  version=$(basename ${versioneddir})
   tmptime=$(date +%Y%m%d%H%M%S)
   processingDir="${rootfs}/tmp/zopen.${tmptime}"
   printDebug "Temporary processing dir evaluated to: ${processingDir}"
@@ -511,7 +511,7 @@ mergeIntoSystem()
   mv "${versioneddir}" "${virtualStore}"
 
   printDebug "Creating main linked directory in store"
-  cd "$virtualStore" && ln -s "$version" "$name"
+  cd "${virtualStore}" && ln -s "${version}" "${name}"
 
   printDebug "Creating virtual root directory structure"
   mkdir -p "${processingDir}/${rebaseusr}"
@@ -523,21 +523,21 @@ mergeIntoSystem()
   printDebug "Generating symlink tree"
 
   printDebug "Creating directory structure"
-  cd "$virtualStore/$name" || printError "Unable to change to virtual store at '$virtualStore/$name'"
-   # since 'ln *' doesn't invoke globbing to allow multiple files at once,
-   # abuse the Recurse option; this results in "already exists" errors but 
-   # ignore them as the first call should generate the correct link but 
-   # subsequent calls would generate a symlink that has incorrect dereferencing 
-   # and ignoring them is actually faster than individually creating the links!
+  cd "${virtualStore}/${name}" || printError "Unable to change to virtual store at '${virtualStore}/${name}'"
+  # since 'ln *' doesn't invoke globbing to allow multiple files at once,
+  # abuse the Recurse option; this results in "already exists" errors but
+  # ignore them as the first call should generate the correct link but
+  # subsequent calls would generate a symlink that has incorrect dereferencing
+  # and ignoring them is actually faster than individually creating the links!
   zosfind . -type d | sort -r | while read dir; do
-    dir=$(echo "$dir" | sed "s#^./##")
-    printDebug "Processing dir: $dir" 
-    [ $dir = "." ] && continue;
-    mkdir -p "$processingDir/$rebaseusr/$dir"
-    cd "$processingDir/$rebaseusr/$dir" || printError "Unable to change to processing directory '$processingDir/$rebaseusr/$dir'"
-    dirrelpath=$(relativePath2 "$virtualStore/$name/$dir" "$processingDir/$rebaseusr/$dir")
-    ln -Rs "$dirrelpath/" "." 2>/dev/null
-  done 
+    dir=$(echo "${dir}" | sed "s#^./##")
+    printDebug "Processing dir: ${dir}"
+    [ "${dir}" = "." ] && continue
+    mkdir -p "${processingDir}/${rebaseusr}/${dir}"
+    cd "${processingDir}/${rebaseusr}/${dir}" || printError "Unable to change to processing directory '${processingDir}/${rebaseusr}/${dir}'"
+    dirrelpath=$(relativePath2 "${virtualStore}/${name}/${dir}" "${processingDir}/${rebaseusr}/${dir}")
+    ln -Rs "${dirrelpath}/" "." 2> /dev/null
+  done
 
   printDebug "Moving unpaxed processing-directory back to main rootfs store."
   # this *must* be done before the merge step below or relative symlinks can't
@@ -550,11 +550,11 @@ mergeIntoSystem()
 
   printDebug "Generating intermediary tar file"
   # Need '-S' to allow long symlinks
-  cd "$processingDir" && tar -S -cf "$tarfile" "usr"
+  cd "${processingDir}" && tar -S -cf "${tarfile}" "usr"
 
   printDebug "Generating listing for remove processing (including main symlink)"
-  echo "Installed files:" > "$versioneddir/.links"
-  tar tf "$processingDir/$tarfile" 2>/dev/null| sort -r >> "$versioneddir/.links"
+  echo "Installed files:" > "${versioneddir}/.links"
+  tar tf "${processingDir}/${tarfile}" 2> /dev/null| sort -r >> "${versioneddir}/.links"
   
   printDebug "Extracting tar to rootfs"
   cd "${processingDir}" && tar xf "${tarfile}" -C "${rootfs}" 2> /dev/null
@@ -563,7 +563,7 @@ mergeIntoSystem()
   rm -rf "${processingDir}" 2> /dev/null
 
   printDebug "Switching to previous cwd - current work dir was purged"
-  cd "$currentDir" || printError "Unable to change to '$currentDir'"
+  cd "${currentDir}" || printError "Unable to change to '${currentDir}'"
 
   printInfo "- Integration complete."
   return 0
@@ -581,28 +581,28 @@ unsymlinkFromSystem()
   dotlinks=$3
   newfilelist=$4
 
-  if [ -e "$dotlinks" ]; then
-    printInfo "- Checking for obsoleted files in $rootfs/usr/ tree from $pkg"
+  if [ -e "${dotlinks}" ]; then
+    printInfo "- Checking for obsoleted files in ${rootfs}/usr/ tree from ${pkg}"
 
-    if [ -e "$newfilelist" ]; then
+    if [ -e "${newfilelist}" ]; then
       printDebug "Release change, so the list of changes to physically remove should be smaller"
       printDebug "Starting spinner..."
       progressHandler "spinner" "- Check complete" &
       ph=$!
-      killph="kill -HUP $ph"
-      addCleanupTrapCmd "$killph 2>/dev/null"
-      obsoleteList=$(diffFile "$dotlinks" "$newfilelist")
-      echo "$obsoleteList" | while read obsoleteFile; do
-        [ -z "$obsoleteFile" ] && return 0
-        obsoleteFile="$ZOPEN_ROOTFS/$obsoleteFile"
+      killph="kill -HUP ${ph} 2>/dev/null"
+      addCleanupTrapCmd "${killph}"
+      obsoleteList=$(diffFile "${dotlinks}" "${newfilelist}")
+      echo "${obsoleteList}" | while read obsoleteFile; do
+        [ -z "${obsoleteFile}" ] && return 0
+        obsoleteFile="${ZOPEN_ROOTFS}/${obsoleteFile}"
         obsoleteFile="${obsoleteFile%% symbolic*}"
-        printDebug "Checking obsoletefile '$obsoleteFile'"
-        if [ -L "$obsoleteFile" ] && [ ! -e "$obsoleteFile" ]; then
+        printDebug "Checking obsoletefile '${obsoleteFile}'"
+        if [ -L "${obsoleteFile}" ] && [ ! -e "${obsoleteFile}" ]; then
           # the linked-to file no longer exists (ie. the symlink is dangling)
-          rm -f "$obsoleteFile" >/dev/null 2>&1
+          rm -f "${obsoleteFile}" > /dev/null 2>&1
         fi 
       done
-      $killph 2>/dev/null  # if the timer is not running, the kill will fail
+      ${killph}  # if the timer is not running, the kill will fail
     else
       # Slower method needed to analyse each link to see if it has
       # become orphaned. Only relevent when removing a package as 
@@ -611,28 +611,28 @@ unsymlinkFromSystem()
       # Note that the contents of the links file are ordered such that
       # processing occurs depth-first; if, after removing orphaned symlinks,
       # a directory is empty, then it can be removed.
-      nfiles=$(sed '1d;$d' "$dotlinks" | wc -l  | tr -d ' ')
+      nfiles=$(sed '1d;$d' "${dotlinks}" | wc -l  | tr -d ' ')
   
       printDebug "Creating Temporary dirname file"
-      tempDirFile="$ZOPEN_ROOTFS/tmp/zopen.rmdir.$RANDOM"
-      tempTrash="$tempDirFile.trash"
-      [ -e "$tempDirFile" ] && rm -f "$tempDirFile" >/dev/null 2>&1
-      touch "$tempDirFile"
-      addCleanupTrapCmd "rm -rf $tempDirFile 2>/dev/null"
-      printDebug "Using temporary file $tempDirFile"
+      tempDirFile="${ZOPEN_ROOTFS}/tmp/zopen.rmdir.${RANDOM}"
+      tempTrash="${tempDirFile}.trash"
+      [ -e "${tempDirFile}" ] && rm -f "${tempDirFile}" >/dev/null 2>&1
+      touch "${tempDirFile}"
+      addCleanupTrapCmd "rm -rf ${tempDirFile} 2>/dev/null"
+      printDebug "Using temporary file ${tempDirFile}"
       printInfo "- Checking ${nfiles} potential links"
   
       rm_fileprocs=15
-      [ -e "$rootfs/etc/zopen/rm_fileprocs" ] && rm_fileprocs=$(cat "$rootfs/etc/zopen/rm_fileprocs")
+      [ -e "${rootfs}/etc/zopen/rm_fileprocs" ] && rm_fileprocs=$(cat "${rootfs}/etc/zopen/rm_fileprocs")
       threshold=$(( nfiles / rm_fileprocs))
       threshold=$(( threshold + 1 ))
-      printDebug "Threshold of files per worker [files/procs] calculated as: $threshold"
-      [ $threshold -le 50 ] && threshold=50 && printVerbose "Threshold below min: using 50" # Don't spawn too many
+      printDebug "Threshold of files per worker [files/procs] calculated as: ${threshold}"
+      [ ${threshold} -le 50 ] && threshold=50 && printVerbose "Threshold below min: using 50" # Don't spawn too many
       printDebug "Starting spinner..."
       progressHandler "spinner" "- Complete" &
       ph=$!
-      killph="kill -HUP $ph"
-      addCleanupTrapCmd "$killph 2>/dev/null"
+      killph="kill -HUP ${ph}"
+      addCleanupTrapCmd "${killph} 2>/dev/null"
   
       printDebug "Spawning as subshell to handle threading"
       # Note that this all must happen in a subshell as the above started
@@ -643,30 +643,30 @@ unsymlinkFromSystem()
         filenames=""
         while read filetounlink; do
           tid=$(( tid + 1 ))
-          filetounlink=$(echo "$filetounlink" | sed 's/\(.*\).symbolic.*/\1/')
-          filenames=$(/bin/printf "%s\n%s" "$filenames" "$filetounlink")
+          filetounlink=$(echo "${filetounlink}" | sed 's/\(.*\).symbolic.*/\1/')
+          filenames=$(/bin/printf "%s\n%s" "${filenames}" "${filetounlink}")
           if [ "$(( tid % threshold ))" -eq 0 ]; then
-            deletethread "$filenames" "$tempDirFile" &
+            deletethread "${filenames}" "${tempDirFile}" &
             printDebug "Started delete thread: $!"
             filenames=""
           fi
         done <<EOF
-$(sed '1d;$d' "$dotlinks")
+$(sed '1d;$d' "${dotlinks}")
 EOF
-        if [ -n "$filenames" ]; then
+        if [ -n "${filenames}" ]; then
           # Handle when there are not enough to trigger the threshold of a new thread above,
           # there will still be items in the "array"
-          deletethread "$filenames" "$tempDirFile" #&
+          deletethread "${filenames}" "${tempDirFile}" #&
           printDebug "Started delete thread: $!"
         fi
         wait 
       )
-      $killph 2>/dev/null  # if the timer is not running, the kill will fail
-      if [ -e "$tempDirFile" ]; then
-        ndirs=$(cat "$tempDirFile" | uniq | wc -l  | tr -d ' ')
+      ${killph} 2>/dev/null  # if the timer is not running, the kill will fail
+      if [ -e "${tempDirFile}" ]; then
+        ndirs=$(cat "${tempDirFile}" | uniq | wc -l  | tr -d ' ')
         printInfo "- Checking ${ndirs} dir links"
-        for d in $(cat "$tempDirFile" | uniq | sort -r) ; do 
-          [ -d "$d" ] && rmdir "$d" >/dev/null 2>&1
+        for d in $(cat "${tempDirFile}" | uniq | sort -r) ; do 
+          [ -d "${d}" ] && rmdir "${d}" >/dev/null 2>&1
         done
       fi
     fi
@@ -716,7 +716,7 @@ printDebug()
   if ${debug}; then
     printColors "${NC}${BLUE}${BOLD}:DEBUG:${NC}: '${1}'" >&2
   fi
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
@@ -726,7 +726,7 @@ printVerbose()
   if ${verbose}; then
     printColors "${NC}${GREEN}${BOLD}VERBOSE${NC}: ${1}" >&2
   fi
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
@@ -769,8 +769,8 @@ runLogProgress()
   addCleanupTrapCmd "${killph}"
   eval "$1"
   rc=$?
-  if [ ! -z "${SSH_TTY}" ]; then
-    chtag -r ${SSH_TTY}
+  if [ -n "${SSH_TTY}" ]; then
+    chtag -r "${SSH_TTY}"
   fi
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail
   return "${rc}"
@@ -848,11 +848,11 @@ runInBackgroundWithTimeoutAndLog()
     kill -0 "${PID}" 2> /dev/null
     if [ $? != 0 ]; then
       wait "${PID}"
-      if [ ! -z "${SSH_TTY}" ]; then
-        chtag -r ${SSH_TTY}
+      if [ -n "${SSH_TTY}" ]; then
+        chtag -r "${SSH_TTY}"
       fi
       rc=$?
-      return "${rc}"
+      return ${rc}
     else
       sleep 1
       n=$(expr ${n} + 1)
@@ -885,7 +885,7 @@ printWarning()
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "${NC}${WARNINGCOLOR}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
   [ -n "${xtrc}" ] && set -x
-  return 0
+  return 0;
 }
 
 printInfo()
@@ -893,7 +893,7 @@ printInfo()
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "$1" >&2
   [ -n "${xtrc}" ] && set -x
-  return 0
+  return 0;
 }
 
 # Used to input sensitive data - turns off echo to the screen for the input
@@ -905,14 +905,14 @@ getInputHidden()
   addCleanupTrapCmd "stty echo 2>/dev/null"
   stty -echo
   read zopen_input
-  echo ${zopen_input}
+  echo "${zopen_input}"
   stty echo
 }
 
 getInput()
 {
   read zopen_input
-  echo ${zopen_input}
+  echo "${zopen_input}"
 }
 
 printElapsedTime()
@@ -940,6 +940,7 @@ processConfig()
   if [ -z "${ZOPEN_ROOTFS}" ]; then
     relativeRootDir="$(cd "$(dirname "$0")/../.." > /dev/null 2>&1 && pwd -P)"
     if [ -f "${relativeRootDir}/etc/zopen-config" ]; then
+      # shellcheck source=/dev/null
       . "${relativeRootDir}/etc/zopen-config"
     else
       printError "Source the zopen-config prior to running $0."
@@ -956,7 +957,7 @@ checkIfConfigLoaded()
     errorMessage="Certificate at ${ZOPEN_CA} could not be accessed. Ensure zopen init has run and zopen-config has been sourced."
   fi
 
-  if [ ! -z "${errorMessage}" ]; then
+  if [ -n "${errorMessage}" ]; then
     if [ -r "${mydir}/../../../etc/zopen-config" ]; then
       relativeConfigDir="$(cd "$(dirname "${mydir}")/../../etc/" > /dev/null 2>&1 && pwd -P)"
       errorMessage="${errorMessage} Run '. ${relativeConfigDir}/zopen-config'  or add it to your .profile."
@@ -968,28 +969,28 @@ checkIfConfigLoaded()
 parseDeps()
 {
   dep="$1"
-  version=$(echo ${dep} | awk -F '[>=<]+' '{print $2}')
+  version=$(echo "${dep}" | awk -F '[>=<]+' '{print $2}')
   if [ -z "${version}" ]; then
     operator=""
-    dep=$(echo ${dep} | awk -F '[>=<]+' '{print $1}')
+    dep=$(echo "${dep}" | awk -F '[>=<]+' '{print $1}')
   else
-    operator=$(echo ${dep} | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
-    dep=$(echo ${dep} | awk -F '[>=<]+' '{print $1}')
+    operator=$(echo "${dep}" | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
+    dep=$(echo "${dep}" | awk -F '[>=<]+' '{print $1}')
     case ${operator} in
     ">=") ;;
     "=") ;;
     *) printError "${operator} is not supported." ;;
     esac
-    major=$(echo ${version} | awk -F. '{print $1}')
-    minor=$(echo ${version} | awk -F. '{print $2}')
+    major=$(echo "${version}" | awk -F. '{print $1}')
+    minor=$(echo "${version}" | awk -F. '{print $2}')
     if [ -z "${minor}" ]; then
       minor=0
     fi
-    patch=$(echo ${version} | awk -F. '{print $3}')
+    patch=$(echo "${version}" | awk -F. '{print $3}')
     if [ -z "${patch}" ]; then
       patch=0
     fi
-    prerelease=$(echo ${version} | awk -F. '{print $4}')
+    prerelease=$(echo "${version}" | awk -F. '{print $4}')
     if [ -z "${prerelease}" ]; then
       prerelease=0
     fi
@@ -1036,6 +1037,7 @@ validateVersion()
   if [ -n "${operator}" ] && [ -z "${version}" ]; then
     printVerbose "${operator} ${requestedVersion} requested, but no version file found in ${versionPath}"
     return 1
+  elif [ -n "${operator}" ] && ! compareVersions "${version}" "${requestedVersion}"; then
   elif [ -n "${operator}" ] && ! compareVersions "${version}" "${requestedVersion}"; then
     printVerbose "${dependency} does not satisfy ${version} ${operator} ${requestedVersion}"
     return 1
@@ -1149,8 +1151,8 @@ getAllReleasesFromGithub()
 
 initDefaultEnvironment()
 {
-  export ZOPEN_OLD_PATH=${PATH}       # Preserve PATH in case scripts need to access it
-  export ZOPEN_OLD_LIBPATH=${LIBPATH} # Preserve LIBPATH in case scripts need to access it
+  export ZOPEN_OLD_PATH="${PATH}"     # Preserve PATH in case scripts need to access it
+  export ZOPEN_OLD_LIBPATH="${LIBPATH}" # Preserve LIBPATH in case scripts need to access it
   export PATH="$(getconf PATH)"
   export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
   unset MANPATH
@@ -1171,138 +1173,137 @@ checkWritable()
   fi
   ROOTDIR="$(cd "${INCDIR}/../" > /dev/null 2>&1 && pwd -P)"
   if ! [ -w "${ROOTDIR}" ]; then
-    printError "Tools distribution is read-only. Cannot run update operation '${ME}'." >&2
+    printError "Tried to run an update operation (${ME}) in a read-only tools distribution" >&2
   fi
 }
 
 installDependencies()
 (
   name=$1
-  printVerbose "List of dependencies to install: $dependencies"
-  skipupgrade_lcl=$skipupgrade
+  printVerbose "List of dependencies to install: ${dependencies}"
+  skipupgrade_lcl=${skipupgrade}
   skipupgrade=true
-  echo "$dependencies" | xargs | tr ' ' '\n' | sort | while read dep; do
-    printDebug "Removing '$dep' from dependency queue '$dependencies'"
+  echo "${dependencies}" | xargs | tr ' ' '\n' | sort | while read dep; do
+    printDebug "Removing '${dep}' from dependency queue '${dependencies}'"
     # done in case of dependency chain that specifies the same dependency more than once!
-    dependencies=$(echo "$dependencies" | sed -e "s/$dep//" | tr -s ' ')
+    dependencies=$(echo "${dependencies}" | sed -e "s/${dep}//" | tr -s ' ')
     printDebug "Checking if package already installed this session"
-    alreadyInstalled=$(echo "$sessionList" | sed -e "s/.*\($dep\).*//")
-    if [ -z "$alreadyInstalled" ]; then
-      handlePackageInstall "$dep"
+    alreadyInstalled=$(echo "${sessionList}" | sed -e "s/.*\(${dep}\).*//")
+    if [ -z "${alreadyInstalled}" ]; then
+      handlePackageInstall "${dep}"
     else
-      printDebug "Package '$dep' installed earlier; no install required"
+      printDebug "Package '${dep}' installed earlier; no install required"
     fi
   done
-  skipupgrade=$skipupgrade_lcl
+  skipupgrade=${skipupgrade_lcl}
 )
 
 handlePackageInstall(){
   printDebug "Checking whether installing direct from pax files or via Github repo"
-  if ! $paxinstall; then
+  if ! ${paxinstall}; then
     printDebug "Using standard Github repo"
     fullname="$1"
-    printDebug "Name to install: $fullname, parsing any version ('=') or tag ('%') has been specified"
-    name=$(echo "$fullname" | sed -e 's#[=%].*##')
+    printDebug "Name to install: ${fullname}, parsing any version ('=') or tag ('%') has been specified"
+    name=$(echo "${fullname}" | sed -e 's#[=%].*##')
     repo="${name}"
-    versioned=$(echo "$fullname" | cut -s -d '=' -f 2)
-    tagged=$(echo "$fullname" | cut -s -d '%' -f 2)
-    printDebug "Name:$name;version:$versioned;tag:$tagged;repo:$repo"
-    printHeader "Installing package: $name"
-    [ -z "$paxrepodir" ] && getAllReleasesFromGithub "${repo}"
+    versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
+    tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
+    printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
+    printHeader "Installing package: ${name}"
+    [ -z "${paxrepodir}" ] && getAllReleasesFromGithub "${repo}"
   else 
     printDebug "Using native pax files to install"
     reponame="$1"
-    if [ "$reponame" = "${reponame%%.zos.pax.Z}" ]; then
+    if [ "${reponame}" = "${reponame%%.zos.pax.Z}" ]; then
       printDebug "Package did not have .zos.pax.Z suffix - attempt to locate suitable pax"
 
       printDebug "Check [in order] cli paxrootdir -> system paxrootdir -> current dir for repo to check"
       testpaxRepo=""
-      [ -n "$paxrepodir" ] && testpaxRepo="$paxrepodir"
-      [ -n "$testpaxRepo" ] && [ ! -r "$testpaxRepo" ] && printError "Could not access location '$testpaxRepo' from parameter --paxrepodir. Check parameter setting and retry command"
-      [ -z "$testpaxRepo" ] && [ -e "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ] && tespaxRepo=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
-      [ -n "$testpaxRepo" ] && [ ! -r "$testpaxRepo" ] && printError "Unable to read system repository at location '$tespaxRepo'. Correct system setting in '$ZOPEN_ROOTFS/etc/zopen/paxrepodir' and retry command"
-      [ -z "$testpaxRepo" ] && testpaxRepo="./"
-      prefix="$reponame-" 
-      printDebug "Finding paxes prefixed '$prefix' in '$testpaxRepo'"
+      [ -n "${paxrepodir}" ] && testpaxRepo="${paxrepodir}"
+      [ -n "${testpaxRepo}" ] && [ ! -r "${testpaxRepo}" ] && printError "Could not access location '${testpaxRepo}' from parameter --paxrepodir. Check parameter setting and retry command"
+      [ -z "${testpaxRepo}" ] && [ -e "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir" ] && tespaxRepo=$(cat "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir")
+      [ -n "${testpaxRepo}" ] && [ ! -r "${testpaxRepo}" ] && printError "Unable to read system repository at location '${tespaxRepo}'. Correct system setting in '${ZOPEN_ROOTFS}/etc/zopen/paxrepodir' and retry command"
+      [ -z "${testpaxRepo}" ] && testpaxRepo="./"
+      prefix="${reponame}-" 
+      printDebug "Finding paxes prefixed '${prefix}' in '${testpaxRepo}'"
       # Note, not cd'ing to dir means we get full pax name - need the "/" at the end though
       #(heads -1 or tails -1 - need to test multiple pax for install)
-      paxRepo=$(zosfind "${testpaxRepo%%/}/" ! -name "${testpaxRepo%%/}/" -prune -a -type f |grep "$prefix" |sort|tail -n 1)
-      printVerbose "Found pax '$paxRepo' as candidate for install for package '$reponame'"
+      paxRepo=$(zosfind "${testpaxRepo%%/}/" ! -name "${testpaxRepo%%/}/" -prune -a -type f |grep "${prefix}" |sort|tail -n 1)
+      printVerbose "Found pax '${paxRepo}' as candidate for install for package '${reponame}'"
     else
       printDebug "Parameter passed in had suffix indicating pax file; try to locate file..."
-      if [ -r "$reponame" ]; then
-        printVerbose "Found file at location specified '$reponame'; using as-is"
-        paxRepo="$reponame"
+      if [ -r "${reponame}" ]; then
+        printVerbose "Found file at location specified '${reponame}'; using as-is"
+        paxRepo="${reponame}"
       else
         printDebug "Attempt to locate rpm file in current directory or in configured locations [if set]"
-        paxfilename=$(basename "$reponame") 
-        printDebug "Checking current directory '$PWD'"
-        testpaxRepo="./$paxfilename"
-        if [ -r "$testpaxRepo" ]; then
-          printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-          paxRepo="$testpaxRepo"
-        elif [ -n "$paxrepodir" ]; then
-          printVerbose "Using repository '$paxrepodir' as specified on cli"
-          testpaxRepo="$paxrepodir/$paxfilename"
-          if [ -r "$testpaxRepo" ]; then
-            printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-            paxRepo="$testpaxRepo"
+        paxfilename=$(basename "${reponame}") 
+        printDebug "Checking current directory '${PWD}'"
+        testpaxRepo="./${paxfilename}"
+        if [ -r "${testpaxRepo}" ]; then
+          printVerbose "Found ${paxfilename} as '${testpaxRepo}'; installing"
+          paxRepo="${testpaxRepo}"
+        elif [ -n "${paxrepodir}" ]; then
+          printVerbose "Using repository '${paxrepodir}' as specified on cli"
+          testpaxRepo="${paxrepodir}/${paxfilename}"
+          if [ -r "${testpaxRepo}" ]; then
+            printVerbose "Found ${paxfilename} as '${testpaxRepo}'; installing"
+            paxRepo="${testpaxRepo}"
           fi
-        elif [ -e "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ]; then
-          printDebug "Using [single] repository specified from system config '$ZOPEN_ROOTFS/etc/zopen/paxrepodir'"
-          paxrepodir=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
-          printVerbose "Trying repository at system configured location '$repodir'"
-          testpaxRepo="$paxrepodir/$paxfilename"
-          if [ -r "$testpaxRepo" ]; then
-            printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-            paxRepo="$testpaxRepo"
+        elif [ -e "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir" ]; then
+          printDebug "Using [single] repository specified from system config '${ZOPEN_ROOTFS}/etc/zopen/paxrepodir'"
+          paxrepodir=$(cat "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir")
+          printVerbose "Trying repository at system configured location '${repodir}'"
+          testpaxRepo="${paxrepodir}/${paxfilename}"
+          if [ -r "${testpaxRepo}" ]; then
+            printVerbose "Found ${paxfilename} as '${testpaxRepo}'; installing"
+            paxRepo="${testpaxRepo}"
           fi
-#          paxlist=$(cd "$paxrepodir" | zosfind "." -type f -name "*$fullname-*zos.pax.Z")
         else
-          printError "Cannot locate specified pax file '$reponame' to install. Validate filename, repository or permissions and retry request"
+          printError "Cannot locate specified pax file '${reponame}' to install. Validate filename, repository or permissions and retry request"
         fi
       fi
     fi
 
-    [ -z "$paxRepo" ] && printError "Could not locate pax file for '$reponame'. Validate filename, repository or permissions and retry request."      
-    printDebug "Installing a custom-repo pax '$paxRepo', need to find and break it open and get the metadata first"
+    [ -z "${paxRepo}" ] && printError "Could not locate pax file for '${reponame}'. Validate filename, repository or permissions and retry request."      
+    printDebug "Installing a custom-repo pax '${paxRepo}', need to find and break it open and get the metadata first"
     tmptime=$(date +%Y%m%d%H%M%S)
-    tmpUnpaxDir="$rootfs/tmp/zopen.$tmptime"
-    printVerbose "Temporary processing dir evaluated to: $tmpUnpaxDir"
-    [ -e "$tmpUnpaxDir" ] && rm -rf "$tmpUnpaxDir"
-    mkdir -p "$tmpUnpaxDir" >/dev/null 2>&1
-    #addCleanupTrapCmd "rm -rf $tmpUnpaxDir"
-    paxredirect="-s %[^/]*/%$tmpUnpaxDir/%"
+    tmpUnpaxDir="${rootfs}/tmp/zopen.${tmptime}"
+    printVerbose "Temporary processing dir evaluated to: ${tmpUnpaxDir}"
+    [ -e "${tmpUnpaxDir}" ] && rm -rf "${tmpUnpaxDir}"
+    mkdir -p "${tmpUnpaxDir}" >/dev/null 2>&1
+    #addCleanupTrapCmd "rm -rf ${tmpUnpaxDir}"
+    paxredirect="-s %[^/]*/%${tmpUnpaxDir}/%"
     
-    if ! runLogProgress "pax -rf $paxRepo -p p $paxredirect ${redirectToDevNull} " "Expanding $paxRepo" "Expanded"; then
-      printError "Errors unpaxing '$paxRepo'"
+    if ! runLogProgress "pax -rf ${paxRepo} -p p ${paxredirect} ${redirectToDevNull} " "Expanding ${paxRepo}" "Expanded"; then
+      printError "Errors unpaxing '${paxRepo}'"
       continue;
     fi
     printDebug "Checking pax for metadata file(s): README.md"
 
     printDebug "Attempting to calculate package name..."
-    if [ -r "$tmpUnpaxDir/README.md" ]; then
+    if [ -r "${tmpUnpaxDir}/README.md" ]; then
       printDebug "Found README.md - first line *might* be package title"
-      name=$(head -1 "$tmpUnpaxDir/README.md" | awk '{print $NF}')
+      name=$(head -1 "${tmpUnpaxDir}/README.md" | awk '{print $NF}')
     fi
-    if [ -z "$name" ]; then 
+    if [ -z "${name}" ]; then 
         # Fallback to pax file name
         name=$(basename "${paxRepo%%-*}")
-        printVerbose "Using '$name' as package name"
+        printVerbose "Using '${name}' as package name"
     fi
     name="${name%port}"
-    [ -z "$name" ] && printError "Could not determine package name from pax file metadata"
-    printVerbose "Using '$name' as package name"    
+    [ -z "${name}" ] && printError "Could not determine package name from pax file metadata"
+    printVerbose "Using '${name}' as package name"    
 
-    printDebug "Copying specified pax '$paxRepo' for package '$name' into correct location for install '$downloadDir'"
-    downloadFile=$(basename "$paxRepo")
+    printDebug "Copying specified pax '${paxRepo}' for package '${name}' into correct location for install '${downloadDir}'"
+    downloadFile=$(basename "${paxRepo}")
     # if already exits, skip copy
-    [ ! -e "$downloadDir/$downloadFile" ] && cp -R "$paxRepo" "$downloadDir"
+    [ ! -e "${downloadDir}/${downloadFile}" ] && cp -R "${paxRepo}" "${downloadDir}"
   fi
 
-  if $localInstall; then
+  if ${localInstall}; then
     printDebug "Local install to current directory"
-    rootInstallDir="$PWD"
+    rootInstallDir="${PWD}"
   else
     printDebug "Setting install root to: ${ZOPEN_PKGINSTALL}"
     rootInstallDir="${ZOPEN_PKGINSTALL}"
@@ -1312,10 +1313,10 @@ handlePackageInstall(){
   printDebug "Finding version/release information"
   if [ -e "${rootInstallDir}/${name}/${name}/.releaseinfo" ]; then
     originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.releaseinfo")
-    printDebug "Found originalFileVersion=$originalFileVersion (port is already installed)"
+    printDebug "Found originalFileVersion=${originalFileVersion} (port is already installed)"
   elif [ -e "${rootInstallDir}/${name}/${name}/.version" ]; then
     originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.version")
-    printDebug "Found originalFileVersion=$originalFileVersion (port is already installed)"
+    printDebug "Found originalFileVersion=${originalFileVersion} (port is already installed)"
   else
     printDebug "Could not detect existing installation at ${rootInstallDir}/${name}/${name}"
   fi
@@ -1324,91 +1325,91 @@ handlePackageInstall(){
   installedReleaseLine=""
   if [ -e "${rootInstallDir}/${name}/${name}/.releaseline" ]; then
     installedReleaseLine=$(cat "${rootInstallDir}/${name}/${name}/.releaseline")
-    printVerbose "Installed product from releaseline: $installedReleaseLine"
+    printVerbose "Installed product from releaseline: ${installedReleaseLine}"
   else
     printVerbose "No current releaseline for package"
   fi
   
   printDebug "Checking whether installing direct from a pax [from a custom repo]"
-  if ! $paxinstall; then
+  if ! ${paxinstall}; then
     releasemetadata=""
     downloadURL=""
     # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
     # either for a previous package install or system default
-    if [ ! "x" = "x$versioned" ]; then
-      printDebug "Specific version $versioned requested - checking existence and URL"
-      requestedMajor=$(echo "$versioned" | awk -F'.' '{print $1}')
-      requestedMinor=$(echo "$versioned" | awk -F'.' '{print $2}')
-      requestedPatch=$(echo "$versioned" | awk -F'.' '{print $3}')
-      requestedSubrelease=$(echo "$versioned" | awk -F'.' '{print $4}')
+    if [ ! "x" = "x${versioned}" ]; then
+      printDebug "Specific version ${versioned} requested - checking existence and URL"
+      requestedMajor=$(echo "${versioned}" | awk -F'.' '{print $1}')
+      requestedMinor=$(echo "${versioned}" | awk -F'.' '{print $2}')
+      requestedPatch=$(echo "${versioned}" | awk -F'.' '{print $3}')
+      requestedSubrelease=$(echo "${versioned}" | awk -F'.' '{print $4}')
       requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
-      printDebug "Finding URL for latest release matching version prefix: requestedVersion: $requestedVersion"
-      releasemetadata=$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.assets[].name | test("'$requestedVersion'")))[0]')
-    elif [ ! "x" = "x$tagged" ]; then
-      printDebug "Explicit tagged version '$tagged' specified. Checking for match"
-      releaseMetadata=$(/bin/printf "%s" "$releases" | jq -e -r '.[] | select(.tag_name == "'$tagged'")')
+      printDebug "Finding URL for latest release matching version prefix: requestedVersion: ${requestedVersion}"
+      releasemetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.assets[].name | test("'${requestedVersion}'")))[0]')
+    elif [ ! "x" = "x${tagged}" ]; then
+      printDebug "Explicit tagged version '${tagged}' specified. Checking for match"
+      releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '.[] | select(.tag_name == "'${tagged}'")')
       printDebug "Use quick check for asset to check for existence of metadata for specific messages"
-      asset=$(/bin/printf "%s" "$releaseMetadata" | jq -e -r '.assets[0]')
+      asset=$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')
       if [ $? -ne 0 ]; then
-        printError "Could not find release tagged '$tagged' in repo '$repo'"
+        printError "Could not find release tagged '${tagged}' in repo '${repo}'"
       fi
-    elif $selectVersion; then
+    elif ${selectVersion}; then
       # Explicitly allow the user to select a release to install; useful if there are broken installs
       # as a known good release can be found, selected and pinned!
       printDebug "List individual releases and allow selection"
-      i=$(/bin/printf "%s" "$releases" | jq -r 'length - 1')
+      i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
       printInfo "Versions available for install:"
-      /bin/printf "%s" "$releases" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
+      /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
   
       printDebug "Getting user selection"
       valid=false
-      while ! $valid; do
-        echo "Enter version to install (0-$i): "
+      while ! ${valid}; do
+        echo "Enter version to install (0-${i}): "
         read selection < /dev/tty
-        if [[ ! -z $(echo "$selection" | sed -e 's/[0-9]*//') ]]; then
-          echo "Invalid input, must be a number between 0 and $i"
-        elif [ "$selection" -ge 0 ] && [ "$selection" -le "$i" ]; then
+        if [ ! -z $(echo "${selection}" | sed -e 's/[0-9]*//') ]; then
+          echo "Invalid input, must be a number between 0 and ${i}"
+        elif [ "${selection}" -ge 0 ] && [ "${selection}" -le "${i}" ]; then
           valid=true
         fi
       done
-      printVerbose "Selecting item $selection from array"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[$selection]")"
+      printVerbose "Selecting item ${selection} from array"
+      releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[${selection}]")"
   
-    elif [ ! -z "$releaseLine" ]; then  
-      printDebug "Install from release line '$releaseLine' specified"
-      validatedReleaseLine=$(validateReleaseLine "$releaseLine")
-      if [ -z "$validatedReleaseLine" ]; then
-        printError "Invalid releaseline specified: '$releaseLine'; Valid values: DEV or STABLE"
+    elif [ -n "${releaseLine}" ]; then  
+      printDebug "Install from release line '${releaseLine}' specified"
+      validatedReleaseLine=$(validateReleaseLine "${releaseLine}")
+      if [ -z "${validatedReleaseLine}" ]; then
+        printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE"
       fi
       printDebug "Finding latest asset on the release line"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$releaseLine'")))[0]')"
+      releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${releaseLine}'")))[0]')"
       printDebug "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
+      asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
       if [ $? -ne 0 ]; then
-        printError "Could not find release-line $releaseLine for repo: $repo"
+        printError "Could not find release-line ${releaseLine} for repo: ${repo}"
       fi
       
     else
       printDebug "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
-      if [ -n "$installedReleaseLine" ]; then
-        printDebug "Found existing releaseline '$installedReleaseLine', restricting to only that releaseline"
-        validatedReleaseLine="$installedReleaseLine"  # Already validated when stored
+      if [ -n "${installedReleaseLine}" ]; then
+        printDebug "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline"
+        validatedReleaseLine="${installedReleaseLine}"  # Already validated when stored
       else 
         printDebug "Checking for system-configured releaseline"
-        sysrelline=$(cat "$ZOPEN_ROOTFS/etc/zopen/releaseline" | awk ' {print toupper($1)}')
-        printDebug "Validating value: $sysrelline"
-        validatedReleaseLine=$(validateReleaseLine "$sysrelline")
-        if [ -n "$validatedReleaseLine" ]; then
-          printDebug "zopen system configured to use releaseline '$sysrelline'; restricting to that releaseline"
+        sysrelline=$(cat "${ZOPEN_ROOTFS}/etc/zopen/releaseline" | awk ' {print toupper($1)}')
+        printDebug "Validating value: ${sysrelline}"
+        validatedReleaseLine=$(validateReleaseLine "${sysrelline}")
+        if [ -n "${validatedReleaseLine}" ]; then
+          printDebug "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline"
         else
-          printWarning "zopen misconfigured to use an unknown releaseline of '$sysrelline'; defaulting to STABLE packages"
-          printWarning "Set the contents of '$ZOPEN_ROOTFS/etc/zopen/releaseline' to a valid value to remove this message"
+          printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages"
+          printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message"
           printWarning "Valid values are: DEV | STABLE"
           validatedReleaseLine="STABLE"
         fi
       fi
 
-      printDebug "Parsing releases: $releases"
+      printDebug "Parsing releases: ${releases}"
       # We have some situations that could arise
         # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
         # 2. system is configured for STABLE but only has DEV stream available
@@ -1417,115 +1418,115 @@ handlePackageInstall(){
         # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
         # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
         # then that specific releaseline will be used
-      printDebug "Finding any releases tagged with $validatedReleaseLine and getting the first (newest/latest)"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$validatedReleaseLine'")))[0]')"
+      printDebug "Finding any releases tagged with ${validatedReleaseLine} and getting the first (newest/latest)"
+      releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${validatedReleaseLine}'")))[0]')"
       printDebug "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
+      asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
       if [ $? -eq 0 ]; then
         # Case 4...
-        printVerbose "Found a specific '$validatedReleaseLine' release-line tagged version; installing..."
+        printVerbose "Found a specific '${validatedReleaseLine}' release-line tagged version; installing..."
       else
         # Case 2 & 3
-        printDebug "No releases on releaseline '$validatedReleaseLine'; checking alternative releaseline"
-        alt=$(echo "$validatedReleaseLine" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
-        releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$alt'")))[0]')"
+        printDebug "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline"
+        alt=$(echo "${validatedReleaseLine}" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
+        releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${alt}'")))[0]')"
         printDebug "Use quick check for asset to check for existence of metadata"
-        asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
+        asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
         if [ $? -eq 0 ]; then
-          printDebug "Found a release on the '$alt' release line so release tagging is active"
-          if [ "DEV" = "$validatedReleaseLine" ]; then
+          printDebug "Found a release on the '${alt}' release line so release tagging is active"
+          if [ "DEV" = "${validatedReleaseLine}" ]; then
             # The system will be configured to use DEV packages where available but if none, use latest
             printInfo "No specific DEV releaseline package, using latest available"
-            releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
+            releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
           else
             printVerbose "The system is configured to only use STABLE releaseline packages but there are none"
-            printInfo "No release available on the '$validatedReleaseLine' releaseline."
+            printInfo "No release available on the '${validatedReleaseLine}' releaseline."
           fi
         else
           # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
           printVerbose "Installing latest release"
-          releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
+          releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
         fi
       fi
     fi
-    printDebug "Getting specific asset details from metadata: $releasemetadata"
-    if [ -z "$asset" ] || [ "null" = "$asset" ]; then
+    printDebug "Getting specific asset details from metadata: ${releasemetadata}"
+    if [ -z "${asset}" ] || [ "null" = "${asset}" ]; then
       printDebug "Asset not found during previous logic; setting now"
-      asset=$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')
+      asset=$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')
     fi
-    if [ "x" = "x$asset" ]; then
+    if [ "x" = "x${asset}" ]; then
       printError "Unable to determine download asset for ${name}"
     fi
   
-    tagname=$(/bin/printf "%s" "$releasemetadata" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
-    installedReleaseLine=$(validateReleaseLine "$tagname" )
+    tagname=$(/bin/printf "%s" "${releasemetadata}" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
+    installedReleaseLine=$(validateReleaseLine "${tagname}" )
   
-    downloadURL=$(/bin/printf "%s" "$asset" | jq -e -r '.url')
-    size=$(/bin/printf "%s" "$asset" | jq -e -r '.expanded_size')
+    downloadURL=$(/bin/printf "%s" "${asset}" | jq -e -r '.url')
+    size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
   
-    if [ "x" = "x$downloadURL" ]; then
+    if [ "x" = "x${downloadURL}" ]; then
       printError "Unable to determine download location for ${name}"
     fi
-    downloadFile=$(basename "$downloadURL")
-    downloadFileVer=$(echo "$downloadFile" |sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
-    printVerbose "Downloading port from URL: $downloadURL to file: $downloadFile (ver=$downloadFileVer)"
+    downloadFile=$(basename "${downloadURL}")
+    downloadFileVer=$(echo "${downloadFile}" |sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
+    printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
   else
-    printVerbose "Installing package '$name' from pax file '$paxRepo'"
-    printDebug "Pax was expanded to '$tmpUnpaxDir' previously"
+    printVerbose "Installing package '${name}' from pax file '${paxRepo}'"
+    printDebug "Pax was expanded to '${tmpUnpaxDir}' previously"
     downloadFilePrfx="${paxRepo%.zos.pax.Z}"
     downloadFileVer="${downloadFilePrfx##*-}"
-    size=$(du -s "$tmpUnpaxDir" | awk ' {print $1}') # in 512-blocks
-    [ -z "$size" ] && printError "Could not calculate directory size"
-    size=$(echo "$size * 512" | bc)
+    size=$(du -s "${tmpUnpaxDir}" | awk ' {print $1}') # in 512-blocks
+    [ -z "${size}" ] && printError "Could not calculate directory size"
+    size=$(echo "${size} * 512" | bc)
   fi
 
-  if $downloadOnly; then
+  if ${downloadOnly}; then
     printVerbose "Skipping installation, downloading only"
   else
     printDebug "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
     if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
-      if ! $reinstall; then
+      if ! ${reinstall}; then
         printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC}"
         return;
       fi
-      printInfo "- Reinstalling version '$downloadFileVer' of ${name}..."
+      printInfo "- Reinstalling version '${downloadFileVer}' of ${name}..."
     fi
 
     printDebug "Checking if package is not installed but scheduled for upgrade"
-    if [ "x" = "x$originalFileVersion" ]; then
+    if [ "x" = "x${originalFileVersion}" ]; then
       printDebug "No previous version found"
-      if $installOrUpgrade; then
+      if ${installOrUpgrade}; then
         printDebug "Package ${name} was not installed so not upgrading but installing"
-      elif $upgradeInstalled; then
+      elif ${upgradeInstalled}; then
         printError "Package ${name} can not be upgraded as it is not installed!"
         continue;
       fi
       unInstallOldVersion=false
       printInfo "- Installing ${name}..."
-    elif $skipupgrade; then
+    elif ${skipupgrade}; then
       printInfo "Package ${name} has a newer release '${downloadFileVer}' but explicitly skipping"
       continue;
-    elif ! $setactive; then
+    elif ! ${setactive}; then
       printVerbose "Current version '${originalFileVersion}' will remain active"
       unInstallOldVersion=false
     else
       printVerbose "Previous version '${originalFileVersion}' installed"
       if [ -e "${rootInstallDir}/${name}/${name}/.pinned" ]; then
         printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped"
-        syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_PACKAGE,$CAT_INSTALL" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped"
+        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_INSTALL}" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped"
         continue;
       else
         printInfo "- Replacing ${name} version '${originalFileVersion}' with '${downloadFileVer}'"
         unInstallOldVersion=true
-        currentversiondir=$(cd "$rootInstallDir/$name/${name}" && pwd -P)
-        currentlinkfile="$currentversiondir/.links"
+        currentversiondir=$(cd "${rootInstallDir}/${name}/${name}" && pwd -P)
+        currentlinkfile="${currentversiondir}/.links"
       fi
     fi
   fi
   printDebug "Ensuring we are in the correct working download location '${downloadDir}'"
   cd "${downloadDir}" || printError "Unable to change to download directory '${downloadDir}'"
 
-  if [ ! $downloadOnly ] || [ ! $localInstall ]; then
+  if [ ! ${downloadOnly} ] || [ ! ${localInstall} ]; then
     printDebug "Checking current directory for already downloaded package [file name comparison]"
     location="current directory"
   else
@@ -1533,59 +1534,59 @@ handlePackageInstall(){
     location="zopen package cache"
   fi
 
-  pax=$downloadFile
-  if [ -f "$pax" ]; then
+  pax=${downloadFile}
+  if [ -f "${pax}" ]; then
     printVerbose "- Found existing file '${pax}' in ${location}"
   else
-    printInfo "- Downloading $pax file from remote to ${location}..."
-    if ! $verbose; then
+    printInfo "- Downloading ${pax} file from remote to ${location}..."
+    if ! ${verbose}; then
       redirectToDevNull="2>/dev/null"
     fi
 
-    progressHandler "network" "- Downloaded $pax file from remote to ${location}." &
+    progressHandler "network" "- Downloaded ${pax} file from remote to ${location}." &
     ph=$!
-    killph="kill -HUP $ph"
-    addCleanupTrapCmd "$killph"
+    killph="kill -HUP ${ph} 2>/dev/null"
+    addCleanupTrapCmd "${killph}"
 
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
       printError "Could not download from ${downloadURL}. Correct any errors and potentially retry"
       continue;
     fi
-    $killph 2>/dev/null  # if the timer is not running, the kill will fail
-    syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_NETWORK,$CAT_PACKAGE,$CAT_FILE" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '$pax'"
+    ${killph}  # if the timer is not running, the kill will fail
+    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_NETWORK},${CAT_PACKAGE},${CAT_FILE}" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '${pax}'"
   fi
   if [ ! -f "${pax}" ]; then
     printError "${pax} was not found after download!?!"
   fi
 
-  if $downloadOnly; then
-    printVerbose "Pax was downloaded to local dir '$downloadDir'"
-  elif $cacheOnly; then
-    printVerbose "Pax was downloaded to zopen cache '$downloadDir'"
+  if ${downloadOnly}; then
+    printVerbose "Pax was downloaded to local dir '${downloadDir}'"
+  elif ${cacheOnly}; then
+    printVerbose "Pax was downloaded to zopen cache '${downloadDir}'"
   else
-    printDebug "Installing $pax"
+    printDebug "Installing ${pax}"
     installdirname="${name}/${pax%.pax.Z}" # Use full pax name as default
 
-    printVerbose "- Processing $pax..."
+    printVerbose "- Processing ${pax}..."
     baseinstalldir="."
     paxredirect=""
-    if ! $localInstall; then
-      baseinstalldir="$rootInstallDir"
-      paxredirect="-s %[^/]*/%$rootInstallDir/$installdirname/%"
-      printDebug "Non-local install, extracting with '$paxredirect'"
+    if ! ${localInstall}; then
+      baseinstalldir="${rootInstallDir}"
+      paxredirect="-s %[^/]*/%${rootInstallDir}/${installdirname}/%"
+      printDebug "Non-local install, extracting with '${paxredirect}'"
     else
       printVerbose "- Local install specified"
-      paxredirect="-s %[^/]*/%$installdirname/%"
-      printDebug "Non-local install, extracting with '$paxredirect'"
+      paxredirect="-s %[^/]*/%${installdirname}/%"
+      printDebug "Non-local install, extracting with '${paxredirect}'"
     fi
 
-    megabytes=$(echo "scale=2; $size / (1024 * 1024)" | bc)
-    printInfo "After this operation, $megabytes MB of additional disk space will be used."
-    if ! $yesToPrompts; then
+    megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
+    printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
+    if ! ${yesToPrompts}; then
       while true; do
         printInfo "Do you want to continue? [y/n/a]"
         read continueInstall < /dev/tty
-        case "$continueInstall" in
+        case "${continueInstall}" in
           "y") break;;
           "n") mutexFree "zopen" && printInfo "Exiting..." && exit 0 ;;
           "a") yesToPrompts=true; break;;
@@ -1594,94 +1595,94 @@ handlePackageInstall(){
       done
     fi
 
-    printDebug "Check for existing directory for version '$installdirname'"
-    if [ -d "$baseinstalldir/$installdirname" ]; then 
+    printDebug "Check for existing directory for version '${installdirname}'"
+    if [ -d "${baseinstalldir}/${installdirname}" ]; then 
       printVerbose "- Clearing existing directory and contents"
-      rm -rf "$baseinstalldir/$installdirname"
+      rm -rf "${baseinstalldir}/${installdirname}"
     fi
 
-    if  ! $paxinstall; then
-      if ! runLogProgress "pax -rf $pax -p p $paxredirect ${redirectToDevNull}" "Expanding $pax" "Expanded"; then
+    if  ! ${paxinstall}; then
+      if ! runLogProgress "pax -rf ${pax} -p p ${paxredirect} ${redirectToDevNull}" "Expanding ${pax}" "Expanded"; then
         printWarning "Errors unpaxing, package directory state unknown"
         printInfo    "Use zopen alt to select previous version to ensure known state"
         continue;
       fi
     else
       printVerbose "Moving already expanded pax directory to expanded location"
-      mkdir -p "$baseinstalldir/$installdirname" 2>/dev/null
-      mv "$tmpUnpaxDir/" "$baseinstalldir/$installdirname" >/dev/null 2?&1
+      mkdir -p "${baseinstalldir}/${installdirname}" 2>/dev/null
+      mv "${tmpUnpaxDir}/" "${baseinstalldir}/${installdirname}" >/dev/null 2?&1
     fi
-    if $localInstall; then
+    if ${localInstall}; then
       rm -f "${pax}"
     fi
 
-    if $setactive; then
-      if [ -L "$baseinstalldir/$name/${name}" ]; then
-        printDebug "Removing old symlink '$baseinstalldir/$name/${name}'"
-        rm -f "$baseinstalldir/$name/${name}"
+    if ${setactive}; then
+      if [ -L "${baseinstalldir}/${name}/${name}" ]; then
+        printDebug "Removing old symlink '${baseinstalldir}/${name}/${name}'"
+        rm -f "${baseinstalldir}/${name}/${name}"
       fi
-      if ! ln -s "$baseinstalldir/$installdirname" "$baseinstalldir/$name/${name}"; then
+      if ! ln -s "${baseinstalldir}/${installdirname}" "${baseinstalldir}/${name}/${name}"; then
         printError "Could not create symbolic link name"
       fi 
     fi 
 
     printDebug "Adding version '${downloadFileVer}' to info file"
     # Add file version information as a .releaseinfo file
-    echo "$downloadFileVer" > "${baseinstalldir}/$installdirname/.releaseinfo"
+    echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.releaseinfo"
 
     # Check for a .version file from the pax - if present good, if not
     # generate one from the file name as the tag isn't granular enough to really
     # be used in dependency checks
-    if [ ! -f "${baseinstalldir}/$installdirname/.version" ]; then
-      echo "$downloadFileVer" > "${baseinstalldir}/$installdirname/.version"
+    if [ ! -f "${baseinstalldir}/${installdirname}/.version" ]; then
+      echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.version"
     fi
 
-    printDebug "Adding releaseline '$installedReleaseLine' metadata to ${baseinstalldir}/$installdirname/.releaseline"
-    echo "$installedReleaseLine" > "${baseinstalldir}/$installdirname/.releaseline"
+    printDebug "Adding releaseline '${installedReleaseLine}' metadata to ${baseinstalldir}/${installdirname}/.releaseline"
+    echo "${installedReleaseLine}" > "${baseinstalldir}/${installdirname}/.releaseline"
 
-    if $setactive; then
-      if ! $nosymlink; then
-        mergeIntoSystem "$name" "${baseinstalldir}/$installdirname" "$ZOPEN_ROOTFS" 
+    if ${setactive}; then
+      if ! ${nosymlink}; then
+        mergeIntoSystem "${name}" "${baseinstalldir}/${installdirname}" "${ZOPEN_ROOTFS}" 
         misrc=$?
-        printDebug "The merge complete with: $misrc"
+        printDebug "The merge complete with: ${misrc}"
       fi
 
       printVerbose "- Checking for env file"
-      if [ -f ${baseinstalldir}/${name}/${name}/.env -o -f ${baseinstalldir}/${name}/${name}/.appenv ]; then
+      if [ -f "${baseinstalldir}/${name}/${name}/.env" ] || [ -f "${baseinstalldir}/${name}/${name}/.appenv" ]; then
         printVerbose "- .env file found, adding to profiled processing"
-        mkdir -p "$ZOPEN_ROOTFS/etc/profiled/$name"
-        cat << EOF > "$ZOPEN_ROOTFS/etc/profiled/$name/dotenv"
+        mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
+        cat << EOF > "${ZOPEN_ROOTFS}/etc/profiled/${name}/dotenv"
 curdir=\$(pwd)
-cd "$baseinstalldir/$name/$name" >/dev/null 2>&1
+cd "${baseinstalldir}/${name}/${name}" >/dev/null 2>&1
 # If .appenv exists, source it as it's quicker
 if [ -f ".appenv" ]; then
   . ./.appenv
 elif [ -f ".env" ]; then
   . ./.env
 fi
-cd \$curdir  >/dev/null 2>&1
+cd \${curdir}  >/dev/null 2>&1
 EOF
         printVerbose "- Running any setup scripts"
         cd "${baseinstalldir}/${name}/${name}" && [ -r "./setup.sh" ] && ./setup.sh
       fi
     fi
-    if $unInstallOldVersion; then
+    if ${unInstallOldVersion}; then
       printDebug "New version merged; checking for orphaned files from previous version"
       # This will remove any old symlinks or dirs that might have changed in an upgrade
       # as the merge process overwrites existing files to point to different version
-      unsymlinkFromSystem "$name" "$ZOPEN_ROOTFS" "$currentlinkfile" "${baseinstalldir}/${name}/${name}/.links"
+      unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}" "${baseinstalldir}/${name}/${name}/.links"
     fi
 
-    if $setactive; then
+    if ${setactive}; then
       printDebug "Marking this version as installed"
       touch "${baseinstalldir}/${name}/${name}/.active"
-      installedList="$name $installedList"
-      syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_INSTALL,$CAT_PACKAGE" "DOWNLOAD" "handlePackageInstall" "Installed package:'$name';version:$downloadFileVer;install_dir='$baseinstalldir/$installdirname';"
+      installedList="${name} ${installedList}"
+      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
     fi
 
-    if $doNotInstallDeps; then
+    if ${doNotInstallDeps}; then
         printVerbose "- Skipping dependency installation"
-    elif $reinstall; then
+    elif ${reinstall}; then
       printDebug "- Reinstalling so no dependency reinstall (unless explicitly listed)"
     else
       printVerbose "- Checking for runtime dependencies"
@@ -1690,23 +1691,23 @@ EOF
         dependencies=$(cat "${baseinstalldir}/${name}/${name}/.runtimedeps")
       fi
       printDebug "Checking for runtime dependencies from the git metadata"
-      if echo "$statusline" | grep "Runtime Dependencies:" >/dev/null; then
-        gitmetadependencies="$(echo "$statusline" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
-        if [ ! "$gitmetadependencies" = "No dependencies" ]; then
-          dependencies="$dependencies $gitmetadependencies"
+      if echo "${statusline}" | grep "Runtime Dependencies:" >/dev/null; then
+        gitmetadependencies="$(echo "${statusline}" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
+        if [ ! "${gitmetadependencies}" = "No dependencies" ]; then
+          dependencies="${dependencies} ${gitmetadependencies}"
         fi
       fi
-      dependencies=$(deleteDuplicateEntries "$dependencies" " ")
-      if [ ! "x" = "x$dependencies" ]; then
-        printVerbose "- $name depends on: $dependencies"
+      dependencies=$(deleteDuplicateEntries "${dependencies}" " ")
+      if [ ! "x" = "x${dependencies}" ]; then
+        printVerbose "- ${name} depends on: ${dependencies}"
         printInfo "- Installing dependencies"
-        installDependencies "$name" "$dependencies"
+        installDependencies "${name}" "${dependencies}"
       else
         printVerbose "- No runtime dependencies found"
       fi
     fi
-    sessionList="$sessionList $name"
-    printInfo "${NC}${GREEN}Successfully installed $name${NC}"
+    sessionList="${sessionLis} ${name}"
+    printInfo "${NC}${GREEN}Successfully installed ${name}${NC}"
   fi # (download only)
 }
 
@@ -1714,573 +1715,17 @@ zopenInitialize()
 {
   # Create the cleanup pipeline and exit handler
   trap "cleanupFunction" EXIT INT TERM QUIT HUP
-  [ -z "$ZOPEN_CLEANUP_PIPE" ] \
-  && [ ! -p "$ZOPEN_CLEANUP_PIPE" ] \
+  [ -z "${ZOPEN_CLEANUP_PIPE}" ] \
+  && [ ! -p "${ZOPEN_CLEANUP_PIPE}" ] \
   && ZOPEN_CLEANUP_PIPE=$(mktempfile "clean" "pipe") \
-  && mkfifo "$ZOPEN_CLEANUP_PIPE" \
-  && chtag -tc 819 "$ZOPEN_CLEANUP_PIPE" \
+  && mkfifo "${ZOPEN_CLEANUP_PIPE}" \
+  && chtag -tc 819 "${ZOPEN_CLEANUP_PIPE}" \
   && export ZOPEN_CLEANUP_PIPE
 
   addCleanupTrapCmd "stty echo 2>/dev/null" # set this as a default to ensure line visibility!
   defineEnvironment
   defineANSI
-  if [ -z "$ZOPEN_DONT_PROCESS_CONFIG" ]; then
-    processConfig
-  fi
-
-  ZOPEN_JSON_CACHE_URL="https://zosopentools.github.io/meta/api/zopen_releases.json"
-}
-
-installDependencies()
-(
-  name=$1
-  printVerbose "List of dependencies to install: $dependencies"
-  skipupgrade_lcl=$skipupgrade
-  skipupgrade=true
-  echo "$dependencies" | xargs | tr ' ' '\n' | sort | while read dep; do
-    printDebug "Removing '$dep' from dependency queue '$dependencies'"
-    # done in case of dependency chain that specifies the same dependency more than once!
-    dependencies=$(echo "$dependencies" | sed -e "s/$dep//" | tr -s ' ')
-    printDebug "Checking if package already installed this session"
-    alreadyInstalled=$(echo "$sessionList" | sed -e "s/.*\($dep\).*//")
-    if [ -z "$alreadyInstalled" ]; then
-      handlePackageInstall "$dep"
-    else
-      printDebug "Package '$dep' installed earlier; no install required"
-    fi
-  done
-  skipupgrade=$skipupgrade_lcl
-)
-
-handlePackageInstall(){
-  printDebug "Checking whether installing direct from pax files or via Github repo"
-  if ! $paxinstall; then
-    printDebug "Using standard Github repo"
-    fullname="$1"
-    printDebug "Name to install: $fullname, parsing any version ('=') or tag ('%') has been specified"
-    name=$(echo "$fullname" | sed -e 's#[=%].*##')
-    repo="${name}"
-    versioned=$(echo "$fullname" | cut -s -d '=' -f 2)
-    tagged=$(echo "$fullname" | cut -s -d '%' -f 2)
-    printDebug "Name:$name;version:$versioned;tag:$tagged;repo:$repo"
-    printHeader "Installing package: $name"
-    [ -z "$paxrepodir" ] && getAllReleasesFromGithub "${repo}"
-  else 
-    printDebug "Using native pax files to install"
-    reponame="$1"
-    if [ "$reponame" = "${reponame%%.zos.pax.Z}" ]; then
-      printDebug "Package did not have .zos.pax.Z suffix - attempt to locate suitable pax"
-
-      printDebug "Check [in order] cli paxrootdir -> system paxrootdir -> current dir for repo to check"
-      testpaxRepo=""
-      [ -n "$paxrepodir" ] && testpaxRepo="$paxrepodir"
-      [ -n "$testpaxRepo" ] && [ ! -r "$testpaxRepo" ] && printError "Could not access location '$testpaxRepo' from parameter --paxrepodir. Check parameter setting and retry command"
-      [ -z "$testpaxRepo" ] && [ -e "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ] && tespaxRepo=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
-      [ -n "$testpaxRepo" ] && [ ! -r "$testpaxRepo" ] && printError "Unable to read system repository at location '$tespaxRepo'. Correct system setting in '$ZOPEN_ROOTFS/etc/zopen/paxrepodir' and retry command"
-      [ -z "$testpaxRepo" ] && testpaxRepo="./"
-      prefix="$reponame-" 
-      printDebug "Finding paxes prefixed '$prefix' in '$testpaxRepo'"
-      # Note, not cd'ing to dir means we get full pax name - need the "/" at the end though
-      #(heads -1 or tails -1 - need to test multiple pax for install)
-      paxRepo=$(zosfind "${testpaxRepo%%/}/" ! -name "${testpaxRepo%%/}/" -prune -a -type f |grep "$prefix" |sort|tail -n 1)
-      printVerbose "Found pax '$paxRepo' as candidate for install for package '$reponame'"
-    else
-      printDebug "Parameter passed in had suffix indicating pax file; try to locate file..."
-      if [ -r "$reponame" ]; then
-        printVerbose "Found file at location specified '$reponame'; using as-is"
-        paxRepo="$reponame"
-      else
-        printDebug "Attempt to locate rpm file in current directory or in configured locations [if set]"
-        paxfilename=$(basename "$reponame") 
-        printDebug "Checking current directory '$PWD'"
-        testpaxRepo="./$paxfilename"
-        if [ -r "$testpaxRepo" ]; then
-          printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-          paxRepo="$testpaxRepo"
-        elif [ -n "$paxrepodir" ]; then
-          printVerbose "Using repository '$paxrepodir' as specified on cli"
-          testpaxRepo="$paxrepodir/$paxfilename"
-          if [ -r "$testpaxRepo" ]; then
-            printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-            paxRepo="$testpaxRepo"
-          fi
-        elif [ -e "$ZOPEN_ROOTFS/etc/zopen/paxrepodir" ]; then
-          printDebug "Using [single] repository specified from system config '$ZOPEN_ROOTFS/etc/zopen/paxrepodir'"
-          paxrepodir=$(cat "$ZOPEN_ROOTFS/etc/zopen/paxrepodir")
-          printVerbose "Trying repository at system configured location '$repodir'"
-          testpaxRepo="$paxrepodir/$paxfilename"
-          if [ -r "$testpaxRepo" ]; then
-            printVerbose "Found $paxfilename as '$testpaxRepo'; installing"
-            paxRepo="$testpaxRepo"
-          fi
-#          paxlist=$(cd "$paxrepodir" | zosfind "." -type f -name "*$fullname-*zos.pax.Z")
-        else
-          printError "Cannot locate specified pax file '$reponame' to install. Validate filename, repository or permissions and retry request"
-        fi
-      fi
-    fi
-
-    [ -z "$paxRepo" ] && printError "Could not locate pax file for '$reponame'. Validate filename, repository or permissions and retry request."      
-    printDebug "Installing a custom-repo pax '$paxRepo', need to find and break it open and get the metadata first"
-    tmptime=$(date +%Y%m%d%H%M%S)
-    tmpUnpaxDir="$rootfs/tmp/zopen.$tmptime"
-    printVerbose "Temporary processing dir evaluated to: $tmpUnpaxDir"
-    [ -e "$tmpUnpaxDir" ] && rm -rf "$tmpUnpaxDir"
-    mkdir -p "$tmpUnpaxDir" >/dev/null 2>&1
-    #addCleanupTrapCmd "rm -rf $tmpUnpaxDir"
-    paxredirect="-s %[^/]*/%$tmpUnpaxDir/%"
-    
-    if ! runLogProgress "pax -rf $paxRepo -p p $paxredirect ${redirectToDevNull} " "Expanding $paxRepo" "Expanded"; then
-      printError "Errors unpaxing '$paxRepo'"
-      continue;
-    fi
-    printDebug "Checking pax for metadata file(s): README.md"
-
-    printDebug "Attempting to calculate package name..."
-    if [ -r "$tmpUnpaxDir/README.md" ]; then
-      printDebug "Found README.md - first line *might* be package title"
-      name=$(head -1 "$tmpUnpaxDir/README.md" | awk '{print $NF}')
-    fi
-    if [ -z "$name" ]; then 
-        # Fallback to pax file name
-        name=$(basename "${paxRepo%%-*}")
-        printVerbose "Using '$name' as package name"
-    fi
-    name="${name%port}"
-    [ -z "$name" ] && printError "Could not determine package name from pax file metadata"
-    printVerbose "Using '$name' as package name"    
-
-    printDebug "Copying specified pax '$paxRepo' for package '$name' into correct location for install '$downloadDir'"
-    downloadFile=$(basename "$paxRepo")
-    # if already exits, skip copy
-    [ ! -e "$downloadDir/$downloadFile" ] && cp -R "$paxRepo" "$downloadDir"
-  fi
-
-  if $localInstall; then
-    printDebug "Local install to current directory"
-    rootInstallDir="$PWD"
-  else
-    printDebug "Setting install root to: ${ZOPEN_PKGINSTALL}"
-    rootInstallDir="${ZOPEN_PKGINSTALL}"
-  fi
-  originalFileVersion=""
-  printDebug "Checking for meta files in '${rootInstallDir}/${name}/${name}'"
-  printDebug "Finding version/release information"
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseinfo" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.releaseinfo")
-    printDebug "Found originalFileVersion=$originalFileVersion (port is already installed)"
-  elif [ -e "${rootInstallDir}/${name}/${name}/.version" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.version")
-    printDebug "Found originalFileVersion=$originalFileVersion (port is already installed)"
-  else
-    printDebug "Could not detect existing installation at ${rootInstallDir}/${name}/${name}"
-  fi
-
-  printDebug "Finding releaseline information"
-  installedReleaseLine=""
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseline" ]; then
-    installedReleaseLine=$(cat "${rootInstallDir}/${name}/${name}/.releaseline")
-    printVerbose "Installed product from releaseline: $installedReleaseLine"
-  else
-    printVerbose "No current releaseline for package"
-  fi
-  
-  printDebug "Checking whether installing direct from a pax [from a custom repo]"
-  if ! $paxinstall; then
-    releasemetadata=""
-    downloadURL=""
-    # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
-    # either for a previous package install or system default
-    if [ ! "x" = "x$versioned" ]; then
-      printDebug "Specific version $versioned requested - checking existence and URL"
-      requestedMajor=$(echo "$versioned" | awk -F'.' '{print $1}')
-      requestedMinor=$(echo "$versioned" | awk -F'.' '{print $2}')
-      requestedPatch=$(echo "$versioned" | awk -F'.' '{print $3}')
-      requestedSubrelease=$(echo "$versioned" | awk -F'.' '{print $4}')
-      requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
-      printDebug "Finding URL for latest release matching version prefix: requestedVersion: $requestedVersion"
-      releasemetadata=$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.assets[].name | test("'$requestedVersion'")))[0]')
-    elif [ ! "x" = "x$tagged" ]; then
-      printDebug "Explicit tagged version '$tagged' specified. Checking for match"
-      releaseMetadata=$(/bin/printf "%s" "$releases" | jq -e -r '.[] | select(.tag_name == "'$tagged'")')
-      printDebug "Use quick check for asset to check for existence of metadata for specific messages"
-      asset=$(/bin/printf "%s" "$releaseMetadata" | jq -e -r '.assets[0]')
-      if [ $? -ne 0 ]; then
-        printError "Could not find release tagged '$tagged' in repo '$repo'"
-      fi
-    elif $selectVersion; then
-      # Explicitly allow the user to select a release to install; useful if there are broken installs
-      # as a known good release can be found, selected and pinned!
-      printDebug "List individual releases and allow selection"
-      i=$(/bin/printf "%s" "$releases" | jq -r 'length - 1')
-      printInfo "Versions available for install:"
-      /bin/printf "%s" "$releases" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
-  
-      printDebug "Getting user selection"
-      valid=false
-      while ! $valid; do
-        echo "Enter version to install (0-$i): "
-        read selection < /dev/tty
-        if [[ ! -z $(echo "$selection" | sed -e 's/[0-9]*//') ]]; then
-          echo "Invalid input, must be a number between 0 and $i"
-        elif [ "$selection" -ge 0 ] && [ "$selection" -le "$i" ]; then
-          valid=true
-        fi
-      done
-      printVerbose "Selecting item $selection from array"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[$selection]")"
-  
-    elif [ ! -z "$releaseLine" ]; then  
-      printDebug "Install from release line '$releaseLine' specified"
-      validatedReleaseLine=$(validateReleaseLine "$releaseLine")
-      if [ -z "$validatedReleaseLine" ]; then
-        printError "Invalid releaseline specified: '$releaseLine'; Valid values: DEV or STABLE"
-      fi
-      printDebug "Finding latest asset on the release line"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$releaseLine'")))[0]')"
-      printDebug "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
-      if [ $? -ne 0 ]; then
-        printError "Could not find release-line $releaseLine for repo: $repo"
-      fi
-      
-    else
-      printDebug "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
-      if [ -n "$installedReleaseLine" ]; then
-        printDebug "Found existing releaseline '$installedReleaseLine', restricting to only that releaseline"
-        validatedReleaseLine="$installedReleaseLine"  # Already validated when stored
-      else 
-        printDebug "Checking for system-configured releaseline"
-        sysrelline=$(cat "$ZOPEN_ROOTFS/etc/zopen/releaseline" | awk ' {print toupper($1)}')
-        printDebug "Validating value: $sysrelline"
-        validatedReleaseLine=$(validateReleaseLine "$sysrelline")
-        if [ -n "$validatedReleaseLine" ]; then
-          printDebug "zopen system configured to use releaseline '$sysrelline'; restricting to that releaseline"
-        else
-          printWarning "zopen misconfigured to use an unknown releaseline of '$sysrelline'; defaulting to STABLE packages"
-          printWarning "Set the contents of '$ZOPEN_ROOTFS/etc/zopen/releaseline' to a valid value to remove this message"
-          printWarning "Valid values are: DEV | STABLE"
-          validatedReleaseLine="STABLE"
-        fi
-      fi
-
-      printDebug "Parsing releases: $releases"
-      # We have some situations that could arise
-        # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
-        # 2. system is configured for STABLE but only has DEV stream available
-        # 3. system is configured for DEV but only has DEV stream available
-        # 4. the port being installed has got full releaseline tagging
-        # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
-        # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
-        # then that specific releaseline will be used
-      printDebug "Finding any releases tagged with $validatedReleaseLine and getting the first (newest/latest)"
-      releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$validatedReleaseLine'")))[0]')"
-      printDebug "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
-      if [ $? -eq 0 ]; then
-        # Case 4...
-        printVerbose "Found a specific '$validatedReleaseLine' release-line tagged version; installing..."
-      else
-        # Case 2 & 3
-        printDebug "No releases on releaseline '$validatedReleaseLine'; checking alternative releaseline"
-        alt=$(echo "$validatedReleaseLine" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
-        releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$alt'")))[0]')"
-        printDebug "Use quick check for asset to check for existence of metadata"
-        asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
-        if [ $? -eq 0 ]; then
-          printDebug "Found a release on the '$alt' release line so release tagging is active"
-          if [ "DEV" = "$validatedReleaseLine" ]; then
-            # The system will be configured to use DEV packages where available but if none, use latest
-            printInfo "No specific DEV releaseline package, using latest available"
-            releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
-          else
-            printVerbose "The system is configured to only use STABLE releaseline packages but there are none"
-            printInfo "No release available on the '$validatedReleaseLine' releaseline."
-          fi
-        else
-          # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
-          printVerbose "Installing latest release"
-          releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
-        fi
-      fi
-    fi
-    printDebug "Getting specific asset details from metadata: $releasemetadata"
-    if [ -z "$asset" ] || [ "null" = "$asset" ]; then
-      printDebug "Asset not found during previous logic; setting now"
-      asset=$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')
-    fi
-    if [ "x" = "x$asset" ]; then
-      printError "Unable to determine download asset for ${name}"
-    fi
-  
-    tagname=$(/bin/printf "%s" "$releasemetadata" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
-    installedReleaseLine=$(validateReleaseLine "$tagname" )
-  
-    downloadURL=$(/bin/printf "%s" "$asset" | jq -e -r '.url')
-    size=$(/bin/printf "%s" "$asset" | jq -e -r '.expanded_size')
-  
-    if [ "x" = "x$downloadURL" ]; then
-      printError "Unable to determine download location for ${name}"
-    fi
-    downloadFile=$(basename "$downloadURL")
-    downloadFileVer=$(echo "$downloadFile" |sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
-    printVerbose "Downloading port from URL: $downloadURL to file: $downloadFile (ver=$downloadFileVer)"
-  else
-    printVerbose "Installing package '$name' from pax file '$paxRepo'"
-    printDebug "Pax was expanded to '$tmpUnpaxDir' previously"
-    downloadFilePrfx="${paxRepo%.zos.pax.Z}"
-    downloadFileVer="${downloadFilePrfx##*-}"
-    size=$(du -s "$tmpUnpaxDir" | awk ' {print $1}') # in 512-blocks
-    [ -z "$size" ] && printError "Could not calculate directory size"
-    size=$(echo "$size * 512" | bc)
-  fi
-
-  if $downloadOnly; then
-    printVerbose "Skipping installation, downloading only"
-  else
-    printDebug "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
-    if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
-      if ! $reinstall; then
-        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC}"
-        return;
-      fi
-      printInfo "- Reinstalling version '$downloadFileVer' of ${name}..."
-    fi
-
-    printDebug "Checking if package is not installed but scheduled for upgrade"
-    if [ "x" = "x$originalFileVersion" ]; then
-      printDebug "No previous version found"
-      if $installOrUpgrade; then
-        printDebug "Package ${name} was not installed so not upgrading but installing"
-      elif $upgradeInstalled; then
-        printError "Package ${name} can not be upgraded as it is not installed!"
-        continue;
-      fi
-      unInstallOldVersion=false
-      printInfo "- Installing ${name}..."
-    elif $skipupgrade; then
-      printInfo "Package ${name} has a newer release '${downloadFileVer}' but explicitly skipping"
-      continue;
-    elif ! $setactive; then
-      printVerbose "Current version '${originalFileVersion}' will remain active"
-      unInstallOldVersion=false
-    else
-      printVerbose "Previous version '${originalFileVersion}' installed"
-      if [ -e "${rootInstallDir}/${name}/${name}/.pinned" ]; then
-        printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped"
-        syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_PACKAGE,$CAT_INSTALL" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped"
-        continue;
-      else
-        printInfo "- Replacing ${name} version '${originalFileVersion}' with '${downloadFileVer}'"
-        unInstallOldVersion=true
-        currentversiondir=$(cd "$rootInstallDir/$name/${name}" && pwd -P)
-        currentlinkfile="$currentversiondir/.links"
-      fi
-    fi
-  fi
-  printDebug "Ensuring we are in the correct working download location '${downloadDir}'"
-  cd "${downloadDir}" || printError "Unable to change to download directory '${downloadDir}'"
-
-  if [ ! $downloadOnly ] || [ ! $localInstall ]; then
-    printDebug "Checking current directory for already downloaded package [file name comparison]"
-    location="current directory"
-  else
-    printDebug "Checking cache for already downloaded package [file name comparison]"
-    location="zopen package cache"
-  fi
-
-  pax=$downloadFile
-  if [ -f "$pax" ]; then
-    printVerbose "- Found existing file '${pax}' in ${location}"
-  else
-    printInfo "- Downloading $pax file from remote to ${location}..."
-    if ! $verbose; then
-      redirectToDevNull="2>/dev/null"
-    fi
-
-    progressHandler "network" "- Downloaded $pax file from remote to ${location}." &
-    ph=$!
-    killph="kill -HUP $ph"
-    addCleanupTrapCmd "$killph"
-
-    if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
-      printError "Could not download from ${downloadURL}. Correct any errors and potentially retry"
-      continue;
-    fi
-    $killph 2>/dev/null  # if the timer is not running, the kill will fail
-    syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_NETWORK,$CAT_PACKAGE,$CAT_FILE" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '$pax'"
-  fi
-  if [ ! -f "${pax}" ]; then
-    printError "${pax} was not found after download!?!"
-  fi
-
-  if $downloadOnly; then
-    printVerbose "Pax was downloaded to local dir '$downloadDir'"
-  elif $cacheOnly; then
-    printVerbose "Pax was downloaded to zopen cache '$downloadDir'"
-  else
-    printDebug "Installing $pax"
-    installdirname="${name}/${pax%.pax.Z}" # Use full pax name as default
-
-    printVerbose "- Processing $pax..."
-    baseinstalldir="."
-    paxredirect=""
-    if ! $localInstall; then
-      baseinstalldir="$rootInstallDir"
-      paxredirect="-s %[^/]*/%$rootInstallDir/$installdirname/%"
-      printDebug "Non-local install, extracting with '$paxredirect'"
-    else
-      printVerbose "- Local install specified"
-      paxredirect="-s %[^/]*/%$installdirname/%"
-      printDebug "Non-local install, extracting with '$paxredirect'"
-    fi
-
-    megabytes=$(echo "scale=2; $size / (1024 * 1024)" | bc)
-    printInfo "After this operation, $megabytes MB of additional disk space will be used."
-    if ! $yesToPrompts; then
-      while true; do
-        printInfo "Do you want to continue? [y/n/a]"
-        read continueInstall < /dev/tty
-        case "$continueInstall" in
-          "y") break;;
-          "n") mutexFree "zopen" && printInfo "Exiting..." && exit 0 ;;
-          "a") yesToPrompts=true; break;;
-          *) echo "?";;
-        esac
-      done
-    fi
-
-    printDebug "Check for existing directory for version '$installdirname'"
-    if [ -d "$baseinstalldir/$installdirname" ]; then 
-      printVerbose "- Clearing existing directory and contents"
-      rm -rf "$baseinstalldir/$installdirname"
-    fi
-
-    if  ! $paxinstall; then
-      if ! runLogProgress "pax -rf $pax -p p $paxredirect ${redirectToDevNull}" "Expanding $pax" "Expanded"; then
-        printWarning "Errors unpaxing, package directory state unknown"
-        printInfo    "Use zopen alt to select previous version to ensure known state"
-        continue;
-      fi
-    else
-      printVerbose "Moving already expanded pax directory to expanded location"
-      mkdir -p "$baseinstalldir/$installdirname" 2>/dev/null
-      mv "$tmpUnpaxDir/" "$baseinstalldir/$installdirname" >/dev/null 2?&1
-    fi
-    if $localInstall; then
-      rm -f "${pax}"
-    fi
-
-    if $setactive; then
-      if [ -L "$baseinstalldir/$name/${name}" ]; then
-        printDebug "Removing old symlink '$baseinstalldir/$name/${name}'"
-        rm -f "$baseinstalldir/$name/${name}"
-      fi
-      if ! ln -s "$baseinstalldir/$installdirname" "$baseinstalldir/$name/${name}"; then
-        printError "Could not create symbolic link name"
-      fi 
-    fi 
-
-    printDebug "Adding version '${downloadFileVer}' to info file"
-    # Add file version information as a .releaseinfo file
-    echo "$downloadFileVer" > "${baseinstalldir}/$installdirname/.releaseinfo"
-
-    # Check for a .version file from the pax - if present good, if not
-    # generate one from the file name as the tag isn't granular enough to really
-    # be used in dependency checks
-    if [ ! -f "${baseinstalldir}/$installdirname/.version" ]; then
-      echo "$downloadFileVer" > "${baseinstalldir}/$installdirname/.version"
-    fi
-
-    printDebug "Adding releaseline '$installedReleaseLine' metadata to ${baseinstalldir}/$installdirname/.releaseline"
-    echo "$installedReleaseLine" > "${baseinstalldir}/$installdirname/.releaseline"
-
-    if $setactive; then
-      if ! $nosymlink; then
-        mergeIntoSystem "$name" "${baseinstalldir}/$installdirname" "$ZOPEN_ROOTFS" 
-        misrc=$?
-        printDebug "The merge complete with: $misrc"
-      fi
-
-      printVerbose "- Checking for env file"
-      if [ -f ${baseinstalldir}/${name}/${name}/.env -o -f ${baseinstalldir}/${name}/${name}/.appenv ]; then
-        printVerbose "- .env file found, adding to profiled processing"
-        mkdir -p "$ZOPEN_ROOTFS/etc/profiled/$name"
-        cat << EOF > "$ZOPEN_ROOTFS/etc/profiled/$name/dotenv"
-curdir=\$(pwd)
-cd "$baseinstalldir/$name/$name" >/dev/null 2>&1
-# If .appenv exists, source it as it's quicker
-if [ -f ".appenv" ]; then
-  . ./.appenv
-elif [ -f ".env" ]; then
-  . ./.env
-fi
-cd \$curdir  >/dev/null 2>&1
-EOF
-        printVerbose "- Running any setup scripts"
-        cd "${baseinstalldir}/${name}/${name}" && [ -r "./setup.sh" ] && ./setup.sh
-      fi
-    fi
-    if $unInstallOldVersion; then
-      printDebug "New version merged; checking for orphaned files from previous version"
-      # This will remove any old symlinks or dirs that might have changed in an upgrade
-      # as the merge process overwrites existing files to point to different version
-      unsymlinkFromSystem "$name" "$ZOPEN_ROOTFS" "$currentlinkfile" "${baseinstalldir}/${name}/${name}/.links"
-    fi
-
-    if $setactive; then
-      printDebug "Marking this version as installed"
-      touch "${baseinstalldir}/${name}/${name}/.active"
-      installedList="$name $installedList"
-      syslog "$ZOPEN_LOG_PATH/audit.log" "$LOG_A" "$CAT_INSTALL,$CAT_PACKAGE" "DOWNLOAD" "handlePackageInstall" "Installed package:'$name';version:$downloadFileVer;install_dir='$baseinstalldir/$installdirname';"
-    fi
-
-    if $doNotInstallDeps; then
-        printVerbose "- Skipping dependency installation"
-    elif $reinstall; then
-      printDebug "- Reinstalling so no dependency reinstall (unless explicitly listed)"
-    else
-      printVerbose "- Checking for runtime dependencies"
-      printDebug "Checking for .runtimedeps file"
-      if [ -e "${baseinstalldir}/${name}/${name}/.runtimedeps" ]; then
-        dependencies=$(cat "${baseinstalldir}/${name}/${name}/.runtimedeps")
-      fi
-      printDebug "Checking for runtime dependencies from the git metadata"
-      if echo "$statusline" | grep "Runtime Dependencies:" >/dev/null; then
-        gitmetadependencies="$(echo "$statusline" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
-        if [ ! "$gitmetadependencies" = "No dependencies" ]; then
-          dependencies="$dependencies $gitmetadependencies"
-        fi
-      fi
-      dependencies=$(deleteDuplicateEntries "$dependencies" " ")
-      if [ ! "x" = "x$dependencies" ]; then
-        printVerbose "- $name depends on: $dependencies"
-        printInfo "- Installing dependencies"
-        installDependencies "$name" "$dependencies"
-      else
-        printVerbose "- No runtime dependencies found"
-      fi
-    fi
-    sessionList="$sessionList $name"
-    printInfo "${NC}${GREEN}Successfully installed $name${NC}"
-  fi # (download only)
-}
-
-zopenInitialize()
-{
-  # Create the cleanup pipeline and exit handler
-  trap "cleanupFunction" EXIT INT TERM QUIT HUP
-  [ -z "$ZOPEN_CLEANUP_PIPE" ] \
-  && [ ! -p "$ZOPEN_CLEANUP_PIPE" ] \
-  && ZOPEN_CLEANUP_PIPE=$(mktempfile "clean" "pipe") \
-  && mkfifo "$ZOPEN_CLEANUP_PIPE" \
-  && chtag -tc 819 "$ZOPEN_CLEANUP_PIPE" \
-  && export ZOPEN_CLEANUP_PIPE
-
-  addCleanupTrapCmd "stty echo 2>/dev/null" # set this as a default to ensure line visibility!
-  defineEnvironment
-  defineANSI
-  if [ -z "$ZOPEN_DONT_PROCESS_CONFIG" ]; then
+  if [ -z "${ZOPEN_DONT_PROCESS_CONFIG}" ]; then
     processConfig
   fi
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -270,6 +270,15 @@ EOF
 
 }
 
+isPackageActive(){
+  pkg="$1"
+  printDebug "Checking if '${pkg}' is installed and active"
+  installedPackage=$(cd "${ZOPEN_PKGINSTALL}" && zosfind . -name ".active" | grep "/${pkg}/")
+  cmdrc=$?
+  # Return 1 for true/Package is Active, 0 for false/Package is not active
+  [ "${cmdrc}" -eq 0 ] && return 1 || return 0
+}
+
 curlCmd()
 {
   # Take the list of parameters and concat them with

--- a/include/common.sh
+++ b/include/common.sh
@@ -1264,16 +1264,13 @@ useLocalRepo()
   if ! runLogProgress "pax -rf ${paxRepo} -p p ${paxredirect} ${redirectToDevNull} " "Expanding ${paxRepo}" "Expanded"; then
     printError "Errors unpaxing '${paxRepo}'"
   fi
-  printDebug "Checking pax for metadata file(s): README.md"
   printDebug "Attempting to calculate package name..."
-  if [ -r "${tmpUnpaxDir}/README.md" ]; then
-    printDebug "Found README.md - first line *might* be package title"
-    name=$(head -1 "${tmpUnpaxDir}/README.md" | awk '{print $NF}')
-  fi
-  if [ -z "${name}" ]; then 
-      # Fallback to pax file name
-      name=$(basename "${paxRepo%%-*}")
-      printVerbose "Using '${name}' as package name"
+  mdf="${tmpUnpaxDir}/metadata.json"
+  printDebug "Checking pax for metadata file: ${mdf}"
+
+  if [ -r "${mdf}" ]; then
+    printDebug "Found ${mdf}"
+    name=$(jq -e -r '.product.name' "${mdf}")
   fi
   name="${name%port}"
   [ -z "${name}" ] && printError "Could not determine package name from pax file metadata"
@@ -1289,7 +1286,7 @@ useGitHubRepo()
   fullname="$1"
   printDebug "Name to install: ${fullname}, parsing any version ('=') or tag ('%') has been specified"
   name=$(echo "${fullname}" | sed -e 's#[=%].*##')
-  repo="${name}"
+  repo="${name%port}"
   versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
   tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
   printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1241,7 +1241,7 @@ useLocalRepo()
       elif [ -e "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir" ]; then
         printDebug "Using [single] repository specified from system config '${ZOPEN_ROOTFS}/etc/zopen/paxrepodir'"
         paxrepodir=$(cat "${ZOPEN_ROOTFS}/etc/zopen/paxrepodir")
-        printVerbose "Trying repository at system configured location '${repodir}'"
+        printVerbose "Trying repository at system configured location '${paxrepodir}'"
         testpaxRepo="${paxrepodir}/${paxfilename}"
         if [ -r "${testpaxRepo}" ]; then
           printVerbose "Found ${paxfilename} as '${testpaxRepo}'; installing"
@@ -1742,7 +1742,7 @@ handlePackageInstall(){
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
       printError "Could not download from ${downloadURL}. Correct any errors and potentially retry"
     fi
-    ${killph}  # if the timer is not running, the kill will fail
+    ${killph} 2>/dev/null # if the timer is not running, the kill will fail
     syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_NETWORK},${CAT_PACKAGE},${CAT_FILE}" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '${pax}'"
   fi
   if [ ! -f "${pax}" ]; then


### PR DESCRIPTION
Handle installing direct from pax file;
- move "install" code from zopen-install into common.sh to enable creation of zopen-upgrade script [separation of concerns!] with appropriate parameters added/removed from each module
- refactoring monolithic "install" code [now in common.sh] into more specialized functions 
Numerous qol fixes found while smoke testing including: 
 - maintaining installation history so dependencies aren't checked multiple times (resolves #472  #431)
 - allowing an "a" option for the "_Do you want to continue (y/n/a)?_" question to automatically answer "yes" to any future questions [in case a command is run without -y/--yes and the user actually meant to!
 - performance when alternating/upgrading improved by diffing updated files rather than systematically checking all symlinks for existence [still required for removal]; resolve #533 as much as possible [removal processing will always be slow due to the need to check every possible file a package ships to see if that symlink is still active]
 - improving query of installed packages
 - improving screen formatting calculation using screen cols (resolve #468)
 - make install less noisier still  (resolve #381)
 - resolve #253 

A global configuration for a paxfile repository [currently a single directory] can be set during initialization using the `--paxrepodir <dir>` option. This can be manually adjusted in the global config at <ZOPEN_ROOTFS>/etc/zopen/paxrepodir. ` --paxrepodir` can also be used with `zopen install ` to force a lookup of that repo for the specified package/pax.

Paxes can be installed using the command:
`zopen install --paxinstall path/to/<paxfile.pax.Z>`   - installs pax as found at specified location
`zopen install --paxinstall <package>`   - attempts to locate a pax for package in the current direcotry or in the global paxrepodir if configured
`zopen install --paxinstall --paxrepodir <dir> <package>.pax.Z` - install the specified package pax file, looking in <dir> for the file

Note that the manual has not been updated - the code is semi-"dark-shipped" for those able to test while the normal installation methodology continues as normal.  Once stabilised, the official documentation can be updated.