### PR TITLE
Fix curl error in zopen-build

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -605,10 +605,6 @@ checkEnv()
 
 setDepsEnv()
 {
-  if command -V curl > /dev/null 2>&1; then
-    curlpath=$(dirname "$(command -V curl | cut -f3 -d' ')")
-  fi
-  initDefaultEnvironment
   deps="${ZOPEN_DEPS}"
 
   orig="${PWD}"
@@ -690,6 +686,12 @@ setEnv()
   export SSL_CERT_FILE="${ZOPEN_CA}"
   export GIT_SSL_CAINFO="${ZOPEN_CA}"
   export CURL_CA_BUNDLE="${ZOPEN_CA}"
+
+  if command -V curl > /dev/null 2>&1; then
+    curlpath=$(dirname "$(command -V curl | cut -f3 -d' ')")
+  fi
+
+  initDefaultEnvironment
 
   setDepsEnv
 


### PR DESCRIPTION
With the recent metadata changes, there is a case where `setDepsEnv` is called twice. If curl is not in the path in the second call, it will be set to empty string, causing erros if `-u` is passed to zopen-build. This moves code away from setDepsEnv so that it is only called once.

```
- Querying remote repo for latest package information
curl: curlCmd 4: downloadJSONCache 18: getReposFromGithub 2: /jenkins/PortBuild/bin/zopen-install 623: FSUM7351 not found
***ERROR: Failed to obtain json cache timestamp from https://zosopentools.github.io/meta/api/zopen_releases.json
***ERROR: zopen install command failed
```

TODO: add -u (upgrade deps) test for zopen-build