### PR TITLE
Use active symlink for LICENSE

### DIFF
--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -238,7 +238,7 @@ install/
 EOT
 printInfo "${name}port/.gitignore created"
 
-metalicense="${ZOPEN_ROOTFS}/usr/local/zopen/meta/meta-main/LICENSE"
+metalicense="${ZOPEN_ROOTFS}/usr/local/zopen/meta/meta/LICENSE"
 ourlicense="${name}port/LICENSE"
 
 if [ -e "${ourlicense}" ]; then


### PR DESCRIPTION
While creating new tests, zopen_generate would fail to find the meta LICENSE file.
The lookup for that file is to: ${ZOPEN_ROOTFS}/usr/local/zopen/meta/meta-main/LICENSE  however I had a different location for my meta as I was testing it.  There should (always?) be a link from meta/meta to the active versioned release which is constant, rather than meta-main which might not exist.  This PR proposes using the main symlink to find metas LICENSE  
