### PR TITLE
Fix query logic in zopen-install

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -580,14 +580,6 @@ if [ -z "${chosenRepos}" ]; then
     if [ ${zqrc} -ne 0 ]; then
       printError "Query for installed packages unexpectedly failed; zopen-query returned message: '${chosenRepos}'"
     fi
-  elif ${all}; then
-    if ! ${yesToPrompts}; then
-      printInfo "Enter 'all' to confirm full installation [takes a long time so be sure!]:"
-      confirmall=$(getInput)
-      if [ ! "xall" = "x${confirmall}" ]; then
-        printError "Cancelling full installation"
-      fi
-    fi
   fi
 fi
 

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -573,8 +573,21 @@ if [ -z "${chosenRepos}" ]; then
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
-    chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-versions)"
+    chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-version 2>&1)"
+    zqrc=$?
     ${killph} 2> /dev/null # if the timer is not running, the kill will fail
+    sleep 1 # give the above process time to clear
+    if [ ${zqrc} -ne 0 ]; then
+      printError "Query for installed packages unexpectedly failed; zopen-query returned message: '${chosenRepos}'"
+    fi
+  elif ${all}; then
+    if ! ${yesToPrompts}; then
+      printInfo "Enter 'all' to confirm full installation [takes a long time so be sure!]:"
+      confirmall=$(getInput)
+      if [ ! "xall" = "x${confirmall}" ]; then
+        printError "Cancelling full installation"
+      fi
+    fi
   fi
 fi
 


### PR DESCRIPTION
Change the zopen-query call to use the updatd parameter no-version rather than no-versions and add more robust error handling if the call was to fail again in future.
Additional test added in metaport PR https://github.com/ZOSOpenTools/metaport/pull/29