### PR TITLE
Fix could not locate curl directory error if you have multiple curl installations

### DIFF
--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -362,7 +362,7 @@ fi
 # Need to source the .env file from within the actual curl directory and cannot
 # spawn sub-process otherwise no access to environment from this script so run inline
 printVerbose "Sourcing environment to trigger any setup required for packages"
-curldir=$(ls "${rootfs}/boot" | grep curl)
+curldir=$(ls "${rootfs}/boot" | grep curl | head -1)
 [ -e "${rootfs}/boot/${curldir}" ] || printError "Could not locate curl directory '${rootfs}/boot/${curldir}/' for bootstrap. Re-run 'zopen init' to retry"
 chmod -R 755 "${rootfs}/boot/${curldir}"
 curwd="${PWD}"
@@ -370,7 +370,7 @@ cd "${rootfs}/boot/${curldir}/" || printError "Could not access curl bootstrap i
 . ./.env
 cd "${curwd}"  || printError "Could not change to ${curwd}. Re-run 'zopen init' to retry"
 
-jqdir=$(ls "${rootfs}/boot" | grep jq)
+jqdir=$(ls "${rootfs}/boot" | grep jq | head -1)
 [ -e "${rootfs}/boot/${jqdir}" ] || printError "Could not locate jq directory '${rootfs}/boot/${jqdir}' for bootstrap. Re-run 'zopen init' to retry"
 chmod -R 755 "${rootfs}/boot/${jqdir}"
 curwd="${PWD}"


### PR DESCRIPTION
If we upgrade to newer versions of curl/jq, then there could be multiple boot installations

Fixes this issue:
```
***ERROR: Could not locate curl directory '/home/itodoro/zopen/boot/curl-8.1.2
curl-8.4.0/' for bootstrap. Re-run 'zopen init' to retry
```

Same fix applied to jq.