### PR TITLE
Use alternate url for zopen_releases.json

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -12,7 +12,7 @@ zopenInitialize()
   if [ -z "${ZOPEN_DONT_PROCESS_CONFIG}" ]; then
     processConfig
   fi
-  ZOPEN_JSON_CACHE_URL="https://zosopentools.github.io/meta/api/zopen_releases.json"
+  ZOPEN_JSON_CACHE_URL="https://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_releases.json"
 }
 
 addCleanupTrapCmd(){


### PR DESCRIPTION
* githubusercontent.com is likely more accessible than github.io: https://github.com/ZOSOpenTools/gpgport/issues/6#issuecomment-1813533898