### PR TITLE
zopen-build: Add an option to avoid installing runtime deps

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -292,6 +292,7 @@ printSyntax()
     echo "  -gp, --generate-pax  generate a pax.Z file based on the install contents"
     echo "  --forcepatchapply    force apply the patches, where rejected patches are placed into a corresponding file of the same name, with the .rej extension"
     echo "  --no-set-active      do not change the pinned version" 
+    echo "  --no-install-deps    do not install project's runtime dependencies"
     echo "  -s                   exec a shell before running configure.  Useful when manually building ports."
     echo ""
     echo "The specifics of how the tool works can be controlled through environment variables."
@@ -326,6 +327,7 @@ processOptions()
   forcePatchApply=false
   depsPath="${ZOPEN_PKGINSTALL}"
   forceUpgradeDeps=false
+  noInstallRuntimeDeps=false
   while [[ $# -gt 0 ]]; do
     case $1 in
     "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
@@ -351,6 +353,9 @@ processOptions()
       ;;
     "--forcepatchapply")
       forcePatchApply=true
+      ;;
+    "--no-install-deps")
+      noInstallRuntimeDeps=true
       ;;
     "-buildtype" | "--buildtype" | "-b")
       shift
@@ -1452,8 +1457,10 @@ ${varName}_originalDir="\$OLDPWD"
 ZZ
     echo "${ZOPEN_RUNTIME_DEPS}" | xargs | tr ' ' '\n' | sort | while read dep; do
       # Use the first path specified in the dependency search list to install to
-      if ! runAndLog "PATH=\"${curlpath}:${PATH}\" ${MYDIR}/zopen-install --install-or-upgrade ${dep} -v --no-deps -y"; then
-        printError "Failed to install dependencies"
+      if $noInstallRuntimeDeps; then
+        if ! runAndLog "PATH=\"${curlpath}:${PATH}\" ${MYDIR}/zopen-install --install-or-upgrade ${dep} -v --no-deps -y"; then
+          printError "Failed to install dependencies"
+        fi
       fi
       cat << ZZ >> "${ZOPEN_INSTALL_DIR}/.depsenv"
 if [ -f "../../${dep}/${dep}/.env" ]; then


### PR DESCRIPTION
By default runtime dependencies are installed as part of the zopen build process. Sometimes we don't want this, especially when we are debugging runtime dependencies along with the current project.