### PR TITLE
Query bug

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -573,7 +573,7 @@ if [ -z "${chosenRepos}" ]; then
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
-    chosenRepos="$(${MYDIR}/zopen-query list --installed --no-header --no-version 2>&1)"
+    chosenRepos="$(${MYDIR}/zopen-query --list --installed --no-header --no-version 2>&1)"
     zqrc=$?
     ${killph} 2> /dev/null # if the timer is not running, the kill will fail
     sleep 1 # give the above process time to clear

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -61,7 +61,7 @@ colorizepct()
   elif [ ${percentage} -eq 100 ]; then
     colored="${GREEN}"
   elif [ ${percentage} -gt 50 ]; then
-    colored="${BLUE}"
+    colored="${BOLD}${BLUE}"
   elif [ ${percentage} -gt 0 ]; then
     colored="${YELLOW}"
   else
@@ -200,9 +200,9 @@ printInstalledEntries()
   printVerbose "Screen width: ${scrcols}; colwidth:${colwidth}"
   if [ -n "$1" ] && ! ${noheader}; then
     if [ "${details}" -eq 0 ]; then
-      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "File" "Releaseline"
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Version" "File" "Releaseline"
     else
-      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "File" "Releaseline" "Expanded Size" "Quality"
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Version" "File" "Releaseline" "Expanded Size" "Quality"
     fi
   fi
   printVerbose "Getting list of symlinks in the package install directory (that point to specific versions)"
@@ -256,7 +256,7 @@ printInstalledEntries()
         if [ -e "${pkghome}/test.status" ]; then
           teststatus=$(cat "${pkghome}/test.status")
           percentage=$(echo "${teststatus}" | sed 's/[^-]*-\([^%\.]*\).*/\1/')
-          printf "${NC}%s-${colwidth}s${NC}" "$(colorizepct "${percentage}")" "${percentage}"
+          printf "${NC}$(colorizepct "${percentage}")%-${colwidth}s${NC}"  "${percentage}"
         else
           printf "${NC}${RED}%-${colwidth}s${NC}" "No tests"
         fi

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -196,9 +196,9 @@ printInstalledEntries()
 {
   scrcols=$(getScreenCols)
   [ "${details}" -eq 0 ] && numcols=4 || numcols=6
-  colwidth=$((${scrcols} / ${numcols} - 1))
+  colwidth=$((scrcols / numcols - 1))
   printVerbose "Screen width: ${scrcols}; colwidth:${colwidth}"
-  if [ ! -z "$1" ] && ! ${noheader}; then
+  if [ -n "$1" ] && ! ${noheader}; then
     if [ "${details}" -eq 0 ]; then
       printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "File" "Releaseline"
     else
@@ -206,7 +206,7 @@ printInstalledEntries()
     fi
   fi
   printVerbose "Getting list of symlinks in the package install directory (that point to specific versions)"
-  installedPackages=$(cd "${ZOPEN_PKGINSTALL}" && zosfind . -type l)
+  installedPackages=$(cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)
   printVerbose "Packages: ${installedPackages}"
   echo "${installedPackages}" | xargs | tr ' ' '\n' | sort | while read repo; do
     repo="${repo##*/}"
@@ -249,14 +249,14 @@ printInstalledEntries()
       if [ "${details}" -eq 1 ]; then
         # Extra headers: disk size and quality
         disksizestr=$(du "${ZOPEN_PKGINSTALL}/${repo}" | tail -n 1)
-        disksizestr=$(echo ${disksizestr} | sed 's#\([0-9]*\).*#\1#')
-        disksize=$((${disksizestr} * 512))
+        disksizestr=$(echo "${disksizestr}" | sed 's#\([0-9]*\).*#\1#')
+        disksize=$((disksizestr * 512))
         printf "%-${colwidth}d" "${disksize}"
 
         if [ -e "${pkghome}/test.status" ]; then
           teststatus=$(cat "${pkghome}/test.status")
           percentage=$(echo "${teststatus}" | sed 's/[^-]*-\([^%\.]*\).*/\1/')
-          printf "${NC}${s}%-${colwidth}s${NC}" "$(colorizepct "${percentage}")" "${percentage}"
+          printf "${NC}%s-${colwidth}s${NC}" "$(colorizepct "${percentage}")" "${percentage}"
         else
           printf "${NC}${RED}%-${colwidth}s${NC}" "No tests"
         fi
@@ -275,7 +275,7 @@ whatProvides()
   # Find any symlinks that match the needle and can then be dereferenced
   found=$(zosfind "${ZOPEN_ROOTFS}" -name "${ZOPEN_PKGINSTALL}/\*" -prune -o -type l -print | grep "${needle}")
   printVerbose "Found list: '${found}'"
-  if [[ -z "${found}" ]]; then
+  if [ -z "${found}" ]; then
     printInfo "No package provides '${needle}'"
   else
     matches=$(echo "${found}" | wc -w | tr -d ' ')
@@ -302,11 +302,11 @@ localoption=true
 upgradeable=false
 details=0
 needle=
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   printError "No option provided for query"
 fi
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   printVerbose "Parsing option: $1"
   case "$1" in
   "--list")
@@ -322,14 +322,14 @@ while [[ $# -gt 0 ]]; do
     localoption=true
     whatprovides=1
     shift
-    [ ! -z $1 ] || printError "Missing file argument"
+    [ -n "$1" ] || printError "Missing file argument"
     needle=$1
     ;;
   "--remote-search")
     localoption=false
     remotesearch=1
     shift
-    [ ! -z $1 ] || printError "Missing package argument"
+    [ -n "$1" ] || printError "Missing package argument"
     needle=$1
     ;;
   "--no-header")
@@ -354,10 +354,11 @@ while [[ $# -gt 0 ]]; do
     exit 0
     ;;
   "--version")
-    zopen-version ${ME}
+    zopen-version "${ME}"
     exit 0
     ;;
   "-v" | "--v" | "-verbose" | "--verbose")
+    # shellcheck disable=SC2034
     verbose=true
     ;;
   -*)


### PR DESCRIPTION
Fix bug with querying for installed packages from within zopen install/upgrade.  zopen-install calls zopen-query directly rather than using the list verb for zopen; the parameters are different for when a "list" action is required - zopen uses the "list" verb, zopen-query uses the "--list" parameter.  zopen-install incorrectly specifies "list" rather than "--list" and as such, the list of returned packages can become corrupted.  For small setups, this might not be noticeable as the returned list is sanitised, however with a sufficiently long list (like if a "--all" had been used previously), the list of packages will become corrupt and break the upgrade mechanism as well as taking a longer period of time than it should.  Full installations might not be upgradeable using the "zopen upgrade" command, packages might need to be manually listed.
The find used to determine the installed packages also recurses too deeply, returning huge volumes of data - again, this gets sanitised for processing but takes a long period of time and can cause issues with envvar lengths etc.  The zosfind should only now pick up in the current directory after switching to PKGINSTALL
In addition, colorization of columns in detailed mode and column headers have been updated and various shellcheck issues resolved.