### PR TITLE
Message cleanup

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -130,13 +130,13 @@ handlePackageInstall()
     printInfo "Versions available for install:"
     /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
 
-    printVerbose "Getting user selection"
+    printVerbose "Getting user selection."
     valid=false
     while ! ${valid}; do
       echo "Enter version to install (0-${i}): "
       read selection < /dev/tty
       if [[ ! -z $(echo "${selection}" | sed -e 's/[0-9]*//') ]]; then
-        echo "Invalid input, must be a number between 0 and ${i}"
+        echo "Invalid input, must be a number between 0 and ${i}."
       elif [ "${selection}" -ge 0 ] && [ "${selection}" -le "${i}" ]; then
         valid=true
       fi
@@ -148,32 +148,32 @@ handlePackageInstall()
     printVerbose "Install from release line '${releaseLine}' specified"
     validatedReleaseLine=$(validateReleaseLine "${releaseLine}")
     if [ -z "${validatedReleaseLine}" ]; then
-      printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE"
+      printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE."
     fi
     printVerbose "Finding latest asset on the release line"
     releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${releaseLine}'")))[0]')"
-    printVerbose "Use quick check for asset to check for existence of metadata"
+    printVerbose "Use quick check for asset to check for existence of metadata."
     asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
     if [ $? -ne 0 ]; then
-      printError "Could not find release-line ${releaseLine} for repo: ${repo}"
+      printError "Could not find release-line ${releaseLine} for repo: ${repo}."
     fi
 
   else
-    printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
+    printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline."
     if [ -n "${installedReleaseLine}" ]; then
-      printVerbose "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline"
+      printVerbose "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline."
       validatedReleaseLine="${installedReleaseLine}" # Already validated when stored
     else
-      printVerbose "Checking for system-configured releaseline"
+      printVerbose "Checking for system-configured releaseline."
       sysrelline=$(cat "${ZOPEN_ROOTFS}/etc/zopen/releaseline" | awk ' {print toupper($1)}')
       printVerbose "Validating value: ${sysrelline}"
       validatedReleaseLine=$(validateReleaseLine "${sysrelline}")
       if [ -n "${validatedReleaseLine}" ]; then
-        printVerbose "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline"
+        printVerbose "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline."
       else
-        printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages"
-        printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message"
-        printWarning "Valid values are: DEV | STABLE"
+        printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages."
+        printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message."
+        printWarning "Valid values are: DEV | STABLE."
         validatedReleaseLine="STABLE"
       fi
     fi

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -194,19 +194,19 @@ handlePackageInstall()
       printVerbose "Found a specific '${validatedReleaseLine}' release-line tagged version; installing..."
     else
       # Case 2 & 3
-      printVerbose "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline"
+      printVerbose "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline."
       alt=$(echo "${validatedReleaseLine}" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
       releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${alt}'")))[0]')"
       printVerbose "Use quick check for asset to check for existence of metadata"
       asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
       if [ $? -eq 0 ]; then
-        printVerbose "Found a release on the '${alt}' release line so release tagging is active"
+        printVerbose "Found a release on the '${alt}' release line so release tagging is active."
         if [ "DEV" = "${validatedReleaseLine}" ]; then
           # The system will be configured to use DEV packages where available but if none, use latest
           printInfo "No specific DEV releaseline package, using latest available"
           releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
         else
-          printVerbose "The system is configured to only use STABLE releaseline packages but there are none"
+          printVerbose "The system is configured to only use STABLE releaseline packages but there are none."
           printInfo "No release available on the '${validatedReleaseLine}' releaseline."
         fi
       else
@@ -219,7 +219,7 @@ handlePackageInstall()
 
   printVerbose "Getting specific asset details from metadata: ${releaseMetadata}"
   if [ -z "${asset}" ] || [ "null" = "${asset}" ]; then
-    printVerbose "Asset not found during previous logic; setting now"
+    printVerbose "Asset not found during previous logic; setting now."
     asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
   fi
   if [ -z "${asset}" ]; then
@@ -240,39 +240,39 @@ handlePackageInstall()
   printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
 
   if ${downloadOnly}; then
-    printVerbose "Skipping installation, downloading only"
+    printVerbose "Skipping installation, downloading only."
   else
     printVerbose "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
     if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
       if ! ${reinstall}; then
-        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC} and due to the absence of the 'reinstall' flag, will not be reinstalled"
+        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC} and due to the absence of the 'reinstall' flag, will not be reinstalled."
         return
       fi
       printInfo "- Reinstalling version '${downloadFileVer}' of ${name}..."
     fi
 
-    printVerbose "Checking if package is not installed but scheduled for upgrade"
+    printVerbose "Checking if package is not installed but scheduled for upgrade."
     if [ -z "${originalFileVersion}" ]; then
-      printVerbose "No previous version found"
+      printVerbose "No previous version found."
       if ${installOrUpgrade}; then
-        printVerbose "Package ${name} was not installed so not upgrading but installing"
+        printVerbose "Package ${name} was not installed, so installing instead of upgrading."
       elif ${upgradeInstalled}; then
-        printError "Package ${name} can not be upgraded as it is not installed!"
+        printError "Package ${name} can not be upgraded as it is not installed."
         continue
       fi
       unInstallOldVersion=false
       printInfo "- Installing ${name}..."
     elif ${skipupgrade}; then
-      printInfo "Package ${name} has a newer release '${downloadFileVer}' but was not specified for an upgrade"
+      printInfo "Package ${name} has a newer release '${downloadFileVer}' but was not specified for an upgrade."
       continue
     elif ! ${setactive}; then
-      printVerbose "Current version '${originalFileVersion}' will remain active"
+      printVerbose "Current version '${originalFileVersion}' will remain active."
       unInstallOldVersion=false
     else
-      printVerbose "Previous version '${originalFileVersion}' installed"
+      printVerbose "Previous version '${originalFileVersion}' installed."
       if [ -e "${rootInstallDir}/${name}/${name}/.pinned" ]; then
-        printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped"
-        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_INSTALL}" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped"
+        printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped."
+        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_INSTALL}" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped."
         continue
       else
         printInfo "- Replacing ${name} version '${originalFileVersion}' with '${downloadFileVer}'"
@@ -308,14 +308,14 @@ handlePackageInstall()
     addCleanupTrapCmd "${killph}"
 
     if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
-      printError "Could not download from ${downloadURL}. Correct any errors and potentially retry"
+      printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
       continue
     fi
     ${killph} 2> /dev/null # if the timer is not running, the kill will fail
     syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_NETWORK},${CAT_PACKAGE},${CAT_FILE}" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '${pax}'"
   fi
   if [ ! -f "${pax}" ]; then
-    printError "${pax} was not found after download!?!"
+    printError "${pax} was not found after download!?"
   fi
 
   if ${downloadOnly}; then
@@ -363,8 +363,8 @@ handlePackageInstall()
     fi
 
     if ! runLogProgress "pax -rf ${pax} -p p ${paxredirect} ${redirectToDevNull}" "Expanding ${pax}" "Expanded"; then
-      printWarning "Errors unpaxing, package directory state unknown"
-      printInfo "Use zopen alt to select previous version"
+      printWarning "Errors unpaxing, package directory state unknown."
+      printInfo "Use zopen alt to select previous version."
       continue
     fi
     if ${localInstall}; then
@@ -377,11 +377,11 @@ handlePackageInstall()
         rm -f "${baseinstalldir}/${name}/${name}"
       fi
       if ! ln -s "${baseinstalldir}/${installdirname}" "${baseinstalldir}/${name}/${name}"; then
-        printError "Could not create symbolic link name"
+        printError "Could not create symbolic link name."
       fi
     fi
 
-    printVerbose "Adding version '${downloadFileVer}' to info file"
+    printVerbose "Adding version '${downloadFileVer}' to info file."
     # Add file version information as a .releaseinfo file
     echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.releaseinfo"
 
@@ -402,7 +402,7 @@ handlePackageInstall()
         printVerbose "The merge completed with: ${misrc}"
       fi
 
-      printInfo "- Checking for env file"
+      printInfo "- Checking for env file."
       if [ -f "${baseinstalldir}/${name}/${name}/.env" ] || [ -f "${baseinstalldir}/${name}/${name}/.appenv" ]; then
         printInfo "- .env file found, adding to profiled processing."
         mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
@@ -563,7 +563,7 @@ done
 
 if [ -z "${chosenRepos}" ]; then
   if ! ${all} && ! ${upgradeInstalled}; then
-    printInfo "No ports selected for installation"
+    printInfo "No ports selected for installation."
     exit 4
   fi
   if ${upgradeInstalled}; then

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -81,24 +81,24 @@ handlePackageInstall()
 
   originalFileVersion=""
   printVerbose "Checking for meta files in '${rootInstallDir}/${name}/${name}'"
-  printVerbose "Finding version/release information"
+  printVerbose "Finding version/release information."
   if [ -e "${rootInstallDir}/${name}/${name}/.releaseinfo" ]; then
     originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.releaseinfo")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)"
+    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
   elif [ -e "${rootInstallDir}/${name}/${name}/.version" ]; then
     originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.version")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)"
+    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
   else
     printVerbose "Could not detect existing installation at ${rootInstallDir}/${name}/${name}"
   fi
 
-  printVerbose "Finding releaseline information"
+  printVerbose "Finding releaseline information."
   installedReleaseLine=""
   if [ -e "${rootInstallDir}/${name}/${name}/.releaseline" ]; then
     installedReleaseLine=$(cat "${rootInstallDir}/${name}/${name}/.releaseline")
     printVerbose "Installed product from releaseline: ${installedReleaseLine}"
   else
-    printVerbose "No current releaseline for package"
+    printVerbose "No current releaseline for package."
   fi
 
   releaseMetadata=""
@@ -106,7 +106,7 @@ handlePackageInstall()
   # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
   # either for a previous package install or system default
   if [ -n "${versioned}" ]; then
-    printVerbose "Specific version ${versioned} requested - checking existence and URL"
+    printVerbose "Specific version ${versioned} requested - checking existence and URL."
     requestedMajor=$(echo "${versioned}" | awk -F'.' '{print $1}')
     requestedMinor=$(echo "${versioned}" | awk -F'.' '{print $2}')
     requestedPatch=$(echo "${versioned}" | awk -F'.' '{print $3}')
@@ -115,9 +115,9 @@ handlePackageInstall()
     printVerbose "Finding URL for latest release matching version prefix: requestedVersion: ${requestedVersion}"
     releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.assets[].name | test("'${requestedVersion}'")))[0]')
   elif [ -n "${tagged}" ]; then
-    printVerbose "Explicit tagged version '${tagged}' specified. Checking for match"
+    printVerbose "Explicit tagged version '${tagged}' specified. Checking for match."
     releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '.[] | select(.tag_name == "'${tagged}'")')
-    printVerbose "Use quick check for asset to check for existence of metadata for specific messages"
+    printVerbose "Use quick check for asset to check for existence of metadata for specific messages."
     asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
     if [ $? -ne 0 ]; then
       printError "Could not find release tagged '${tagged}' in repo '${repo}'"
@@ -125,7 +125,7 @@ handlePackageInstall()
   elif ${selectVersion}; then
     # Explicitly allow the user to select a release to install; useful if there are broken installs
     # as a known good release can be found, selected and pinned!
-    printVerbose "List individual releases and allow selection"
+    printVerbose "List individual releases and allow selection."
     i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
     printInfo "Versions available for install:"
     /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
@@ -286,10 +286,10 @@ handlePackageInstall()
   printVerbose "Ensuring we are in the correct working download location '${downloadDir}'"
   cd "${downloadDir}" || exit
   if [ ! -n "${downloadOnly}" ] || [ ! -n "${localInstall}" ]; then
-    printVerbose "Checking current directory for already downloaded package [file name comparison]"
+    printVerbose "Checking current directory for already downloaded package [file name comparison]."
     location="current directory"
   else
-    printVerbose "Checking cache for already downloaded package [file name comparison]"
+    printVerbose "Checking cache for already downloaded package [file name comparison]."
     location="zopen package cache"
   fi
 
@@ -334,7 +334,7 @@ handlePackageInstall()
       paxredirect="-s %[^/]*/%${rootInstallDir}/${installdirname}/%"
       printVerbose "Non-local install, extracting with '${paxredirect}'"
     else
-      printInfo "- Local install specified"
+      printInfo "- Local install specified."
       paxredirect="-s %[^/]*/%${installdirname}/%"
       printVerbose "Non-local install, extracting with '${paxredirect}'"
     fi
@@ -404,7 +404,7 @@ handlePackageInstall()
 
       printInfo "- Checking for env file"
       if [ -f "${baseinstalldir}/${name}/${name}/.env" ] || [ -f "${baseinstalldir}/${name}/${name}/.appenv" ]; then
-        printInfo "- .env file found, adding to profiled processing"
+        printInfo "- .env file found, adding to profiled processing."
         mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
         cat << EOF > "${ZOPEN_ROOTFS}/etc/profiled/${name}/dotenv"
 curdir=\$(pwd)
@@ -417,35 +417,35 @@ elif [ -f ".env" ]; then
 fi
 cd \${curdir}  >/dev/null 2>&1
 EOF
-        printInfo "- Sourcing environment to run any setup"
+        printInfo "- Sourcing environment to run any setup."
         cd "${baseinstalldir}/${name}/${name}" && ./setup.sh
       fi
     fi
     if ${unInstallOldVersion}; then
-      printVerbose "New version merged; checking for orphaned files from previous version"
+      printVerbose "New version merged; checking for orphaned files from previous version."
       # This will remove any old symlinks or dirs that might have changed in an upgrade
       # as the merge process overwrites existing files to point to different version
       unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}"
     fi
 
     if ${setactive}; then
-      printVerbose "Marking this version as installed"
+      printVerbose "Marking this version as installed."
       touch "${baseinstalldir}/${name}/${name}/.active"
       installedList="${name} ${installedList}"
       syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
     fi
 
     if ${doNotInstallDeps}; then
-      printInfo "- Skipping dependency installation"
+      printInfo "- Skipping dependency installation."
     elif ${reinstall}; then
-      printVerbose "- Reinstalling so no dependency reinstall (unless explicitly listed)"
+      printVerbose "- Reinstalling so no dependency reinstall (unless explicitly listed)."
     else
-      printInfo "- Checking for runtime dependencies"
-      printVerbose "Checking for .runtimedeps file"
+      printInfo "- Checking for runtime dependencies."
+      printVerbose "Checking for .runtimedeps file."
       if [ -e "${baseinstalldir}/${name}/${name}/.runtimedeps" ]; then
         dependencies=$(cat "${baseinstalldir}/${name}/${name}/.runtimedeps")
       fi
-      printVerbose "Checking for runtime dependencies from the git metadata"
+      printVerbose "Checking for runtime dependencies from the git metadata."
       if echo "${statusline}" | grep "Runtime Dependencies:" > /dev/null; then
         gitmetadependencies="$(echo "${statusline}" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
         if [ ! "${gitmetadependencies}" = "No dependencies" ]; then
@@ -455,13 +455,13 @@ EOF
       dependencies=$(deleteDuplicateEntries "${dependencies}" " ")
       if [ -n "${dependencies}" ]; then
         printInfo "- ${name} depends on: ${dependencies}"
-        printInfo "- Installing dependencies"
+        printInfo "- Installing dependencies."
         installDependencies "${name}" "${dependencies}"
       else
-        printInfo "- No runtime dependencies found"
+        printInfo "- No runtime dependencies found."
       fi
     fi
-    printInfo "${NC}${GREEN}Successfully installed ${name}${NC}"
+    printInfo "${NC}${GREEN}Successfully installed: ${name}${NC}"
   fi # (download only)
 }
 
@@ -567,9 +567,9 @@ if [ -z "${chosenRepos}" ]; then
     exit 4
   fi
   if ${upgradeInstalled}; then
-    printVerbose "No specific port to upgrade, upgrade all installed packages"
-    printInfo "- Querying for installed packages"
-    progressHandler "spinner" "- Query complete" &
+    printVerbose "No specific port to upgrade, upgrade all installed packages."
+    printInfo "- Querying for installed packages."
+    progressHandler "spinner" "- Query complete." &
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"
@@ -598,7 +598,7 @@ elif ${localInstall}; then
 else
   printVerbose "Installing to zopen file system: ${ZOPEN_ROOTFS}"
   if [ -z "${ZOPEN_ROOTFS}" ]; then
-    printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined"
+    printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined."
   fi
   downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
 fi
@@ -616,7 +616,7 @@ fi
 
 printVerbose "Working directory: ${downloadDir}"
 # Parse passed in repositories and check if valid zopen framework repos
-printInfo "- Querying remote repo for latest package information"
+printInfo "- Querying remote repo for latest package information."
 getReposFromGithub
 grfgRc=$?
 ${killph} 2> /dev/null # if the timer is not running, the kill will fail
@@ -631,15 +631,15 @@ if ${all}; then
     spaceRequiredBytes=$(jq '.release_data | to_entries | map(select(.value | length > 0)) | map(.value[0].assets[0]) | reduce .[] as $item ({}; . + {($item.name): ($item.size + $item.expanded_size)}) | [.[]] | add' ${JSON_CACHE})
     spaceRequiredMB=$(echo "scale=0; ${spaceRequiredBytes} / (1024 * 1024)" | bc)
     availableSpaceMB=$(/bin/df -m ${ZOPEN_ROOTFS} | sed "1d" | awk '{ print $3 }' | awk -F'/' '{ print $1 }')
-    
+
     printInfo "You have chosen to install all tools. An estimated ${spaceRequiredMB} MB of additional disk space will be used."
     if [ $availableSpaceMB -lt $spaceRequiredMB ]; then
       printWarning "Your zopen file-system ($ZOPEN_ROOTFS) only has ${availableSpaceMB} MB of available space."
     fi
-    printInfo "Enter 'all' to confirm full installation [takes a long time so be sure!]:"
+    printInfo "Enter 'all' to confirm full installation. (This can take a VERY long time!):"
     confirmall=$(getInput)
     if [ ! "xall" = "x${confirmall}" ]; then
-      printError "Cancelling full installation"
+      printError "Cancelling full installation."
     fi
   fi
   for repo in $(echo ${repo_results}); do
@@ -648,20 +648,20 @@ if ${all}; then
   installArray=$(strtrim "${installArray}")
 else
   for chosenRepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
-    printVerbose "Processing repo: ${chosenrepo}"
-    printVerbose "Stripping any version (%), tag (#) or port suffixes"
+    printVerbose "Processing repo: ${chosenRepo}."
+    printVerbose "Stripping any version (%), tag (#) or port suffixes."
     toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
-    printVerbose "Adding prefix and 'port' suffix" # quicker than testing for presence!
+    printVerbose "Adding prefix and 'port' suffix." # quicker than testing for presence!
     toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}')
     if [ "${toolfound}" = "${toolrepo}" ]; then
-      printVerbose "Adding '${chosenRepo}' to the install queue"
+      printVerbose "Adding '${chosenRepo}' to the install queue."
       installArray="${installArray} ${chosenRepo}"
-      printVerbose "Removing valid port from input list"
+      printVerbose "Removing valid port from input list."
       chosenRepos=$(echo "${chosenRepos}" | sed -e "s#${chosenRepo}##")
     fi
   done
 fi
-printVerbose "Checking whether any ports remain in the input list"
+printVerbose "Checking whether any ports remain in the input list."
 chosenRepos=$(strtrim "${chosenRepos}")
 if [ -n "${chosenRepos}" ]; then
   printError "The following requested port(s) do not exist:\n\t$(echo ${chosenRepos} | tr -s '[:space:]')"

--- a/include/common.sh
+++ b/include/common.sh
@@ -679,7 +679,7 @@ printVerbose()
 {
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   if ${verbose}; then
-    printColors "${NC}${GREEN}${BOLD}VERBOSE${NC}: '${1}'" >&2
+    printColors "${NC}${GREEN}${BOLD}VERBOSE${NC}: ${1}" >&2
   fi
   [ ! -z "${xtrc}" ] && set -x
   return 0

--- a/include/common.sh
+++ b/include/common.sh
@@ -76,7 +76,7 @@ getCurrentVersionDir(){
 }
 
 # isPackageActive
-# returns whether the package is active ie. has a symlink from 
+# returns whether the package is active ie. has a symlink from
 #  $PKGINSTALL/pkg/pkg to a versioned directory
 # inputs: $1 - package to get currently active version of
 # return: 0  for active
@@ -87,7 +87,7 @@ isPackageActive(){
 }
 
 # Generate a file name that has a high probability of being unique for
-# use as a temporary filename - the filename should be unique in the 
+# use as a temporary filename - the filename should be unique in the
 # instance it was generated and probability suggests it should be for
 # a "reasonable" time after...
 mktempfile()
@@ -120,7 +120,7 @@ isPermString()
   test=$(echo "$1" | zossed "s/[-+rwxugo,=]//g")
   if [ -n "${test}" ]; then
     printDebug "Permission string '$1' was invalid"
-    false; 
+    false;
   else
     true;
   fi
@@ -150,7 +150,7 @@ sanitizeEnvVar(){
   echo "\${value}" | awk -v RS="\${delim}" -v DLIM="\${delim}" -v PRFX="\${prefix}" '{ if (match(\$1, PRFX)==0) {printf("%s%s",\$1,DLIM)}}'
 }
 
-deleteDuplicateEntries() 
+deleteDuplicateEntries()
 {
   value="\$1"
   delim="\$2"
@@ -179,7 +179,7 @@ if [ -z "\${ZOPEN_QUICK_LOAD}" ]; then
     printf "Processing \$zot configuration..."
     for dotenv in \$dotenvs; do
       . \$dotenv
-    done 
+    done
     /bin/echo "DONE"
     unset dotenvs
   fi
@@ -253,7 +253,7 @@ defineANSI()
   CRSRHIDE="${ESC}[?25l"
   # shellcheck disable=SC2034
   CRSRSHOW="${ESC}[?25h"
-  
+
   # Color-type codes, needs explicit terminal settings
   if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
     esc="\047"
@@ -270,7 +270,7 @@ defineANSI()
     NC="${esc}[0m"
     darkbackground
     bg=$?
-    if [ $bg -ne 0 ]; then 
+    if [ $bg -ne 0 ]; then
       #if the background was set to black or unknown the header and warning color will be yellow
       HEADERCOLOR="${YELLOW}"
       WARNINGCOLOR="${YELLOW}"
@@ -517,7 +517,7 @@ mergeIntoSystem()
     ln -Rs "${dirrelpath}/" "." 2> /dev/null
   done
 
-  printDebug "Moving unpaxed processing-directory back to main rootfs store"
+  printDebug "Moving unpaxed processing-directory back to main rootfs store."
   # this *must* be done before the merge step below or relative symlinks can't
   # work
   versioneddirname=$(basename "${versioneddir}")
@@ -530,21 +530,21 @@ mergeIntoSystem()
   # Need '-S' to allow long symlinks
   $(cd "${processingDir}" && tar -S -cf "${tarfile}" "usr")
 
-  printDebug "Generating listing for remove processing (including main symlink)"
+  printDebug "Generating listing for remove processing (including main symlink)."
   listing=$(tar tf "${processingDir}/${tarfile}" 2> /dev/null | sort -r)
   echo "Installed files:" > "${versioneddir}/.links"
   echo "${listing}" >> "${versioneddir}/.links"
 
-  printDebug "Extracting tar to rootfs"
+  printDebug "Extracting tar to rootfs."
   cd "${processingDir}" && tar xf "${tarfile}" -C "${rootfs}" 2> /dev/null
 
-  printDebug "Cleaning temp resources"
+  printDebug "Cleaning temp resources."
   rm -rf "${processingDir}" 2> /dev/null
 
-  printDebug "Switching to previous cwd - current work dir was purged"
+  printDebug "Switching to previous cwd - current work dir was purged."
   cd "${currentDir}" || exit
 
-  printInfo "- Integration complete"
+  printInfo "- Integration complete."
   return 0
 }
 
@@ -559,7 +559,7 @@ unsymlinkFromSystem()
   rootfs=$2
   dotlinks=$3
   if [ -e "${dotlinks}" ]; then
-    printInfo "- Checking for obsoleted files in ${rootfs}/usr/ tree from ${pkg}"
+    printInfo "- Checking for obsoleted files in ${rootfs}/usr/ tree from ${pkg}."
     # Use sed to skip header line in .links file
     # Note that the contents of the links file are ordered such that
     # processing occurs depth-first; if, after removing orphaned symlinks,
@@ -568,28 +568,28 @@ unsymlinkFromSystem()
     flecnt=0
     pct=0
 
-    printDebug "Creating Temporary dirname file"
+    printDebug "Creating temporary dirname file."
     tempDirFile="${ZOPEN_ROOTFS}/tmp/zopen.rmdir.${RANDOM}"
     tempTrash="${tempDirFile}.trash"
     [ -e "${tempDirFile}" ] && rm -f "${tempDirFile}" > /dev/null 2>&1
     touch "${tempDirFile}"
     addCleanupTrapCmd "rm -rf ${tempDirFile}"
     printDebug "Using temporary file ${tempDirFile}"
-    printInfo "- Checking ${nfiles} potential links"
+    printInfo "- Checking ${nfiles} potential links."
 
     rm_fileprocs=15
     [ -e "${rootfs}/etc/zopen/rm_fileprocs" ] && rm_fileprocs=$(cat "${rootfs}/etc/zopen/rm_fileprocs")
     threshold=$((nfiles / rm_fileprocs))
     threshold=$((threshold + 1))
     printDebug "Threshold of files per worker [files/procs] calculated as: ${threshold}"
-    [ "${threshold}" -le 50 ] && threshold=50 && printVerbose "Threshold below min: using 50" # Don't spawn too many
+    [ "${threshold}" -le 50 ] && threshold=50 && printVerbose "Threshold below min: using 50." # Don't spawn too many
     printDebug "Starting spinner..."
     progressHandler "spinner" "- Complete" &
     ph=$!
     killph="kill -HUP ${ph} 2>/dev/null"
     addCleanupTrapCmd "${killph}"
 
-    printDebug "Spawning as subshell to handle threading"
+    printDebug "Spawning as subshell to handle threading."
     # Note that this all must happen in a subshell as the above started
     # progressHandler is a signal-terminated process - and a wait issued in
     # the parent will never complete until that ph is signalled/terminated!
@@ -744,7 +744,7 @@ spinloop()
 
 progressAnimation()
 {
-  [ $# -eq 0 ] && printError "Internal error: no animation strings"
+  [ $# -eq 0 ] && printError "Internal error: no animation strings."
   animcnt=$#
   anim=1
   ansiline 0 0 "$1"
@@ -752,7 +752,7 @@ progressAnimation()
     spinloop 1000
     # Check for daemonization of this process (ie. orphaned and PPID=1)
     # Cannot actually use "$PPID" as it is set at script initialization
-    # and not updated when the parent changes so need to query
+    # and not updated when the parent changes so need to query.
     getParentProcess "$$" >/dev/null 2>&1
     ppid=$?
     [ "${ppid}" -eq 1 ] && kill INT "${ppid}" >/dev/null 2>&1
@@ -780,7 +780,7 @@ progressHandler()
     # shellcheck disable=SC2064
     trap "${trapcmd}" HUP
     case "${type}" in
-      "spinner") progressAnimation '-' '\' '|' '/' 
+      "spinner") progressAnimation '-' '\' '|' '/'
       ;;
       "network") progressAnimation '-----' '>----' '->---' '-->--' '--->-' '---->' '-----' '----<' '---<-' '--<--' '-<---' '<----'
       ;;
@@ -795,7 +795,7 @@ runInBackgroundWithTimeoutAndLog()
   command="$1"
   timeout="$2"
 
-  printVerbose "${command} with timeout of ${timeout}s"
+  printVerbose "${command} with timeout of ${timeout}s."
   eval "${command} &; TEEPID=$!"
   PID=$!
   n=0
@@ -897,7 +897,7 @@ processConfig()
     if [ -f "${relativeRootDir}/etc/zopen-config" ]; then
       . "${relativeRootDir}/etc/zopen-config"
     else
-      printError "Source the zopen-config prior to running $0"
+      printError "Source the zopen-config prior to running $0."
     fi
   fi
 }
@@ -989,9 +989,9 @@ validateVersion()
   requestedVersion=$3
   dependency=$4
   if [ -n "${operator}" ] && [ -z "${version}" ]; then
-    printVerbose "${operator} ${requestedVersion} requsted, but no version file found in ${versionPath}."
+    printVerbose "${operator} ${requestedVersion} requested, but no version file found in ${versionPath}"
     return 1
-  elif [ ! -z "${operator}" ] && ! compareVersions "${version}" "${requestedVersion}"; then
+  elif [ -n "${operator}" ] && ! compareVersions "${version}" "${requestedVersion}"; then
     printVerbose "${dependency} does not satisfy ${version} ${operator} ${requestedVersion}"
     return 1
   fi
@@ -1054,13 +1054,13 @@ downloadJSONCache()
 
     # Need to check that we can read & write to the JSON timestamp cache files
     if [ -e "${JSON_TIMESTAMP_CURRENT}" ]; then
-      [ ! -w "${JSON_TIMESTAMP_CURRENT}" ] || [ ! -r "${JSON_TIMESTAMP_CURRENT}" ] && printError "Cannot access cache at '${JSON_TIMESTAMP_CURRENT}'. Check permissions and retry request"
+      [ ! -w "${JSON_TIMESTAMP_CURRENT}" ] || [ ! -r "${JSON_TIMESTAMP_CURRENT}" ] && printError "Cannot access cache at '${JSON_TIMESTAMP_CURRENT}'. Check permissions and retry request."
     fi
     if [ -e "${JSON_TIMESTAMP}" ]; then
-      [ ! -w "${JSON_TIMESTAMP}" ] || [ ! -r "${JSON_TIMESTAMP}" ] && printError "Cannot access cache at '${JSON_TIMESTAMP}'. Check permissions and retry request"
+      [ ! -w "${JSON_TIMESTAMP}" ] || [ ! -r "${JSON_TIMESTAMP}" ] && printError "Cannot access cache at '${JSON_TIMESTAMP}'. Check permissions and retry request."
     fi
     if [ -e "${JSON_CACHE}" ]; then
-      [ ! -w "${JSON_CACHE}" ] || [ ! -r "${JSON_CACHE}" ] && printError "Cannot access cache at '${JSON_CACHE}'. Check permissions and retry request"
+      [ ! -w "${JSON_CACHE}" ] || [ ! -r "${JSON_CACHE}" ] && printError "Cannot access cache at '${JSON_CACHE}'. Check permissions and retry request."
     fi
 
     if ! curlCmd -L -s -I "${ZOPEN_JSON_CACHE_URL}" -o "${JSON_TIMESTAMP_CURRENT}"; then
@@ -1071,8 +1071,8 @@ downloadJSONCache()
     if [ -f "${JSON_CACHE}" ] && [ -f "${JSON_TIMESTAMP}" ] && [ "$(grep 'Last-Modified' "${JSON_TIMESTAMP_CURRENT}")" = "$(grep 'Last-Modified' "${JSON_TIMESTAMP}")" ]; then
       return
     fi
-    
-    printVerbose "Replacing old timestamp with latest"
+
+    printVerbose "Replacing old timestamp with latest."
     mv -f "${JSON_TIMESTAMP_CURRENT}" "${JSON_TIMESTAMP}"
 
     if ! curlCmd -L -s -o "${JSON_CACHE}" "${ZOPEN_JSON_CACHE_URL}"; then
@@ -1126,8 +1126,7 @@ checkWritable()
   fi
   ROOTDIR="$(cd "${INCDIR}/../" > /dev/null 2>&1 && pwd -P)"
   if ! [ -w "${ROOTDIR}" ]; then
-    printError "Tried to run an update operation (${ME}) in a read-only tools distribution" >&2
-    exit 8
+    printError "Tools distribution is read-only. Cannot run update operation '${ME}'." >&2
   fi
 }
 


### PR DESCRIPTION
A significant number of output messages did not have periods at the end of the text.  I've added them, except in the case where the last part of the message is a path.

I've cleaned up the verbose message output by removing extraneous single quotes around the text that cluttered things up.

I also fixed a variable (`chosenRepo`) that had the wrong case, which prevented the text from being printed.