### PR TITLE
Use ETag vs Last modified to check if zopen_releases.json is updated

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -1081,7 +1081,7 @@ downloadJSONCache()
     fi
     chtag -tc 819 "${JSON_TIMESTAMP_CURRENT}"
 
-    if [ -f "${JSON_CACHE}" ] && [ -f "${JSON_TIMESTAMP}" ] && [ "$(grep 'Last-Modified' "${JSON_TIMESTAMP_CURRENT}")" = "$(grep 'Last-Modified' "${JSON_TIMESTAMP}")" ]; then
+    if [ -f "${JSON_CACHE}" ] && [ -f "${JSON_TIMESTAMP}" ] && grep -q 'ETag' "${JSON_TIMESTAMP_CURRENT}" && [ "$(grep 'ETag' "${JSON_TIMESTAMP_CURRENT}")" = "$(grep 'ETag' "${JSON_TIMESTAMP}")" ]; then
       return
     fi
 


### PR DESCRIPTION
* This fixes the problem of zopen list/zopen install not pulling in the latest releases because zopen_releases.json is not getting updated.
* With the change to use `https://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_releases.json`, it seems that the "Last modified" http header is removed. So we now use ETag instead: https://en.wikipedia.org/wiki/HTTP_ETag . I verified that the ETag changes once zopen_releases.json is updated.
* The PR also check if ETag exists, and if it doesn't download the zopen_releases.json cache

I'll add a subsequent test in metaport to ensure ETag is present