### PR TITLE
Metaport43 zopen upgrade failure

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -654,6 +654,7 @@ if ${all}; then
   done
   installArray=$(strtrim "${installArray}")
 else
+  chosenRepos=$(strtrim "${chosenRepos}")
   for chosenRepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
     printVerbose "Processing repo: ${chosenrepo}"
     printVerbose "Stripping any version (%), tag (#) or port suffixes"
@@ -664,7 +665,7 @@ else
       printVerbose "Adding '${chosenRepo}' to the install queue."
       installArray="${installArray} ${chosenRepo}"
       printVerbose "Removing valid port from input list."
-      chosenRepos=$(echo "${chosenRepos}" | sed -e "s#${chosenRepo}##")
+      chosenRepos=$(echo "${chosenRepos}" | sed -e "s#^${chosenRepo}\$##")
     fi
   done
 fi

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -67,8 +67,9 @@ handlePackageInstall()
   repo="${name}"
   versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
   tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
-  printVerbose "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
-  printHeader "Installing package: ${name}"
+  printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
+  printInfo "Processing package: ${name}"
+
   nameSansPort=$(echo "${name}" | sed -e 's#\(.*\)port$#\1#')
   # findutilsport -> findutils
   # findutils -> findutils
@@ -252,7 +253,7 @@ handlePackageInstall()
     printVerbose "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
     if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
       if ! ${reinstall}; then
-        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer}${NC} and due to the absence of the 'reinstall' flag, will not be reinstalled."
+        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer} and due to the absence of the 'reinstall' flag, will not be reinstalled.${NC}"
         return
       fi
       printInfo "- Reinstalling version '${downloadFileVer}' of ${name}..."
@@ -623,7 +624,7 @@ fi
 
 printVerbose "Working directory: ${downloadDir}"
 # Parse passed in repositories and check if valid zopen framework repos
-printInfo "- Querying remote repo for latest package information."
+printInfo "- Querying repo for latest package information."
 getReposFromGithub
 grfgRc=$?
 ${killph} 2> /dev/null # if the timer is not running, the kill will fail
@@ -655,24 +656,27 @@ if ${all}; then
   installArray=$(strtrim "${installArray}")
 else
   chosenRepos=$(strtrim "${chosenRepos}")
-  for chosenRepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
-    printVerbose "Processing repo: ${chosenrepo}"
+  invalidlist=""
+  for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' ' | tr -s ' '); do
+    printVerbose "Processing repo: ${chosenRepo}"
     printVerbose "Stripping any version (%), tag (#) or port suffixes"
-    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#\(.*\)port$#\1#')
-    printVerbose "Adding prefix and 'port' suffix" # quicker than testing for presence!
+    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##')
     toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}')
     if [ "${toolfound}" = "${toolrepo}" ]; then
       printVerbose "Adding '${chosenRepo}' to the install queue."
       installArray="${installArray} ${chosenRepo}"
       printVerbose "Removing valid port from input list."
       chosenRepos=$(echo "${chosenRepos}" | sed -e "s#^${chosenRepo}\$##")
+    else
+      invalidlist=$(printf "%s %s" "${invalidlist}" "${chosenRepo}")
     fi
   done
 fi
-printVerbose "Checking whether any ports remain in the input list."
-chosenRepos=$(strtrim "${chosenRepos}")
-if [ -n "${chosenRepos}" ]; then
-  printError "The following requested port(s) do not exist:\n\t$(echo ${chosenRepos} | tr -s '[:space:]')"
+
+printVerbose "Checking whether any invalid ports were specified."
+if [ -n "${invalidlist}" ]; then
+  printSoftError "The following requested port(s) do not exist:\n\t$(echo "${invalidlist}" | tr -s '[:space:]')"
+  printError "Check port name(s), remove any port suffixes and retry command."
 fi
 
 installPorts "${installArray}"

--- a/include/common.sh
+++ b/include/common.sh
@@ -376,7 +376,7 @@ findrev()
 
 strtrim()
 {
-  echo "$1" | sed -e 's/^[ ]*//' -e 's/[ ]*$//'
+  echo "$1" | sed -e 's/^\s*//' -e 's/[ ]*$//'
 }
 
 defineEnvironment()

--- a/include/common.sh
+++ b/include/common.sh
@@ -376,7 +376,7 @@ findrev()
 
 strtrim()
 {
-  echo "$1" | sed -e 's/^\s*//' -e 's/[ ]*$//'
+  echo "$1" | sed -e 's/^[ \t]*//' -e 's/[ ]*$//'
 }
 
 defineEnvironment()


### PR DESCRIPTION
Should fix ZOSOpenTools/metaport/#43
Fixes logic that populates the install/upgrade tree and causes issues with ports like git/githubcli, lua/luarocks, tree/zospstree ...
