### PR TITLE
Implement some granular logic to --cache

### DIFF
--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -27,13 +27,15 @@ from the system to save space and prevent clutter
 Usage: zopen clean [OPTION] [PACKAGE]
 
 Options:
+  -m, --metadata    cleans and refreshes the metadata for zopen
   -c, --cache  [PACKAGE ...]
-                    cleans the downloaded package cache; packages will be re-downloaded if needed
-  -d, --dangling    removes dangling symlinks from the zopen file system in case of issues during
-                    package maintenance
+                    cleans the downloaded package cache; packages will be 
+                    re-downloaded if needed
+  -d, --dangling    removes dangling symlinks from the zopen file system in case 
+                    of issues during package maintenance
   -u, --unused [PACKAGE ...]     
-                    remove versions of PACKAGEs that are available as alternatives, leaving only the 
-                    currently active version
+                    remove versions of PACKAGEs that are available as 
+                    alternatives, leaving only the currently active version
       --all         apply cleanup command to all applicable packages
   -v, --verbose     run in verbose mode
   -h,-?, --help     display this help and exit
@@ -41,7 +43,7 @@ Options:
 
 Examples:
   zopen clean -c    clear the package download cache
-  zopen clean -d    analyse the zopen file system and remove any dangling symlinks
+  zopen clean -d    analyse the zopen file system and remove dangling symlinks
   zopen clean -u [PACKAGE]
                     remove unused versions for PACKAGE
 
@@ -115,23 +117,30 @@ cleanDangling()
   syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanDangling" "zopen system at '${ZOPEN_ROOTFS}' scanned for dangling symlinks"
 }
 
-cleanCache()
+cleanPackageCache()
 {
   # "All" option ignores the input parameter list as it brute force-cleans the cache rather
-  # than cherry-pick the files to remove
+  # than cherry-pick the files to remove which would be slowed
   if ${all}; then
-    printVerbose "Cleaning all entries in ${ZOPEN_ROOTFS}/var/cache/zopen"
-    rm -rf "${ZOPEN_ROOTFS}/var/cache/zopen/"*
-    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Main cache in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned"
+    printVerbose "Cleaning all cached packages in ${ZOPEN_ROOTFS}/var/cache/zopen"
+    rm -rf "${ZOPEN_ROOTFS}"/var/cache/zopen/*.pax.Z  # We actively want globbing
+    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanPackageCache" "Main cache in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned"
     printInfo "- Cache at '${ZOPEN_ROOTFS}/var/cache/zopen' cleaned"
   else
     for needle in $1; do
       printVerbose "Cleaning ${ZOPEN_ROOTFS}/var/cache/zopen entries for '${needle}"
-      rm -rf "${ZOPEN_ROOTFS}"/var/cache/zopen/"${needle}"-*
-      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Cache for '${needle}' in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned."
+      zosfind "${ZOPEN_ROOTFS}"/var/cache/zopen -name "${needle}-*" -exec rm {} \;
+      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanPackageCache" "Cache for '${needle}' in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned."
       printVerbose "- Cleaned cached files for '${needle}' in cache at '${ZOPEN_ROOTFS}/var/cache/zopen'."
     done
   fi
+}
+
+cleanMetadata()
+{
+  # Zopen metadata should prefix with the zopen_*
+  printVerbose "Clearing meta info files from ${ZOPEN_ROOTFS}/var/cache/zopen"
+  rm "${ZOPEN_ROOTFS}"/var/cache/zopen/zopen_* || printError "Unable to clear metadata from ${ZOPEN_ROOTFS}/var/cache/zopen. Check permissions and retry."
 }
 
 # Main code start here
@@ -143,6 +152,7 @@ dangling=false
 cache=false
 all=false
 packagelist=""
+meta=false
 
 if [ $# -eq 0 ]; then
   printError "No option provided for cleaning"
@@ -161,10 +171,15 @@ while [ $# -gt 0 ]; do
     unused=false
     dangling=true
     cache=false
+    meta=false
     ;;
   "-c" | "--cache")
     dangling=false
     cache=true
+    ;;
+  "-m" | "--metadata")
+    dangling=false
+    meta=true
     ;;
   "-h" | "--help" | "-?")
     printHelp "${args}"
@@ -178,7 +193,9 @@ while [ $# -gt 0 ]; do
     verbose=true
     ;;
   "--debug")
+    # shellcheck disable=SC2034
     verbose=true
+    # shellcheck disable=SC2034
     debug=true
     ;;
   *)
@@ -188,34 +205,35 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+${dangling} && cleanDangling && exit
+${meta} && cleanMetadata
 
-if ! ${dangling}; then
-  getReposFromGithub
-  if $all; then
-    # shellcheck disable=SC2154
-    for repo in ${repo_results}; do
-      cleanlist="${cleanlist} ${repo}"
-    done
-  elif [ -n "$packagelist" ]; then
-    for pkg in $(echo "${packagelist}" | tr ',' ' ' | tr -s ' '); do
-      pkgfound=$(echo "${repo_results}" | awk -vpkg="${pkg}" '$0 == pkg {print}')
-      if [ "${pkgfound}" = "${pkg}" ]; then
-        printVerbose "Adding '${pkg}' to the clean queue."
-        cleanlist=$(printf "%s %s" "${cleanlist}" "${pkg}")
-      else
-        invalidlist=$(printf "%s %s" "${invalidlist}" "${pkg}")
-      fi
-    done
-    [ -n "${invalidlist}" ] && printError "The following package(s) were invalid and cannot be cleaned:\n${invalidlist}"
-  elif [ ${cache} ]; then
-    all=true
-  else
-    [ -z "${packagelist}" ] && printError "Missing parameters. Correct command syntax and retry."
-  fi
-  ${unused} && cleanUnused "${cleanlist}"
-  ${cache} && cleanCache "${cleanlist}"
-  exit
+getReposFromGithub
+if $all; then
+  printVerbose "Generating complete list of all packages"
+  # shellcheck disable=SC2154
+  for repo in ${repo_results}; do
+    cleanlist="${cleanlist} ${repo}"
+  done
+elif [ -n "$packagelist" ]; then
+  for pkg in $(echo "${packagelist}" | tr ',' ' ' | tr -s ' '); do
+    pkgfound=$(echo "${repo_results}" | awk -vpkg="${pkg}" '$0 == pkg {print}')
+    if [ "${pkgfound}" = "${pkg}" ]; then
+      printVerbose "Adding '${pkg}' to the clean queue."
+      cleanlist=$(printf "%s %s" "${cleanlist}" "${pkg}")
+    else
+      invalidlist=$(printf "%s %s" "${invalidlist}" "${pkg}")
+    fi
+  done
+  [ -n "${invalidlist}" ] && printError "The following package(s) were invalid and cannot be cleaned:\n${invalidlist}"
+elif [ ${cache} ]; then
+  printVerbose "Default for --cache is all ${NC}${BOLD}installed${NC} packages"
+  all=true
 else
-  cleanDangling
-  exit
+  [ -z "${packagelist}" ] && printError "Missing parameters. Correct command syntax and retry."
 fi
+${unused} && cleanUnused "${cleanlist}"
+${cache} && cleanPackageCache "${cleanlist}"
+
+# At this point, commands completed successfully
+exit 0

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -27,12 +27,14 @@ from the system to save space and prevent clutter
 Usage: zopen clean [OPTION] [PACKAGE]
 
 Options:
-  -c, --cache       cleans the downloaded package cache; packages will be re-downloaded if needed
+  -c, --cache  [PACKAGE ...]
+                    cleans the downloaded package cache; packages will be re-downloaded if needed
   -d, --dangling    removes dangling symlinks from the zopen file system in case of issues during
                     package maintenance
-  -u, --unused [PACKAGE]     
-                    remove versions of PACKAGE that are available as alternatives, leaving only the 
+  -u, --unused [PACKAGE ...]     
+                    remove versions of PACKAGEs that are available as alternatives, leaving only the 
                     currently active version
+      --all         apply cleanup command to all applicable packages
   -v, --verbose     run in verbose mode
   -h,-?, --help     display this help and exit
   --version         print version
@@ -50,28 +52,32 @@ HELPDOC
 
 cleanUnused()
 {
-  needle=$1
-  [ -z "${needle}" ] && return 
-  current=$(getCurrentVersionDir "${needle}")
-
-  if [ -n "${current}" ]; then
-    current=$(basename "${current}")
-  else
-    printInfo "No currently active version of '${needle}'; removing all versions"
-  fi
-  cd "${ZOPEN_PKGINSTALL}/${needle}" && zosfind . -name "./*" -prune -type d |
-  while read repo; do
-    printVerbose "Parsing repo: '${repo}' as '${repo#./}'"
-    repo="${repo#./}"
-    if [ "${current}" = "${repo}" ]; then
-      printInfo "${NC}${GREEN}-> ${repo}  <- Current version${NC}"
+  for needle in $1; do
+    [ -z "${needle}" ] && return 
+    [ ! -e "${ZOPEN_PKGINSTALL}/${needle}" ] && printInfo "No versions of '${needle}' found" && continue
+    
+    current=$(getCurrentVersionDir "${needle}")
+  
+    if [ -n "${current}" ]; then
+      current=$(basename "${current}")
     else
-      deref=$(cd "${ZOPEN_PKGINSTALL}/${needle}/${repo}" && pwd -P)
-      [ "${deref}" = "/" ] || rm -rf "${deref}" > /dev/null 2>&1
-      printInfo "-- ${repo} <- Removed"
-      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE},${CAT_PACKAGE},${CAT_REMOVE}" "CLEAN" "cleanUnused" "Removed unused package at ${repo#"${ZOPEN_PKGINSTALL}"/} "
+      printInfo "No currently active version of '${needle}'; removing all versions"
     fi
-  done  
+
+    cd "${ZOPEN_PKGINSTALL}/${needle}" && zosfind . -name "./*" -prune -type d |
+    while read repo; do
+      printVerbose "Parsing repo: '${repo}' as '${repo#./}'"
+      repo="${repo#./}"
+      if [ "${current}" = "${repo}" ]; then
+        printInfo "${NC}${GREEN}-> ${repo}  <- Current version${NC}"
+      else
+        deref=$(cd "${ZOPEN_PKGINSTALL}/${needle}/${repo}" && pwd -P)
+        [ "${deref}" = "/" ] || rm -rf "${deref}" > /dev/null 2>&1
+        printInfo "-- ${repo} <- Removed"
+        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE},${CAT_PACKAGE},${CAT_REMOVE}" "CLEAN" "cleanUnused" "Removed unused package at ${repo#"${ZOPEN_PKGINSTALL}"/} "
+      fi
+    done  
+  done
 }
 
 cleanDangling()
@@ -102,7 +108,7 @@ cleanDangling()
   killph="kill -HUP ${ph}"
   addCleanupTrapCmd "${killph}"
   zosfind "${ZOPEN_ROOTFS}" -type l -exec test ! -e {} \; -print | while read sl; do
-    printVerbose "Removing symlink '${sl}'"
+    printVerbose "Removing dahngling symlink '${sl}'"
     rm -f "${sl}"
   done
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail
@@ -111,10 +117,21 @@ cleanDangling()
 
 cleanCache()
 {
-  printVerbose "Cleaning ${ZOPEN_ROOTFS}/var/cache/zopen"
-  rm -rf "${ZOPEN_ROOTFS}/var/cache/zopen/"*
-  syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Main cache in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned"
-  printInfo "- Cache at '${ZOPEN_ROOTFS}/var/cache/zopen' cleaned"
+  # "All" option ignores the input parameter list as it brute force-cleans the cache rather
+  # than cherry-pick the files to remove
+  if ${all}; then
+    printVerbose "Cleaning all entries in ${ZOPEN_ROOTFS}/var/cache/zopen"
+    rm -rf "${ZOPEN_ROOTFS}/var/cache/zopen/"*
+    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Main cache in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned"
+    printInfo "- Cache at '${ZOPEN_ROOTFS}/var/cache/zopen' cleaned"
+  else
+    for needle in $1; do
+      printVerbose "Cleaning ${ZOPEN_ROOTFS}/var/cache/zopen entries for '${needle}"
+      rm -rf "${ZOPEN_ROOTFS}"/var/cache/zopen/"${needle}"-*
+      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanCache" "Cache for '${needle}' in ${ZOPEN_ROOTFS}/var/cache/zopen cleaned."
+      printVerbose "- Cleaned cached files for '${needle}' in cache at '${ZOPEN_ROOTFS}/var/cache/zopen'."
+    done
+  fi
 }
 
 # Main code start here
@@ -124,7 +141,8 @@ debug=false
 unused=false
 dangling=false
 cache=false
-package=""
+all=false
+packagelist=""
 
 if [ $# -eq 0 ]; then
   printError "No option provided for cleaning"
@@ -133,12 +151,11 @@ while [ $# -gt 0 ]; do
   printVerbose "Parsing option: $1"
   case "$1" in
   "-u" | "--unused")
-    shift
-    [ $# -lt 1 ] && printError "Missing parameter for 'clean unused' option"
     unused=true
     dangling=false
-    cache=false
-    package="$1"
+    ;;
+  "--all")
+    all=true
     ;;
   "-d" | "--dangling")
     unused=false
@@ -146,7 +163,6 @@ while [ $# -gt 0 ]; do
     cache=false
     ;;
   "-c" | "--cache")
-    unused=false
     dangling=false
     cache=true
     ;;
@@ -166,18 +182,40 @@ while [ $# -gt 0 ]; do
     debug=true
     ;;
   *)
-    package="$1" # Use the last unrecognised parameter as the package
+    packagelist=$(printf "%s %s" "${packagelist}" "$1") # Use the last unrecognised parameter as the package
     ;;
   esac
   shift
 done
 
-if ${unused}; then
-  cleanUnused "${package}"
-fi
-if ${dangling}; then
+
+if ! ${dangling}; then
+  getReposFromGithub
+  if $all; then
+    # shellcheck disable=SC2154
+    for repo in ${repo_results}; do
+      cleanlist="${cleanlist} ${repo}"
+    done
+  elif [ -n "$packagelist" ]; then
+    for pkg in $(echo "${packagelist}" | tr ',' ' ' | tr -s ' '); do
+      pkgfound=$(echo "${repo_results}" | awk -vpkg="${pkg}" '$0 == pkg {print}')
+      if [ "${pkgfound}" = "${pkg}" ]; then
+        printVerbose "Adding '${pkg}' to the clean queue."
+        cleanlist=$(printf "%s %s" "${cleanlist}" "${pkg}")
+      else
+        invalidlist=$(printf "%s %s" "${invalidlist}" "${pkg}")
+      fi
+    done
+    [ -n "${invalidlist}" ] && printError "The following package(s) were invalid and cannot be cleaned:\n${invalidlist}"
+  elif [ ${cache} ]; then
+    all=true
+  else
+    [ -z "${packagelist}" ] && printError "Missing parameters. Correct command syntax and retry."
+  fi
+  ${unused} && cleanUnused "${cleanlist}"
+  ${cache} && cleanCache "${cleanlist}"
+  exit
+else
   cleanDangling
-fi
-if ${cache}; then
-  cleanCache
+  exit
 fi

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -108,7 +108,7 @@ cleanDangling()
   killph="kill -HUP ${ph}"
   addCleanupTrapCmd "${killph}"
   zosfind "${ZOPEN_ROOTFS}" -type l -exec test ! -e {} \; -print | while read sl; do
-    printVerbose "Removing dahngling symlink '${sl}'"
+    printVerbose "Removing dangling symlink '${sl}'"
     rm -f "${sl}"
   done
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail

--- a/include/common.sh
+++ b/include/common.sh
@@ -1061,9 +1061,11 @@ syslog()
 downloadJSONCache()
 {
   if [ -z "${JSON_CACHE}" ]; then
-    JSON_CACHE="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.json"
-    JSON_TIMESTAMP="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.timestamp"
-    JSON_TIMESTAMP_CURRENT="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.timestamp.current"
+    cachedir="${ZOPEN_ROOTFS}/var/cache/zopen"
+    [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
+    JSON_CACHE="${cachedir}/zopen_releases.json"
+    JSON_TIMESTAMP="${cachedir}/zopen_releases.timestamp"
+    JSON_TIMESTAMP_CURRENT="${cachedir}/zopen_releases.timestamp.current"
 
     # Need to check that we can read & write to the JSON timestamp cache files
     if [ -e "${JSON_TIMESTAMP_CURRENT}" ]; then
@@ -1076,8 +1078,8 @@ downloadJSONCache()
       [ ! -w "${JSON_CACHE}" ] || [ ! -r "${JSON_CACHE}" ] && printError "Cannot access cache at '${JSON_CACHE}'. Check permissions and retry request."
     fi
 
-    if ! curlCmd -L -s -I "${ZOPEN_JSON_CACHE_URL}" -o "${JSON_TIMESTAMP_CURRENT}"; then
-      printError "Failed to obtain json cache timestamp from ${ZOPEN_JSON_CACHE_URL}"
+    if ! curlout=$(curlCmd -L --no-progress-meter -I "${ZOPEN_JSON_CACHE_URL}" -o "${JSON_TIMESTAMP_CURRENT}"); then
+      printError "Failed to obtain json cache timestamp from ${ZOPEN_JSON_CACHE_URL}; ${curlout}"
     fi
     chtag -tc 819 "${JSON_TIMESTAMP_CURRENT}"
 
@@ -1088,8 +1090,8 @@ downloadJSONCache()
     printVerbose "Replacing old timestamp with latest."
     mv -f "${JSON_TIMESTAMP_CURRENT}" "${JSON_TIMESTAMP}"
 
-    if ! curlCmd -L -s -o "${JSON_CACHE}" "${ZOPEN_JSON_CACHE_URL}"; then
-      printError "Failed to obtain json cache from ${ZOPEN_JSON_CACHE_URL}"
+    if ! curlout=$(curlCmd -L --no-progress-meter -o "${JSON_CACHE}" "${ZOPEN_JSON_CACHE_URL}"); then
+      printError "Failed to obtain json cache from ${ZOPEN_JSON_CACHE_URL}; ${curlout}"
     fi
     chtag -tc 819 "${JSON_CACHE}"
   fi


### PR DESCRIPTION
Allow multiple package specifications for --unused and --cache
Allow --all  for --unused and --cache  [--cache with no parameters defaults to --all]
Allow both --unused and --cache to be specified together (with a package ilst or --all)