### PR TITLE
Message fixes

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -314,7 +314,7 @@ handlePackageInstall()
       redirectToDevNull="2>/dev/null"
     fi
 
-    progressHandler "network" "- Downloaded ${pax} file from remote to ${location}." &
+    progressHandler "network" "- Download complete." &
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -28,7 +28,7 @@ printSyntax()
 
 tool='zopen' # Default name
 package="zopen tools"
-copyright="Copyright (C) 2023 zOS Open Tools Community."
+copyright="Copyright (C) 2023 z/OS Open Tools Community."
 license="License Apache: The Apache Software Foundation license, <https://directory.fsf.org/wiki/License:Apache2.0>"
 freesw="This is free software: you are free to change and redistribute it."
 warranty="There is NO WARRANTY, to the extent permitted by law."


### PR DESCRIPTION
I made a small change to reduce the number of times the name of the downloaded package is printed during the installation process.  It was printed twice by the download function, and it just looked redundant.  After the change, the "Download complete" line signals the end of the download process.

```sh
> zopen install bzip2 --reinstall
- Querying repo for latest package information.
Processing package: bzip2
- Reinstalling version '1.0.8.20231113_064143' of bzip2...
- Replacing bzip2 version '1.0.8.20231113_064143' with '1.0.8.20231113_064143'
- Downloading bzip2-1.0.8.20231113_064143.zos.pax.Z file from remote to zopen package cache...
- Download complete.
- Processing bzip2-1.0.8.20231113_064143.zos.pax.Z...
After this operation, 3.58 MB of additional disk space will be used.
Do you want to continue? [y/n]
```

I also added a missing slash to "z/OS" in the `zopen --version` output.