### PR TITLE
Cleanup `zopen-install --help` output

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -23,9 +23,9 @@ setupMyself
 
 printHelp(){
 cat << HELPDOC
-zopen is a utility for managing a z/OS Open Tools environment.
+${ME} is a utility for managing a z/OS Open Tools environment.
 
-Usage: zopen [COMMAND] [OPTION] [PARAMETERS]...
+Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 
 Command:
   init              initializes a zopen environment at the specified location

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -38,9 +38,9 @@ Options:
   --cache-only             do not install dependencies.
   --no-set-active          do not change the pinned version.
   --skip-upgrade           do not upgrade.
-  --yes, -y                automatically answer yes to prompts.
+  -y, --yes                automatically answer yes to prompts.
   --select                 select a version to install.
-  -v                       run in verbose mode.
+  -v, --verbose            run in verbose mode.
   --download-only          download package to current directory.
   --local-install          download and unpackage to current directory.
   --all                    download/install all z/OS Open Tools packages.

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -40,7 +40,7 @@ Options:
   --skip-upgrade           do not upgrade.
   -y, --yes                automatically answer yes to prompts.
   --select                 select a version to install.
-  -v, --verbose            run in verbose mode.
+  -v, --verbose            print verbose messages.
   --download-only          download package to current directory.
   --local-install          download and unpackage to current directory.
   --all                    download/install all z/OS Open Tools packages.

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -22,8 +22,8 @@ printSyntax()
 {
   args=$*
 cat << HELPDOC
-zopen install is a utility to download/install a z/OS Open Tools package.
-Usage: zopen install [OPION] [PACKAGE]
+${ME} is a utility to download/install a z/OS Open Tools package.
+Usage: ${ME} [OPION] [PACKAGE]
   [PACKAGE] is a package to install. Multiple packages can be specified.
 Options:
   --help                   print this help.

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -31,7 +31,7 @@ Options:
   -u, --update, --upgrade  updates installed z/OS Open Tools packages.
   --install-or-upgrade     installs the package if not installed,
                            or upgrades the package if installed.
-  --reinstall              reinstall already installed z/OS Open Tools packages.
+  -r, --reinstall          reinstall already installed z/OS Open Tools packages.
   --nosymlink              do not integrate into filesystem through symlink redirection.
   --release-line [stable, dev] the release line to build off of.
   --no-deps                do not install dependencies.
@@ -504,7 +504,7 @@ yesToPrompts=false
 chosenRepos=""
 while [ $# -gt 0 ]; do
   case "$1" in
-  "-u" | "--update" | "-update" | "-upgrade" | "--upgrade")
+  "-u" | "--update" | "--upgrade")
     upgradeInstalled=true # Upgrade packages
     ;;
   "-r" | "-reinstall" | "--reinstall")
@@ -547,7 +547,7 @@ while [ $# -gt 0 ]; do
   "--select")
     selectVersion=true # Display a selction table to allow version picking
     ;;
-  "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+  "-h" | "--help" | "-?" )
     printSyntax "${args}"
     exit 0
     ;;
@@ -555,7 +555,7 @@ while [ $# -gt 0 ]; do
     verbose=true
     debug=true
     ;;
-  "-v" | "--v" | "-verbose" | "--verbose")
+  "-v" | "--verbose")
     verbose=true
     ;;
   "--version")

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -21,27 +21,30 @@ checkWritable
 printSyntax()
 {
   args=$*
-  echo "zopen install is a utility to download/install a z/OS Open Tools package."
-  echo "Usage: zopen install [OPION] [PACKAGE]"
-  echo "  [PACKAGE] is a package to install. Multiple packages can be specified."
-  echo "Options:"
-  echo "  --help                   print this help."
-  echo "  --version                print version"
-  echo "  -u, --update, --upgrade  updates installed z/OS Open Tools packages."
-  echo "  --install-or-upgrade     installs the package if not installed, or upgrades the package if installed."
-  echo "  --reinstallx             reinstall already installed z/OS Open Tools packages."
-  echo "  --nosymlink              do not integrate into filesystem through symlink redirection."
-  echo "  --release-line [stable, dev] the release line to build off of."
-  echo "  --no-deps                do not install dependencies."
-  echo "  --cache-only             do not install dependencies."
-  echo "  --no-set-active          do not change the pinned version"
-  echo "  --skip-upgrade           do not upgrade."
-  echo "  --yes, -y                automatically answer yes to prompts."
-  echo "  --select                 select a version to install."
-  echo "  -v                       run in verbose mode"
-  echo "  --download-only          download package to current directory"
-  echo "  --local-install          download and unpackage to current directory"
-  echo "  --all                    download/install all z/OS Open Tools packages"
+cat << HELPDOC
+zopen install is a utility to download/install a z/OS Open Tools package.
+Usage: zopen install [OPION] [PACKAGE]
+  [PACKAGE] is a package to install. Multiple packages can be specified.
+Options:
+  --help                   print this help.
+  --version                print version.
+  -u, --update, --upgrade  updates installed z/OS Open Tools packages.
+  --install-or-upgrade     installs the package if not installed,
+                           or upgrades the package if installed.
+  --reinstall              reinstall already installed z/OS Open Tools packages.
+  --nosymlink              do not integrate into filesystem through symlink redirection.
+  --release-line [stable, dev] the release line to build off of.
+  --no-deps                do not install dependencies.
+  --cache-only             do not install dependencies.
+  --no-set-active          do not change the pinned version.
+  --skip-upgrade           do not upgrade.
+  --yes, -y                automatically answer yes to prompts.
+  --select                 select a version to install.
+  -v                       run in verbose mode.
+  --download-only          download package to current directory.
+  --local-install          download and unpackage to current directory.
+  --all                    download/install all z/OS Open Tools packages.
+HELPDOC
 }
 
 installDependencies()

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -19,14 +19,16 @@ pd='split-patches'
 
 printSyntax()
 {
-  echo "${ME} - split a patch file into one patch file for each patch"
-  echo "  Patches are written to ${pd} in the current directory"
-  echo "Usage: ${ME} [OPTION] [PATCHFILE]"
-  echo "Options:"
-  echo "  --help      display this help and exit"
-  echo "  --version   print version"
-  echo "Example:"
-  echo "  ${ME} P1.patch    write P1.patch into multiple patches under ${pd}"
+  cat << HELPDOC
+${ME} - split a patch file into one patch file for each patch."
+  Patches are written to ${pd} in the current directory."
+Usage: ${ME} [OPTION] [PATCHFILE]"
+Options:"
+  --help      display this help and exit."
+  --version   print version."
+Example:"
+  ${ME} P1.patch    write P1.patch into multiple patches under ${pd}"
+HELPDOC
 }
 
 if [ "x$1" = "x--help" ]; then
@@ -50,15 +52,15 @@ fi
 #
 # For each aggregate:
 #  Extract lines that start with 'diff --git', and put the line numbers
-#  for each match into the 'lines' array. 
+#  for each match into the 'lines' array.
 #  Add the 'lastline' to the end of the lines array.
 #  These entries indicate the line numbers for each diff file that we will want to create.
-#   Get the relative file names (a and b) from these 'diff --git' lines and make sure they 
+#   Get the relative file names (a and b) from these 'diff --git' lines and make sure they
 #  match as a check that this is a 'standard' git diff.
 #  Put the array of file names into the 'file' array
 #
-#  Loop through the lines and create new files from the original aggregate file, 
-#  using the line numbers and file names from the lines and file arrays. 
+#  Loop through the lines and create new files from the original aggregate file,
+#  using the line numbers and file names from the lines and file arrays.
 #
 for aggregate in $@; do
   info=$(grep -n '^diff --git' "${aggregate}")

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -20,14 +20,14 @@ pd='split-patches'
 printSyntax()
 {
   cat << HELPDOC
-${ME} - split a patch file into one patch file for each patch."
-  Patches are written to ${pd} in the current directory."
-Usage: ${ME} [OPTION] [PATCHFILE]"
-Options:"
-  --help      display this help and exit."
-  --version   print version."
-Example:"
-  ${ME} P1.patch    write P1.patch into multiple patches under ${pd}"
+${ME} - split a patch file into one patch file for each patch.
+  Patches are written to ${pd} in the current directory.
+Usage: ${ME} [OPTION] [PATCHFILE]
+Options:
+  --help      display this help and exit.
+  --version   print version.
+Example:
+  ${ME} P1.patch    write P1.patch into multiple patches under ${pd}
 HELPDOC
 }
 

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -40,10 +40,10 @@ printHelp()
 {
   args=$*
 cat << HELPDOC
-zopen-update-cacert:
+${ME}:
   Update your cacert.pem file to the latest curl CA certificates extracted from Mozilla.
 Syntax:
-  zopen-update-cacert [-fhv] [<directory>]
+  ${ME} [-fhv] [<directory>]
 Options:
   -f, --force           update cacert.pem file even if up to date.
   -h, --help            print this help.

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -39,18 +39,21 @@ trap "cleanupOnExit" EXIT INT TERM QUIT HUP
 printHelp()
 {
   args=$*
-  echo "zopen-update-cacert:"
-  echo "  Update your cacert.pem file to the latest curl CA certificates extracted from Mozilla"
-  echo "Syntax:"
-  echo "  zopen-update-cacert [-fhv] [<directory>]"
-  echo "Options:"
-  echo "  -f|--force: update cacert.pem file even if it may be up to date"
-  echo "  -h|--help: print this help"
-  echo "  --version: print version"
-  echo "  -v|--verbose: print verbose messages"
-  echo "Parameters:"
-  echo "  <directory>: the directory where the cacert.pem will be updated"
-  echo "    The default directory location is: ${default_dir}"
+cat << HELPDOC
+zopen-update-cacert:
+  Update your cacert.pem file to the latest curl CA certificates extracted from Mozilla.
+Syntax:
+  zopen-update-cacert [-fhv] [<directory>]
+Options:
+  -f, --force           update cacert.pem file even if up to date.
+  -h, --help            print this help.
+  -v, --verbose         print verbose messages.
+  --version             print version.
+
+Parameters:
+  <directory>: the directory where the cacert.pem will be updated.
+    The default directory location is: ${default_dir}
+HELPDOC
 }
 
 getCACertFromCurl()

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -20,10 +20,10 @@ printSyntax()
   echo "${ME} prints version information for ${package}"
   echo "Usage: ${ME} [OPTION] tool"
   echo "   or: ${ME} [OPTION]"
-  echo "Syntax: zopen-version [OPTIONS]"
+  echo "Syntax: ${ME} [OPTIONS]"
   echo "where OPTIONS can be:"
-  echo "  --help: print this help"
-  echo "  --version: print version"
+  echo "  --help          print this help"
+  echo "  --version       print version"
 }
 
 tool='zopen' # Default name

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -17,13 +17,15 @@ setupMyself
 
 printSyntax()
 {
-  echo "${ME} prints version information for ${package}"
-  echo "Usage: ${ME} [OPTION] tool"
-  echo "   or: ${ME} [OPTION]"
-  echo "Syntax: ${ME} [OPTIONS]"
-  echo "where OPTIONS can be:"
-  echo "  --help          print this help"
-  echo "  --version       print version"
+  cat << HELPDOC
+  ${ME} prints version information for ${package}
+  Usage: ${ME} [OPTION] tool
+     or: ${ME} [OPTION]
+  Syntax: ${ME} [OPTIONS]
+  where OPTIONS can be:
+    --help          print this help
+    --version       print version
+HELPDOC
 }
 
 tool='zopen' # Default name


### PR DESCRIPTION
The output of `zopen-install --help` needed some work.  It was rather slow to print out, due to the large amount of `echo` statements used.  I converted it to a single `cat` call, along with fixing some spelling, grammar, and argument issues.