### PR TITLE
Add copyright text

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -43,7 +43,7 @@ Command:
   upgrade           upgrades existing z/OS Open Tools packages.
 
 Options:
-  -h,-?, --help     display this help and exit.
+  -h, --help, -?    display this help and exit.
   -v, --verbose     run in verbose mode.
 
 Examples:

--- a/bin/zopen
+++ b/bin/zopen
@@ -15,7 +15,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen
+++ b/bin/zopen
@@ -3,8 +3,6 @@
 # zopen wrapper script to allow single point of entry to zopen
 # tooling.
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 ZOPEN_DONT_PROCESS_CONFIG=1
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.

--- a/bin/zopen
+++ b/bin/zopen
@@ -55,16 +55,16 @@ Examples:
   zopen alt bash    list installed alternative bash z/OS Open Tools packages.
 
 SEE ALSO:
-  zopen-version(1)
+  zopen-alt(1)
+  zopen-build(1)
+  zopen-clean(1)
+  zopen-generate(1)
   zopen-init(1)
   zopen-install(1)
   zopen-query(1)
   zopen-remove(1)
-  zopen-build(1)
-  zopen-alt(1)
-  zopen-clean(1)
-  zopen-generate(1)
   zopen-update-cacert(1)
+  zopen-version(1)
 
 Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 

--- a/bin/zopen
+++ b/bin/zopen
@@ -7,7 +7,7 @@
 #
 ZOPEN_DONT_PROCESS_CONFIG=1
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen
+++ b/bin/zopen
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # zopen wrapper script to allow single point of entry to zopen
-# tooling
+# tooling.
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
 #
 ZOPEN_DONT_PROCESS_CONFIG=1
 #

--- a/bin/zopen
+++ b/bin/zopen
@@ -66,7 +66,7 @@ SEE ALSO:
   zopen-update-cacert(1)
   zopen-version(1)
 
-Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+Report bugs at https://github.com/ZOSOpenTools/meta/issues
 
 HELPDOC
 }

--- a/bin/zopen
+++ b/bin/zopen
@@ -30,28 +30,29 @@ ${ME} is a utility for managing a z/OS Open Tools environment.
 Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 
 Command:
-  init              initializes a zopen environment at the specified location
-  install           installs one or more z/OS Open Tools packages
-  list              lists information about z/OS Open Tools packages
-  upgrade           upgrades existing z/OS Open Tools packages
-  remove            removes installed z/OS Open Tools packages
-  build             builds the enclosing z/OS Open Tools git-cloned package
-  alt               manage alternate versions of z/OS Open Tools packages
-  clean             cleans up your zopen environment
-  query             list local or remote information about z/OS Open Tools packages
-  generate          generates a new zopen project
-  update-cacert     update the cacert.pem file used by z/OS Open Tools
+  alt               manage alternate versions of z/OS Open Tools packages.
+  build             builds the enclosing z/OS Open Tools git-cloned package.
+  clean             cleans up your zopen environment.
+  generate          generates a new zopen project.
+  init              initializes a zopen environment at the specified location.
+  install           installs one or more z/OS Open Tools packages.
+  list              lists information about z/OS Open Tools packages.
+  query             list local or remote info about z/OS Open Tools packages.
+  remove            removes installed z/OS Open Tools packages.
+  update-cacert     update the cacert.pem file used by z/OS Open Tools.
+  upgrade           upgrades existing z/OS Open Tools packages.
 
-Option:
-  -v, --verbose     run in verbose mode
-  -h,-?, --help     display this help and exit
+Options:
+  -h,-?, --help     display this help and exit.
+  -v, --verbose     run in verbose mode.
 
 Examples:
-  zopen --help      displays zopen help
-  zopen --version   displays the installed zopen version
-  zopen install git install the latest z/OS Open Tools git package
-  zopen upgrade -y  upgrade all installed packages to the latest release, without prompting
-  zopen alt bash    list the installed alternative bash z/OS Open Tools packages
+  zopen --help      displays zopen help.
+  zopen --version   displays the installed zopen version.
+  zopen install git install the latest z/OS Open Tools git package.
+  zopen upgrade -y  upgrade all installed packages to the latest release,
+                    without prompting.
+  zopen alt bash    list installed alternative bash z/OS Open Tools packages.
 
 SEE ALSO:
   zopen-version(1)
@@ -64,7 +65,6 @@ SEE ALSO:
   zopen-clean(1)
   zopen-generate(1)
   zopen-update-cacert(1)
-
 
 Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -24,18 +24,18 @@ checkWritable
 printHelp()
 {
   cat << HELPDOC
-zopen alt is a utility for z/OS Open Tools to switch package versions
+${ME} is a utility for z/OS Open Tools to switch package versions
 for currently installed packages.
 
-Usage: zopen alt [OPTION] [PACKAGE] [PARAMETERS]...
+Usage: ${ME} [OPTION] [PACKAGE] [PARAMETERS]...
 
 Options:
+  -h, --help, -?    display this help and exit.
+  --select [PACKAGE]
+                    select the active version for PACKAGE from a list.
   -s, --set [PACKAGE] [VERSION]
-                    set the active version for PACKAGE to VERSION
-      --select [PACKAGE]
-                    select the active version for PACKAGE from a list
-  -v, --verbose     run in verbose mode
-  -h,-?, --help     display this help and exit
+                    set the active version for PACKAGE to VERSION.
+  -v, --verbose     run in verbose mode.
   --version         print version
 
 Examples:

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -1,6 +1,10 @@
 #!/bin/sh
 # "Alternatives" utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()
@@ -20,15 +24,15 @@ checkWritable
 printHelp()
 {
   cat << HELPDOC
-zopen alt is a utility for z/OS Open Tools to switch package versions 
+zopen alt is a utility for z/OS Open Tools to switch package versions
 for currently installed packages.
 
 Usage: zopen alt [OPTION] [PACKAGE] [PARAMETERS]...
 
 Options:
   -s, --set [PACKAGE] [VERSION]
-                    set the active version for PACKAGE to VERSION 
-      --select [PACKAGE] 
+                    set the active version for PACKAGE to VERSION
+      --select [PACKAGE]
                     select the active version for PACKAGE from a list
   -v, --verbose     run in verbose mode
   -h,-?, --help     display this help and exit

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -47,7 +47,7 @@ Examples:
                     set the active version of package 'foo' to version
                     foo-1.2.3.19700101_012345.zos if available
 
-Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+Report bugs at https://github.com/ZOSOpenTools/meta/issues
 
 HELPDOC
 }

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -1,7 +1,6 @@
 #!/bin/sh
-# "Alternatives" utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# "Alternatives" utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
 
 #

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -59,89 +59,145 @@ printEnvVar()
   echo "User-Provided environment variables:
 
 Required:
-  ZOPEN_BUILD_LINE     Specify the default build line, either 'DEV' or 'STABLE'
-  ZOPEN_CATEGORIES     Specify all categories that apply with space as a delimiter. Valid categories: ('${ZOPEN_VALID_CATEGORIES}')
-  ZOPEN_DEV_DEPS       Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev build dependencies
-  ZOPEN_DEV_URL        Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev build url (either a git url or tarball url)
-  ZOPEN_STABLE_DEPS    Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build dependencies
-  ZOPEN_STABLE_URL     Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build url (either a git url or tarball url)
+  ZOPEN_BUILD_LINE    Specify the default build line, either 'DEV' or 'STABLE'
+  ZOPEN_CATEGORIES    Specify a space-delimited list of applicable categories.
+                      Valid categories:
+                      ('${ZOPEN_VALID_CATEGORIES}')
+  ZOPEN_DEV_DEPS      Required IF ZOPEN_BUILD_LINE='DEV'.
+                      Specify the dev build dependencies
+  ZOPEN_DEV_URL       Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev
+                      build URL (either git or tarball).
+  ZOPEN_STABLE_DEPS   Required IF ZOPEN_BUILD_LINE='STABLE'.
+                      Specify the stable build dependencies.
+  ZOPEN_STABLE_URL    Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the
+                      stable build URL (either git or tarball).
 
 Optional:
-  ZOPEN_EXTRA_CFLAGS    C compiler flags to append to CFLAGS (defaults to '')
-  ZOPEN_EXTRA_CPPFLAGS  C,C++ pre-processor flags to append to CPPFLAGS (defaults to '')
-  ZOPEN_EXTRA_CXXFLAGS  C++ compiler flags to append to CXXFLAGS (defaults to '')
-  ZOPEN_EXTRA_LDFLAGS   C,C++ linker flags to append to LDFLAGS (defaults to '')
-  ZOPEN_EXTRA_LIBS      C,C++ libraries to append to LIBS (defaults to '')
+  ZOPEN_EXTRA_CFLAGS    C compiler flags to append to CFLAGS (defaults to '').
+  ZOPEN_EXTRA_CPPFLAGS  C,C++ pre-processor flags to append to CPPFLAGS.
+                        (defaults to '')
+  ZOPEN_EXTRA_CXXFLAGS  C++ compiler flags to append to CXXFLAGS.
+                        (defaults to '')
+  ZOPEN_EXTRA_LDFLAGS   C,C++ linker flags to append to LDFLAGS.
+                        (defaults to '')
+  ZOPEN_EXTRA_LIBS      C,C++ libraries to append to LIBS. (defaults to '')
 
-  ZOPEN_BOOTSTRAP             Bootstrap program to run. If skip is specified, no bootstrap step is performed (defaults to '${ZOPEN_BOOTSTRAPD}')
-  ZOPEN_BOOTSTRAP_OPTS        Options to pass to bootstrap program (defaults to '${ZOPEN_BOOTSTRAP_OPTSD}')
-  ZOPEN_CHECK                 Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}')
-  ZOPEN_CHECK_MINIMAL         Check program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
-  ZOPEN_CHECK_OPTS            Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
-  ZOPEN_CHECK_TIMEOUT         Timeout limit in seconds for the check program (defaults to '${ZOPEN_CHECK_TIMEOUTD}')
-  ZOPEN_CLEAN                 Clean up program to run (defaults to '${ZOPEN_CLEAND}')
-  ZOPEN_CLEAN_OPTS            Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')
-  ZOPEN_CONFIGURE             Configuration program to run. If skip is specified, no configuration step is performed (defaults to '${ZOPEN_CONFIGURED}')
-  ZOPEN_CONFIGURE_MINIMAL     Configuration program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
-  ZOPEN_CONFIGURE_OPTS        Options to pass to configuration program (defaults to '--prefix=\${ZOPEN_INSTALL_DIR}')
-  ZOPEN_EXTRA_CONFIGURE_OPTS  Extra configure options to pass to configuration program (defaults to '')
-  ZOPEN_INSTALL               Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
-  ZOPEN_INSTALL_OPTS          Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
-  ZOPEN_MAKE                  Build program to run. If skip is specified, no build step is performed (defaults to '${ZOPEN_MAKED}')
-  ZOPEN_MAKE_MINIMAL          Build program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
-  ZOPEN_MAKE_OPTS             Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
+  ZOPEN_BOOTSTRAP             Bootstrap program to run. If skip is specified,
+                              no bootstrap step is performed.
+                              (defaults to '${ZOPEN_BOOTSTRAPD}')
+  ZOPEN_BOOTSTRAP_OPTS        Options to pass to bootstrap program.
+                              (defaults to '${ZOPEN_BOOTSTRAP_OPTSD}')
+  ZOPEN_CHECK                 Check program to run. If skip is specified,
+                              no check step is performed.
+                              (defaults to '${ZOPEN_CHECKD}')
+  ZOPEN_CHECK_MINIMAL         Check program will not be passed CFLAGS, LDFLAGS,
+                              CPPFLAGS options but will get them from env vars.
+  ZOPEN_CHECK_OPTS            Options to pass to check program.
+                              (defaults to '${ZOPEN_CHECK_OPTSD}')
+  ZOPEN_CHECK_TIMEOUT         Timeout limit in seconds for the check program.
+                              (defaults to '${ZOPEN_CHECK_TIMEOUTD}')
+  ZOPEN_CLEAN                 Clean up program to run.
+                              (defaults to '${ZOPEN_CLEAND}')
+  ZOPEN_CLEAN_OPTS            Options to pass to clean up  program.
+                              (defaults to '${ZOPEN_CLEAN_OPTSD}')
+  ZOPEN_CONFIGURE             Configuration program to run. If skip is
+                              specified, no configuration step is performed.
+                              (defaults to '${ZOPEN_CONFIGURED}')
+  ZOPEN_CONFIGURE_MINIMAL     Configuration program will not be passed CFLAGS,
+                              LDFLAGS, CPPFLAGS options but will get them from
+                              env vars.
+  ZOPEN_CONFIGURE_OPTS        Options to pass to configuration program.
+                              (defaults to '--prefix=\${ZOPEN_INSTALL_DIR}')
+  ZOPEN_EXTRA_CONFIGURE_OPTS  Extra configure options to pass to configuration
+                              program. (defaults to '')
+  ZOPEN_INSTALL               Installation program to run. If skip is specified,
+                              no installation step is performed.
+                              (defaults to '${ZOPEN_INSTALLD}')
+  ZOPEN_INSTALL_OPTS          Options to pass to installation program.
+                              (defaults to '${ZOPEN_INSTALL_OPTSD}')
+  ZOPEN_MAKE                  Build program to run. If skip is specified,
+                              no build step is performed.
+                              (defaults to '${ZOPEN_MAKED}')
+  ZOPEN_MAKE_MINIMAL          Build program will not be passed CFLAGS, LDFLAGS,
+                              CPPFLAGS options but will get them from env vars.
+  ZOPEN_MAKE_OPTS             Options to pass to build program.
+                              (defaults to '-j\${ZOPEN_NUM_JOBS}')
 
 Restricted Usage - only set in ports if necessary
-  ZOPEN_DONT_ADD_ZOSLIB_DEP Set it to avoid adding zoslib as a dependency
+  ZOPEN_DONT_ADD_ZOSLIB_DEP   Set to avoid adding zoslib as a dependency.
 
 Restricted Usage - only SET by metaport, otherwise READ ONLY:
-  ZOPEN_INSTALL_DIR    Installation directory to pass to configuration (defaults to '\${ZOPEN_PKGINSTALL}/<pkg>/<pkg>')
-  ZOPEN_NUM_JOBS       Number of jobs that can be run in parallel (defaults to 1/2 the CPUs on the system)
+  ZOPEN_INSTALL_DIR   Installation directory to pass to configuration.
+                      (defaults to '\${ZOPEN_PKGINSTALL}/<pkg>/<pkg>')
+  ZOPEN_NUM_JOBS      Number of jobs that can be run in parallel
+                      (defaults to half the CPUs on the system)
 
 Restricted Usage (clangport):
-  ZOPEN_CFLAGS         C compiler flags (default set by dependency)
-  ZOPEN_CPPFLAGS       C/C++ pre-processor flags (default set by dependency)
-  ZOPEN_CXXFLAGS       C++ compiler flags (default set by dependency)
-  ZOPEN_LDFLAGS        C/C++ linker flags (default set by dependency)
+  ZOPEN_CFLAGS        C compiler flags. (default set by dependency)
+  ZOPEN_CPPFLAGS      C/C++ pre-processor flags. (default set by dependency)
+  ZOPEN_CXXFLAGS      C++ compiler flags. (default set by dependency)
+  ZOPEN_LDFLAGS       C/C++ linker flags. (default set by dependency)
 
 Restricted Usage (phpport):
-  ZOPEN_GIT_SETUP      Specify whether git files should be added to a local repo or if this will be done manually (defaults to Y)
+  ZOPEN_GIT_SETUP     Specify whether git files should be added to a local
+                      repo or if this will be done manually. (defaults to Y)
 
 Restricted Usage (tclport):
-  ZOPEN_SRC_DIR        specify a relative source directory to cd to for bootstrap, configure, build, check, install (defaults to '.')
+  ZOPEN_SRC_DIR       Specify a relative source directory to cd to for
+                      bootstrap, configure, build, check, install.
+                      (defaults to '.')
 
 Restricted Usage (meta):
-  ZOPEN_IMAGE_DOCKERFILE_NAME    Dockerfile name (default: Dockerfile)
-  ZOPEN_IMAGE_DOCKER_NAME        Docker/podman tool name (default: podman)
-  ZOPEN_IMAGE_REGISTRY           Docker image registry to an OCI image to (use with --oci option)
-  ZOPEN_IMAGE_REGISTRY_ID        The ID to authenticate to the Docker image registry (use with --oci option)
-  ZOPEN_IMAGE_REGISTRY_KEY_FILE  The file containing the key to authenticate to the Docker image registry (use with --oci option)
-  ZOPEN_LOG_DIR                  The directory to store build logs (defaults to '${ZOPEN_ROOT}/log')
-  ZOPEN_SHELL                    Specify an alternate shell to use if -s option specified (defaults to /bin/sh)
+  ZOPEN_IMAGE_DOCKERFILE_NAME     Dockerfile name. (default: Dockerfile)
+  ZOPEN_IMAGE_DOCKER_NAME         Docker/podman tool name. (default: podman)
+  ZOPEN_IMAGE_REGISTRY            Docker image registry to an OCI image to
+                                  (use with --oci option)
+  ZOPEN_IMAGE_REGISTRY_ID         The ID to authenticate to the Docker image
+                                  registry. (use with --oci option)
+  ZOPEN_IMAGE_REGISTRY_KEY_FILE   The file containing authentication key to the
+                                  Docker image registry. (use with --oci option)
+  ZOPEN_LOG_DIR                   The directory to store build logs.
+                                  (defaults to '${ZOPEN_ROOT}/log')
+  ZOPEN_SHELL                     Specify an alternate shell to use if -s
+                                  option specified. (defaults to /bin/sh)
 
 Being reworked to move to common ZOPEN_xxx_GIT_REFS:
-  ZOPEN_DEV_BRANCH     The branch that the git repo should checkout (default is repo default)
-  ZOPEN_DEV_TAG        The tag that the git repo should checkout as a branch (optional)
-  ZOPEN_STABLE_BRANCH  The branch that the stable repo should checkout (default is repo default)
-  ZOPEN_STABLE_TAG     The tag that the git repo should checkout as a branch (optional)
+  ZOPEN_DEV_BRANCH      The branch that the git repo should checkout.
+                        (default is repo default)
+  ZOPEN_DEV_TAG         The tag that the git repo should checkout as a branch.
+                        (optional)
+  ZOPEN_STABLE_BRANCH   The branch that the stable repo should checkout.
+                        (default is repo default)
+  ZOPEN_STABLE_TAG      The tag that the git repo should checkout as a branch.
+                        (optional)
 
 Currently unused:
-  ZOPEN_DEV_TYPE       The type of package to download. Valid types are TARBALL, BARE and GIT
-  ZOPEN_STABLE_TYPE    The type of package to download. Valid types are TARBALL, BARE and GIT
+  ZOPEN_DEV_TYPE        The type of package to download. Valid types are
+                        TARBALL, BARE and GIT.
+  ZOPEN_STABLE_TYPE     The type of package to download. Valid types are
+                        TARBALL, BARE and GIT.
 
 Deprecated:
-  ZOPEN_CC             C compiler (default set by dependency)
-  ZOPEN_CXX            C++ compiler (default set by dependency)
-  ZOPEN_DEPS           Alternate environment variable instead of ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS (alternate to ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS)
-  ZOPEN_GIT_BRANCH     The branch that the git repo should checkout
-  ZOPEN_GIT_DEPS       Space-delimited set of source packages this tarball package depends on to build (required if ZOPEN_TYPE=GIT)
-  ZOPEN_GIT_TAG        The tag that the git repo should checkout as a branch
-  ZOPEN_GIT_URL        The fully qualified URL that the git repo should be cloned from (required if ZOPEN_TYPE=GIT)
-  ZOPEN_LIBS           C/C++ libraries (default set by dependency)
-  ZOPEN_TARBALL_DEPS   Space-delimited set of source packages this git package depends on to build (required if ZOPEN_TYPE=TARBALL)
-  ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
-  ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT
-  ZOPEN_URL            Alternate environment variable instead of ZOPEN_TARBALL_URL or ZOPEN_GIT_URL (alternate to ZOPEN_TARBALL_URL or ZOPEN_GIT_URL)
+  ZOPEN_CC              C compiler. (default set by dependency)
+  ZOPEN_CXX             C++ compiler. (default set by dependency)
+  ZOPEN_DEPS            Alternate environment variable instead of
+                        ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS.
+  ZOPEN_GIT_BRANCH      The branch that the git repo should checkout.
+  ZOPEN_GIT_DEPS        Space-delimited set of source packages this tarball
+                        package depends on to build.
+                        (required if ZOPEN_TYPE=GIT)
+  ZOPEN_GIT_TAG         The tag that the git repo should checkout as a branch.
+  ZOPEN_GIT_URL         The fully qualified URL that the git repo should be
+                        cloned from. (required if ZOPEN_TYPE=GIT)
+  ZOPEN_LIBS            C/C++ libraries (default set by dependency)
+  ZOPEN_TARBALL_DEPS    Space-delimited set of source packages this git package
+                        depends on to build. (required if ZOPEN_TYPE=TARBALL)
+  ZOPEN_TARBALL_URL     The fully qualified URL that the tarball should be
+                        downloaded from. (required if ZOPEN_TYPE=TARBALL)
+  ZOPEN_TYPE            The type of package to download. Valid types are
+                        TARBALL, BARE and GIT.
+  ZOPEN_URL             Alternate environment variable instead of
+                        ZOPEN_TARBALL_URL or ZOPEN_GIT_URL.
 "
 }
 

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -11,7 +11,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -56,41 +56,41 @@ asciiecho()
 
 printEnvVar()
 {
-  echo "
+  cat << ENVARS
 User-Provided environment variables:
 
 Required:
   ZOPEN_BUILD_LINE     Specify the default build line, either 'DEV' or 'STABLE'
   ZOPEN_CATEGORIES     Specify all categories that apply with space as a delimiter. Valid categories: ('${ZOPEN_VALID_CATEGORIES}')
-  ZOPEN_STABLE_URL     Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build url (either a git url or tarball url)
-  ZOPEN_STABLE_DEPS    Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build dependencies
-  ZOPEN_DEV_URL        Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev build url (either a git url or tarball url)
   ZOPEN_DEV_DEPS       Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev build dependencies
+  ZOPEN_DEV_URL        Required IF ZOPEN_BUILD_LINE='DEV'. Specify the dev build url (either a git url or tarball url)
+  ZOPEN_STABLE_DEPS    Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build dependencies
+  ZOPEN_STABLE_URL     Required IF ZOPEN_BUILD_LINE='STABLE'. Specify the stable build url (either a git url or tarball url)
 
 Optional:
-  ZOPEN_EXTRA_CPPFLAGS  C,C++ pre-processor flags to append to CPPFLAGS (defaults to '')
   ZOPEN_EXTRA_CFLAGS    C compiler flags to append to CFLAGS (defaults to '')
+  ZOPEN_EXTRA_CPPFLAGS  C,C++ pre-processor flags to append to CPPFLAGS (defaults to '')
   ZOPEN_EXTRA_CXXFLAGS  C++ compiler flags to append to CXXFLAGS (defaults to '')
   ZOPEN_EXTRA_LDFLAGS   C,C++ linker flags to append to LDFLAGS (defaults to '')
   ZOPEN_EXTRA_LIBS      C,C++ libraries to append to LIBS (defaults to '')
 
   ZOPEN_BOOTSTRAP             Bootstrap program to run. If skip is specified, no bootstrap step is performed (defaults to '${ZOPEN_BOOTSTRAPD}')
   ZOPEN_BOOTSTRAP_OPTS        Options to pass to bootstrap program (defaults to '${ZOPEN_BOOTSTRAP_OPTSD}')
-  ZOPEN_CONFIGURE             Configuration program to run. If skip is specified, no configuration step is performed (defaults to '${ZOPEN_CONFIGURED}')
-  ZOPEN_CONFIGURE_MINIMAL     Configuration program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
-  ZOPEN_CONFIGURE_OPTS        Options to pass to configuration program (defaults to '--prefix=\${ZOPEN_INSTALL_DIR}')
-  ZOPEN_EXTRA_CONFIGURE_OPTS  Extra configure options to pass to configuration program (defaults to '')
-  ZOPEN_MAKE                  Build program to run. If skip is specified, no build step is performed (defaults to '${ZOPEN_MAKED}')
-  ZOPEN_MAKE_MINIMAL          Build program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
-  ZOPEN_MAKE_OPTS             Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
   ZOPEN_CHECK                 Check program to run. If skip is specified, no check step is performed (defaults to '${ZOPEN_CHECKD}')
   ZOPEN_CHECK_MINIMAL         Check program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
   ZOPEN_CHECK_OPTS            Options to pass to check program (defaults to '${ZOPEN_CHECK_OPTSD}')
   ZOPEN_CHECK_TIMEOUT         Timeout limit in seconds for the check program (defaults to '${ZOPEN_CHECK_TIMEOUTD}')
-  ZOPEN_INSTALL               Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
-  ZOPEN_INSTALL_OPTS          Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
   ZOPEN_CLEAN                 Clean up program to run (defaults to '${ZOPEN_CLEAND}')
   ZOPEN_CLEAN_OPTS            Options to pass to clean up  program (defaults to '${ZOPEN_CLEAN_OPTSD}')
+  ZOPEN_CONFIGURE             Configuration program to run. If skip is specified, no configuration step is performed (defaults to '${ZOPEN_CONFIGURED}')
+  ZOPEN_CONFIGURE_MINIMAL     Configuration program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
+  ZOPEN_CONFIGURE_OPTS        Options to pass to configuration program (defaults to '--prefix=\${ZOPEN_INSTALL_DIR}')
+  ZOPEN_EXTRA_CONFIGURE_OPTS  Extra configure options to pass to configuration program (defaults to '')
+  ZOPEN_INSTALL               Installation program to run. If skip is specified, no installation step is performed (defaults to '${ZOPEN_INSTALLD}')
+  ZOPEN_INSTALL_OPTS          Options to pass to installation program (defaults to '${ZOPEN_INSTALL_OPTSD}')
+  ZOPEN_MAKE                  Build program to run. If skip is specified, no build step is performed (defaults to '${ZOPEN_MAKED}')
+  ZOPEN_MAKE_MINIMAL          Build program will not be passed CFLAGS, LDFLAGS, CPPFLAGS options but will just get them from env vars
+  ZOPEN_MAKE_OPTS             Options to pass to build program (defaults to '-j\${ZOPEN_NUM_JOBS}')
 
 Restricted Usage - only set in ports if necessary
   ZOPEN_DONT_ADD_ZOSLIB_DEP Set it to avoid adding zoslib as a dependency
@@ -100,8 +100,8 @@ Restricted Usage - only SET by metaport, otherwise READ ONLY:
   ZOPEN_NUM_JOBS       Number of jobs that can be run in parallel (defaults to 1/2 the CPUs on the system)
 
 Restricted Usage (clangport):
-  ZOPEN_CPPFLAGS       C/C++ pre-processor flags (default set by dependency)
   ZOPEN_CFLAGS         C compiler flags (default set by dependency)
+  ZOPEN_CPPFLAGS       C/C++ pre-processor flags (default set by dependency)
   ZOPEN_CXXFLAGS       C++ compiler flags (default set by dependency)
   ZOPEN_LDFLAGS        C/C++ linker flags (default set by dependency)
 
@@ -112,38 +112,38 @@ Restricted Usage (tclport):
   ZOPEN_SRC_DIR        specify a relative source directory to cd to for bootstrap, configure, build, check, install (defaults to '.')
 
 Restricted Usage (meta):
-  ZOPEN_IMAGE_REGISTRY           Docker image registry to an OCI image to (use with --oci option)
   ZOPEN_IMAGE_DOCKERFILE_NAME    Dockerfile name (default: Dockerfile)
   ZOPEN_IMAGE_DOCKER_NAME        Docker/podman tool name (default: podman)
+  ZOPEN_IMAGE_REGISTRY           Docker image registry to an OCI image to (use with --oci option)
   ZOPEN_IMAGE_REGISTRY_ID        The ID to authenticate to the Docker image registry (use with --oci option)
   ZOPEN_IMAGE_REGISTRY_KEY_FILE  The file containing the key to authenticate to the Docker image registry (use with --oci option)
   ZOPEN_LOG_DIR                  The directory to store build logs (defaults to '${ZOPEN_ROOT}/log')
   ZOPEN_SHELL                    Specify an alternate shell to use if -s option specified (defaults to /bin/sh)
 
 Being reworked to move to common ZOPEN_xxx_GIT_REFS:
-  ZOPEN_DEV_TAG        The tag that the git repo should checkout as a branch (optional)
-  ZOPEN_STABLE_TAG     The tag that the git repo should checkout as a branch (optional)
   ZOPEN_DEV_BRANCH     The branch that the git repo should checkout (default is repo default)
+  ZOPEN_DEV_TAG        The tag that the git repo should checkout as a branch (optional)
   ZOPEN_STABLE_BRANCH  The branch that the stable repo should checkout (default is repo default)
+  ZOPEN_STABLE_TAG     The tag that the git repo should checkout as a branch (optional)
 
 Currently unused:
   ZOPEN_DEV_TYPE       The type of package to download. Valid types are TARBALL, BARE and GIT
   ZOPEN_STABLE_TYPE    The type of package to download. Valid types are TARBALL, BARE and GIT
 
 Deprecated:
-  ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT
-  ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
-  ZOPEN_TARBALL_DEPS   Space-delimited set of source packages this git package depends on to build (required if ZOPEN_TYPE=TARBALL)
-  ZOPEN_GIT_URL        The fully qualified URL that the git repo should be cloned from (required if ZOPEN_TYPE=GIT)
-  ZOPEN_GIT_DEPS       Space-delimited set of source packages this tarball package depends on to build (required if ZOPEN_TYPE=GIT)
-  ZOPEN_GIT_BRANCH     The branch that the git repo should checkout
-  ZOPEN_GIT_TAG        The tag that the git repo should checkout as a branch
-  ZOPEN_URL            Alternate environment variable instead of ZOPEN_TARBALL_URL or ZOPEN_GIT_URL (alternate to ZOPEN_TARBALL_URL or ZOPEN_GIT_URL)
-  ZOPEN_DEPS           Alternate environment variable instead of ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS (alternate to ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS)
   ZOPEN_CC             C compiler (default set by dependency)
   ZOPEN_CXX            C++ compiler (default set by dependency)
+  ZOPEN_DEPS           Alternate environment variable instead of ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS (alternate to ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS)
+  ZOPEN_GIT_BRANCH     The branch that the git repo should checkout
+  ZOPEN_GIT_DEPS       Space-delimited set of source packages this tarball package depends on to build (required if ZOPEN_TYPE=GIT)
+  ZOPEN_GIT_TAG        The tag that the git repo should checkout as a branch
+  ZOPEN_GIT_URL        The fully qualified URL that the git repo should be cloned from (required if ZOPEN_TYPE=GIT)
   ZOPEN_LIBS           C/C++ libraries (default set by dependency)
-  "
+  ZOPEN_TARBALL_DEPS   Space-delimited set of source packages this git package depends on to build (required if ZOPEN_TYPE=TARBALL)
+  ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
+  ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT
+  ZOPEN_URL            Alternate environment variable instead of ZOPEN_TARBALL_URL or ZOPEN_GIT_URL (alternate to ZOPEN_TARBALL_URL or ZOPEN_GIT_URL)
+ENVARS
 }
 
 printFunctions()

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -206,23 +206,45 @@ printFunctions()
   echo "User-Provided functions:
 
 Required:
-  zopen_check_results         This function runs after the 'check' step of the build is run and must print out expected and actual failures.
-  zopen_get_version           This function returns the version of the tool in accordance with semantic versioning
+  zopen_check_results               This function runs after the 'check' step
+                                    of the build and must print out expected
+                                    and actual failures.
+  zopen_get_version                 This function returns the version of the
+                                    tool in accordance with semantic versioning.
 
 Optional:
-  zopen_init                  This function runs after code is downloaded and patched but before the code is built.
-  zopen_post_buildenv         This function runs after the 'buildenv' is processed.
-  zopen_pre_patch             This function runs before the 'patch' step of the build is run.
-  zopen_pre_check             This function runs before the 'check' step of the build is run.
-  zopen_pre_configure         This function runs before the 'configure' step of the build is run.
-  zopen_pre_build             This function runs before the 'make' step of the build is run.
-  zopen_append_to_env         This function runs as part of generation of the .env file. The output of the function is appended to .env
-  zopen_append_to_setup       This function runs as part of generation of the setup.sh file. The output of the function is appended to setup.sh
-  zopen_append_to_validate_install  This function runs as part of generation of the install_test.sh file. The output of the function is appended to install_test.sh script.
-  zopen_pre_install           This function runs before the 'install' step of the build is run.
-  zopen_post_install          This function runs after the 'install' step of the build is run.
-  zopen_pre_terminate         This function runs before zopen build terminates.
-  zopen_append_to_zoslib_env  This function runs as part of generation of the C function zoslib_env_hook, which can be used to set environment variables before main is run.
+  zopen_append_to_env               This function runs as part of generation
+                                    of the .env file. The output of the
+                                    function is appended to .env.
+  zopen_append_to_setup             This function runs as part of generation of
+                                    the setup.sh file. The output of the
+                                    function is appended to setup.sh.
+  zopen_append_to_validate_install  This function runs as part of generation of
+                                    the install_test.sh file. The output of the
+                                    function is appended to install_test.sh
+                                    script.
+  zopen_append_to_zoslib_env        This function runs as part of generation of
+                                    the C function zoslib_env_hook, which can
+                                    be used to set environment variables before
+                                    main is run.
+  zopen_init                        This function runs after code is downloaded
+                                    and patched but before the code is built.
+  zopen_post_buildenv               This function runs after the 'buildenv' is
+                                    processed.
+  zopen_post_install                This function runs after the 'install' step
+                                    of the build is run.
+  zopen_pre_build                   This function runs before the 'make' step
+                                    of the build is run.
+  zopen_pre_check                   This function runs before the 'check' step
+                                    of the build is run.
+  zopen_pre_configure               This function runs before the 'configure'
+                                    step of the build is run.
+  zopen_pre_install                 This function runs before the 'install'
+                                    step of the build is run.
+  zopen_pre_patch                   This function runs before the 'patch' step
+                                    of the build is run.
+  zopen_pre_terminate               This function runs before 'zopen build'
+                                    terminates.
   "
 }
 

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -268,7 +268,7 @@ for tmp in "${TMPDIR}" "${TMP}" /tmp; do
 done
 
 if [ ! -d "${tmp}" ]; then
-  printError "Temporary directory not found. Please specify \$TMPDIR, \$TMP or have a valid /tmp directory"
+  printError "Temporary directory not found. Please specify \$TMPDIR, \$TMP or have a valid /tmp directory."
 fi
 
 TMP_FIFO_PIPE="${tmp}/${LOGNAME}.pipe"
@@ -352,7 +352,8 @@ printSyntax()
 {
   args=$*
   cat << HELPDOC
-${ME} is a general purpose build script to be used with the ZOSOpenTools ports.
+${ME} is a general purpose build script to be used with the
+z/OS Open Tools ports.
 
 Usage: ${ME} [OPTION]...
 

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -356,10 +356,10 @@ processOptions()
       zopen-version ${ME}
       exit 0
       ;;
-    "-v" | "--v" | "-verbose" | "--verbose")
+    "-v" | "--verbose")
       verbose=true
       ;;
-    "-vv" | "--vv" | "-veryverbose" | "--veryverbose")
+    "-vv" | "--vv" | "--veryverbose")
       export V=1
       export VERBOSE=1
       verbose=true
@@ -421,7 +421,7 @@ processOptions()
       startShell=true
       ;;
     *)
-      printError "Unknown option ${arg} specified"
+      printError "Unknown option ${1} specified"
       ;;
     esac
     shift

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -56,8 +56,7 @@ asciiecho()
 
 printEnvVar()
 {
-  cat << ENVARS
-User-Provided environment variables:
+  echo "User-Provided environment variables:
 
 Required:
   ZOPEN_BUILD_LINE     Specify the default build line, either 'DEV' or 'STABLE'
@@ -143,7 +142,7 @@ Deprecated:
   ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
   ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT
   ZOPEN_URL            Alternate environment variable instead of ZOPEN_TARBALL_URL or ZOPEN_GIT_URL (alternate to ZOPEN_TARBALL_URL or ZOPEN_GIT_URL)
-ENVARS
+"
 }
 
 printFunctions()
@@ -316,13 +315,11 @@ in the root directory of the [PACKAGE]port github repository.
 To see a fully functioning z/OS Open Tools sample port see:
 https://github.com/ZOSOpenTools/zotsampleport
 
-opts=$(printEnvVar)
-echo "${opts}"
-fns=$(printFunctions)
-echo "${fns}"
-seeAlso=$(printSeeAlso)
-echo "${seeAlso}"
 HELPDOC
+
+printEnvVar
+printFunctions
+printSeeAlso
 }
 
 processOptions()

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1,12 +1,15 @@
 #!/bin/sh
 #
-# General purpose build script for ZOSOpenTools ports
+# General purpose build script for z/OS Open Tools ports - https://github.com/ZOSOpenTools
 #
 # ZOPEN_BUILD_LINE must be defined to either STABLE or DEV. This indicates the type of package to build
 #
 # For more details, see the help which you can get by issuing:
 # zopen-build -h
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
@@ -124,17 +127,17 @@ Being reworked to move to common ZOPEN_xxx_GIT_REFS:
   ZOPEN_STABLE_BRANCH  The branch that the stable repo should checkout (default is repo default)
 
 Currently unused:
-  ZOPEN_DEV_TYPE       The type of package to download. Valid types are TARBALL, BARE and GIT 
+  ZOPEN_DEV_TYPE       The type of package to download. Valid types are TARBALL, BARE and GIT
   ZOPEN_STABLE_TYPE    The type of package to download. Valid types are TARBALL, BARE and GIT
 
 Deprecated:
-  ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT 
+  ZOPEN_TYPE           The type of package to download. Valid types are TARBALL, BARE and GIT
   ZOPEN_TARBALL_URL    The fully qualified URL that the tarball should be downloaded from (required if ZOPEN_TYPE=TARBALL)
   ZOPEN_TARBALL_DEPS   Space-delimited set of source packages this git package depends on to build (required if ZOPEN_TYPE=TARBALL)
   ZOPEN_GIT_URL        The fully qualified URL that the git repo should be cloned from (required if ZOPEN_TYPE=GIT)
   ZOPEN_GIT_DEPS       Space-delimited set of source packages this tarball package depends on to build (required if ZOPEN_TYPE=GIT)
-  ZOPEN_GIT_BRANCH     The branch that the git repo should checkout 
-  ZOPEN_GIT_TAG        The tag that the git repo should checkout as a branch 
+  ZOPEN_GIT_BRANCH     The branch that the git repo should checkout
+  ZOPEN_GIT_TAG        The tag that the git repo should checkout as a branch
   ZOPEN_URL            Alternate environment variable instead of ZOPEN_TARBALL_URL or ZOPEN_GIT_URL (alternate to ZOPEN_TARBALL_URL or ZOPEN_GIT_URL)
   ZOPEN_DEPS           Alternate environment variable instead of ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS (alternate to ZOPEN_TARBALL_DEPS or ZOPEN_GIT_DEPS)
   ZOPEN_CC             C compiler (default set by dependency)
@@ -292,7 +295,7 @@ printSyntax()
     echo "  -g, --get-source     get the source and apply patch without building"
     echo "  -gp, --generate-pax  generate a pax.Z file based on the install contents"
     echo "  --forcepatchapply    force apply the patches, where rejected patches are placed into a corresponding file of the same name, with the .rej extension"
-    echo "  --no-set-active      do not change the pinned version" 
+    echo "  --no-set-active      do not change the pinned version"
     echo "  --no-install-deps    do not install project's runtime dependencies"
     echo "  -s                   exec a shell before running configure.  Useful when manually building ports."
     echo ""
@@ -425,7 +428,7 @@ loadBuildEnv()
   . ${buildEnvFile}
 
   setDefaultBuild
-  
+
 
   if command -V "zopen_post_buildenv" > /dev/null 2>&1; then
     printVerbose "Running zopen_post_buildenv"
@@ -585,7 +588,7 @@ checkEnv()
     fi
     implicitDeps="${implicitDeps}"
     printVerbose "Implicitly adding git dependencies: ${implicitDeps}"
-  fi 
+  fi
   ZOPEN_DEPS="${implicitDeps} ${ZOPEN_DEPS}"
 
   ZOPEN_COMMIT_SHA="$(git rev-parse HEAD)"
@@ -849,7 +852,7 @@ extractTarBall()
     if [ $? -gt 0 ]; then
       printError "Unable to untar ${tarballz}"
     fi
-  else 
+  else
     # Standard unzip
     # Remove the old directory contents if it already exists.
     # Keep the directory itself since there may be a symbolic
@@ -859,7 +862,7 @@ extractTarBall()
     out=$(unzip "${tarballz}" 2> /dev/null)
     if [ $? -gt 1 ]; then
       printError "unzip failed for ${tarballz}."
-      echo "${out}" >&2 
+      echo "${out}" >&2
     fi
   fi
   rm -f "${tarballz}"
@@ -1546,7 +1549,7 @@ generateMetadataJSON()
   fi
 
 metadata_version_scheme="0.1" # Update if we add breaking changes to the json format
-cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
 {
 "version_scheme": "${metadata_version_scheme}",
 "product": {
@@ -1568,7 +1571,7 @@ cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
 zz
 
 # Build Dependencies
-cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
   "build_dependencies": [
 zz
 
@@ -1578,7 +1581,7 @@ echo "${ZOPEN_DEPS}" | xargs | tr ' ' '\n' | sort | while read dep; do
 if ! $isFirst; then
   echo "," >> "${ZOPEN_INSTALL_DIR}/metadata.json"
 fi
-cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
       {
         "name": "${dep}",
         "versionRange": null
@@ -1588,7 +1591,7 @@ isFirst=false
 done
 
 # Runtime Dependencies
-cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
   ],"runtime_dependencies": [
 zz
 
@@ -1598,7 +1601,7 @@ echo "${ZOPEN_RUNTIME_DEPS}" | xargs | tr ' ' '\n' | sort | while read dep; do
 if ! $isFirst; then
   echo "," >> "${ZOPEN_INSTALL_DIR}/metadata.json"
 fi
-cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
       {
         "name": "${dep}",
         "versionRange": null
@@ -1607,13 +1610,13 @@ zz
 isFirst=false
 done
 
-cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"  
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
   ]
 }}
 zz
   if ! jq -e '.' "${ZOPEN_INSTALL_DIR}/metadata.json" 1>/dev/null 2>&1; then
     printError "${ZOPEN_INSTALL_DIR}/metadata.json contains invalid json: $(cat ${ZOPEN_INSTALL_DIR}/metadata.json)"
-  fi 
+  fi
   # Format json
   jq "." "${ZOPEN_INSTALL_DIR}/metadata.json" > "${ZOPEN_ROOT}/install/metadata.json"
   cp "${ZOPEN_ROOT}/install/metadata.json" "${ZOPEN_INSTALL_DIR}/metadata.json"
@@ -2001,7 +2004,7 @@ zz
     action=$(echo ${line} | cut -d '|' -f 2)
     value=$(echo ${line} | cut -d '|' -f 3)
     projectRootCount=$(echo "${value}" | awk -F "PROJECT_ROOT" '{print NF-1}')
-  
+
     if [ "${action}" = "unset" ]; then
       echo "unsetenv(\"${var}\");" >> "${output}"
     elif [ "${action}" = "set" -o "${action}" = "overrideset" ]; then

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -19,7 +19,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -175,11 +175,11 @@ printSeeAlso()
 {
   echo "SEE ALSO:
   zopen(1)
+  zopen-alt(1)
   zopen-init(1)
   zopen-install(1)
   zopen-list(1)
   zopen-remove(1)
-  zopen-alt(1)
   "
 }
 
@@ -274,43 +274,55 @@ setDefaults()
 printSyntax()
 {
   args=$*
-  (
-    echo ""
-    echo "zopen-build is a general purpose build script to be used with the ZOSOpenTools ports."
-    echo ""
-    echo "Usage: zopen-build [OPTION]..."
-    echo ""
-    echo "Option:"
-    echo "  -h                   print this information"
-    echo "  -v                   run in verbose mode"
-    echo "  -vv                  run in very verbose mode (sets environment variables V=1 and VERBOSE=1)"
-    echo "  -u, --upgradedeps    upgrade all dependencies by running zopen install"
-    echo "  --buildtype TYPE     TYPE may be release or debug.  The default is release"
-    echo "  --build LINE         LINE may be dev or stable. This is the build line to build off of"
-    echo "  --comp COMP          COMP may be comp_xlclang, comp_clang, comp_go, comp_python. The default is comp_xlclang."
-    echo "  --oci                build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY"
-    echo "  -e ENV_FILE          source ENV_FILE instead of buildenv to establish build environment"
-    echo "  -c, --clean          Deletes all of the build output and forces reconfigure with next build"
-    echo "  -f, --force-rebuild  forces a rebuild, including running bootstrap and configure again"
-    echo "  -g, --get-source     get the source and apply patch without building"
-    echo "  -gp, --generate-pax  generate a pax.Z file based on the install contents"
-    echo "  --forcepatchapply    force apply the patches, where rejected patches are placed into a corresponding file of the same name, with the .rej extension"
-    echo "  --no-set-active      do not change the pinned version"
-    echo "  --no-install-deps    do not install project's runtime dependencies"
-    echo "  -s                   exec a shell before running configure.  Useful when manually building ports."
-    echo ""
-    echo "The specifics of how the tool works can be controlled through environment variables."
-    echo "The only environment variables you _must_ specify are to tell zopen-build where the source is, and in what format type the source is stored."
-    echo "By default, the environment variables are defined in a file named buildenv in the root directory of the [PACKAGE]port github repository"
-    echo "To see a fully functioning z/OSOpenTools sample port see: https://github.com/ZOSOpenTools/zotsampleport"
+  cat << HELPDOC
+${ME} is a general purpose build script to be used with the ZOSOpenTools ports.
 
-    opts=$(printEnvVar)
-    echo "${opts}"
-    fns=$(printFunctions)
-    echo "${fns}"
-    seeAlso=$(printSeeAlso)
-    echo "${seeAlso}"
-  )
+Usage: ${ME} [OPTION]...
+
+Option:
+  --build LINE          LINE may be dev or stable. This is the build line
+                        to build off of.
+  --buildtype TYPE      TYPE may be release or debug.  The default is release.
+  -c, --clean           Deletes all of the build output and forces
+                        reconfigure with next build.
+  --comp COMP           COMP may be comp_xlclang, comp_clang, comp_go,
+                        comp_python. The default is comp_xlclang.
+  -e ENV_FILE           source ENV_FILE instead of buildenv to establish
+                        build environment.
+  -f, --force-rebuild   forces a rebuild, including running bootstrap
+                        and configure again.
+  --forcepatchapply     force apply the patches, where rejected patches are
+                        placed into a corresponding file of the same name,
+                        with the .rej extension.
+  -g, --get-source      get the source and apply patch without building.
+  -gp, --generate-pax   generate a pax.Z file based on the install contents.
+  -h, --help, -?        print this information.
+  --no-set-active       do not change the pinned version.
+  --no-install-deps     do not install project's runtime dependencies.
+  --oci                 build and publish an OCI image to \$ZOPEN_IMAGE_REGISTRY.
+  -s                    exec a shell before running configure. Useful when
+                        manually building ports.
+  -v                    run in verbose mode.
+  -vv                   run in very verbose mode (sets environment variables
+                        V=1 and VERBOSE=1).
+  -u, --upgradedeps     upgrade all dependencies by running zopen install.
+
+The specifics of how the tool works can be controlled through environment
+variables. The only environment variables you _must_ specify are to tell
+${ME} where the source is, and in what format type the source is stored.
+By default, the environment variables are defined in a file named buildenv
+in the root directory of the [PACKAGE]port github repository.
+
+To see a fully functioning z/OS Open Tools sample port see:
+https://github.com/ZOSOpenTools/zotsampleport
+
+opts=$(printEnvVar)
+echo "${opts}"
+fns=$(printFunctions)
+echo "${fns}"
+seeAlso=$(printSeeAlso)
+echo "${seeAlso}"
+HELPDOC
 }
 
 processOptions()
@@ -332,9 +344,9 @@ processOptions()
   depsPath="${ZOPEN_PKGINSTALL}"
   forceUpgradeDeps=false
   noInstallRuntimeDeps=false
-  while [[ $# -gt 0 ]]; do
+  while [ $# -gt 0 ]; do
     case $1 in
-    "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+    "-h" | "--help" | "-?")
       trap - EXIT
       printSyntax "${args}"
       exit 0

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -50,7 +50,7 @@ Examples:
   zopen clean -u [PACKAGE]
                     remove unused versions for PACKAGE
 
-Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+Report bugs at https://github.com/ZOSOpenTools/meta/issues.
 
 HELPDOC
 }

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -1,5 +1,8 @@
 #!/bin/sh
 # Cleanup utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
@@ -29,12 +32,12 @@ Usage: zopen clean [OPTION] [PACKAGE]
 Options:
   -m, --metadata    cleans and refreshes the metadata for zopen
   -c, --cache  [PACKAGE ...]
-                    cleans the downloaded package cache; packages will be 
+                    cleans the downloaded package cache; packages will be
                     re-downloaded if needed
-  -d, --dangling    removes dangling symlinks from the zopen file system in case 
+  -d, --dangling    removes dangling symlinks from the zopen file system in case
                     of issues during package maintenance
-  -u, --unused [PACKAGE ...]     
-                    remove versions of PACKAGEs that are available as 
+  -u, --unused [PACKAGE ...]
+                    remove versions of PACKAGEs that are available as
                     alternatives, leaving only the currently active version
       --all         apply cleanup command to all applicable packages
   -v, --verbose     run in verbose mode
@@ -55,11 +58,11 @@ HELPDOC
 cleanUnused()
 {
   for needle in $1; do
-    [ -z "${needle}" ] && return 
+    [ -z "${needle}" ] && return
     [ ! -e "${ZOPEN_PKGINSTALL}/${needle}" ] && printInfo "No versions of '${needle}' found" && continue
-    
+
     current=$(getCurrentVersionDir "${needle}")
-  
+
     if [ -n "${current}" ]; then
       current=$(basename "${current}")
     else
@@ -78,7 +81,7 @@ cleanUnused()
         printInfo "-- ${repo} <- Removed"
         syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE},${CAT_PACKAGE},${CAT_REMOVE}" "CLEAN" "cleanUnused" "Removed unused package at ${repo#"${ZOPEN_PKGINSTALL}"/} "
       fi
-    done  
+    done
   done
 }
 

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -24,25 +24,25 @@ checkWritable
 printHelp()
 {
   cat << HELPDOC
-zopen clean is a utility for z/OS Open Tools to clean uneeded resources
-from the system to save space and prevent clutter
+${ME} is a utility for z/OS Open Tools to remove uneeded resources
+from the system to save space and prevent clutter.
 
-Usage: zopen clean [OPTION] [PACKAGE]
+Usage: ${ME} [OPTION] [PACKAGE]
 
 Options:
-  -m, --metadata    cleans and refreshes the metadata for zopen
+  --all             apply cleanup command to all applicable packages.
   -c, --cache  [PACKAGE ...]
                     cleans the downloaded package cache; packages will be
-                    re-downloaded if needed
-  -d, --dangling    removes dangling symlinks from the zopen file system in case
-                    of issues during package maintenance
+                    re-downloaded if needed.
+  -d, --dangling    removes dangling symlinks from the zopen file system in
+                    case of issues during package maintenance.
+  -h, --help, -?    display this help and exit.
+  -m, --metadata    cleans and refreshes the metadata for zopen.
   -u, --unused [PACKAGE ...]
                     remove versions of PACKAGEs that are available as
-                    alternatives, leaving only the currently active version
-      --all         apply cleanup command to all applicable packages
-  -v, --verbose     run in verbose mode
-  -h,-?, --help     display this help and exit
-  --version         print version
+                    alternatives, leaving only the currently active version.
+  -v, --verbose     run in verbose mode.
+  --version         print version.
 
 Examples:
   zopen clean -c    clear the package download cache

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -1,7 +1,6 @@
 #!/bin/sh
-# Cleanup utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Cleanup utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
 
 #

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -30,10 +30,13 @@ syntax()
   cat << HELPDOC
 $ME - print out build dependencies (transitive closure) for a given tool.
   NOTE: This tool will clone several repositories into a temporary directory for this computation.
+
 Usage: $ME [OPTION] [tool]
+
 Options:
   --help        display this help and exit
   --version     print version
+
 Examples:
   print out the tools required to build git.
     $ME git

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -29,16 +29,17 @@ syntax()
 {
   cat << HELPDOC
 $ME - print out build dependencies (transitive closure) for a given tool.
-  NOTE: This tool will clone several repositories into a temporary directory for this computation.
+  NOTE: This tool will clone several repositories into a
+  temporary directory for this computation.
 
 Usage: $ME [OPTION] [tool]
 
 Options:
-  --help        display this help and exit
-  --version     print version
+  --help        display this help and exit.
+  --version     print version.
 
 Examples:
-  print out the tools required to build git.
+  Print out the tools required to build git.
     $ME git
 HELPDOC
   exit 0
@@ -70,7 +71,7 @@ rootpkg="$1"
 tmpdir="/tmp/blddep_$$"
 
 if ! mkdir "${tmpdir}"; then
-  echo "Unable to create temporary directory for computing transitive closure" >&2
+  echo "Unable to create temporary directory for computing transitive closure." >&2
   syntax
 fi
 

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -1,8 +1,11 @@
 #!/bin/env bash
-
 #
 # Print out build dependencies (transitive closure) for a given tool
 #
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
@@ -19,17 +22,22 @@ setupMyself()
 }
 setupMyself
 
+#
+# Display help text.
+#
 syntax()
 {
-  echo "$ME - print out build dependencies (transitive closure) for a given tool."
-  echo "  Note this tool will clone several repositories into a temporary directory for this computation."
-  echo "Usage: $ME [OPTION] [tool]"
-  echo "Options:"
-  echo "  --help     display this help and exit"
-  echo "  --version  print version"
-  echo "Examples:"
-  echo "  print out the tools required to build git"
-  echo "    $ME git"
+  cat << HELPDOC
+$ME - print out build dependencies (transitive closure) for a given tool.
+  NOTE: This tool will clone several repositories into a temporary directory for this computation.
+Usage: $ME [OPTION] [tool]
+Options:
+  --help        display this help and exit
+  --version     print version
+Examples:
+  print out the tools required to build git.
+    $ME git
+HELPDOC
   exit 0
 }
 
@@ -38,7 +46,7 @@ secondary_type="DEV"
 verbose=true
 
 if [ $# -eq 0 ]; then
-  echo "Need to specify a package name" >&2
+  echo "Need to specify a package name." >&2
   syntax
 fi
 

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -15,7 +15,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"
@@ -29,8 +29,8 @@ syntax()
 {
   cat << HELPDOC
 $ME - print out build dependencies (transitive closure) for a given tool.
-  NOTE: This tool will clone several repositories into a
-  temporary directory for this computation.
+  NOTE: This tool will clone several repositories into a temporary directory
+  for this computation.
 
 Usage: $ME [OPTION] [tool]
 

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -7,7 +7,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-compute-builddeps
+++ b/bin/zopen-compute-builddeps
@@ -2,9 +2,6 @@
 #
 # Print out build dependencies (transitive closure) for a given tool
 #
-#
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -15,7 +15,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -3,6 +3,9 @@
 ZOPEN_DONT_PROCESS_CONFIG=1
 # Generates a zopen compatible project
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
@@ -31,12 +34,11 @@ buildLicenseLookup()
 
 printSyntax()
 {
-  args=$*
   echo "zopen-generate will generate a zopen compatible project" >&2
   echo "Syntax: zopen-generate" >&2
 }
 
-if [[ $# -eq 1 ]]; then
+if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
     printSyntax
     exit 0

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -1,9 +1,8 @@
 #!/bin/sh
+#
 # Initialize zopen
 ZOPEN_DONT_PROCESS_CONFIG=1
 # Generates a zopen compatible project
-#
-# Copyright (C) 2023 z/OS Open Tools Community.
 #
 
 #

--- a/bin/zopen-generate
+++ b/bin/zopen-generate
@@ -7,7 +7,7 @@ ZOPEN_DONT_PROCESS_CONFIG=1
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-help2man
+++ b/bin/zopen-help2man
@@ -16,7 +16,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-help2man
+++ b/bin/zopen-help2man
@@ -4,8 +4,6 @@
 #
 # We may choose to use --extendedhelp if the --help output is too long for folks.
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.

--- a/bin/zopen-help2man
+++ b/bin/zopen-help2man
@@ -8,7 +8,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-help2man
+++ b/bin/zopen-help2man
@@ -1,5 +1,13 @@
 #!/bin/sh
 #
+# Routine to generate man pages from the --help and --version for the various tools.
+#
+# We may choose to use --extendedhelp if the --help output is too long for folks.
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()
@@ -15,25 +23,22 @@ setupMyself()
 }
 setupMyself
 
-#
-# Routine to generate man pages from the --help and --version for the various tools
-#
-# We may choose to use --extendedhelp if the --help output is too long for folks
-#
 
 printSyntax()
 {
-  echo "${ME} - generate man pages from help and version information for zopen and zopen-* tools"
-  echo "Usage: ${ME} [OPTION] DIRECTORY"
-  echo "  DIRECTORY  the existing directory to write the man pages"
-  echo "Options:"
-  echo "  --help     display this help and exit"
-  echo "  --version  print version"
-  echo "Example:"
-  echo "  ${ME} /tmp/man1    write the man pages to the /tmp/man1 directory"
+  cat << HELPDOC
+${ME} - generate man pages from help and version information for zopen and zopen-* tools.
+Usage: ${ME} [OPTION] DIRECTORY
+  DIRECTORY  the existing directory to write the man pages.
+Options:
+  --help         display this help and exit
+  --version      print version
+Example:"
+  ${ME} /tmp/man1    write the man pages to the /tmp/man1 directory.
+HELPDOC
 }
 
-if [[ $# -eq 1 ]]; then
+if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
     printSyntax
     exit 0

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -19,7 +19,7 @@ setupMyself()
   MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -11,7 +11,7 @@ fi
 
 ZOPEN_DONT_PROCESS_CONFIG=1
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -1,8 +1,6 @@
 #!/bin/sh
 # Initialize zopen environment - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 ME=$(basename "$0")
 
 if [ -z "${utildir}" ]; then

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -1,5 +1,8 @@
 #!/bin/sh
-# Initialize zopen
+# Initialize zopen environment - https://github.com/ZOSOpenTools
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
 ME=$(basename "$0")
 
 if [ -z "${utildir}" ]; then
@@ -26,31 +29,26 @@ checkWritable
 
 printHelp(){
 cat << HELPDOC
-zopen init is a utility for z/OS Open Tools to generate a zopen 
+zopen init is a utility for z/OS Open Tools to generate a zopen
 environment, bootstrapping initial tools and creating a configuration
 file
 
 Usage: zopen init [OPTION] [PARAMETERS]...
 
 Options:
-  -y, --yes         
-          automatically answer 'yes' to prompts
-
   --append-to-profile
-          appends sourcing of zopen-config to current 
+          appends sourcing of zopen-config to current
           user's .profile
 
-  --releaseline-dev
-          globally configure the release line for package
-          installs to enable Development (DEV) packages; the
-          default is for a system to use STABLE packages
+  --[no]enable-stats
+          Toggle enabling collection of usage statistics
 
   -f, --fs-layout <LAYOUT>
-          The filesystem structure to use for installed 
-          packages on disk; packages will be installed to 
-          this location under <zopen rootfs>. 
+          The filesystem structure to use for installed
+          packages on disk; packages will be installed to
+          this location under <zopen rootfs>.
 
-          <LAYOUT> should be one of:                                         
+          <LAYOUT> should be one of:
 
             usrlclz: /usr/local/zopen (default),
             zopen: /usr/zopen,
@@ -59,28 +57,33 @@ Options:
             fhs: File Hierarchical Standard (/opt),
             usrlcl: usr/local
 
-  --re-init      
-          Re-initializes a previous zopen environment or 
-          create a new environment using current tooling.
-          Re-initializing over a previous installation will 
-          re-use existing package structures and 
-          configuration and regenerate configuration files.                    
-          select the active version for PACKAGE from a list
-
-  --refresh         
-          Refreshes the zopen-config file 
-
-  --[no]enable-stats
-          Toggle enabling collection of usage statistics
-
--v, --verbose     
-          run in verbose mode
-
--h, -?, --help    
+  -h, -?, --help
           display this help and exit
 
+  --re-init
+          Re-initializes a previous zopen environment or
+          create a new environment using current tooling.
+          Re-initializing over a previous installation will
+          re-use existing package structures and
+          configuration and regenerate configuration files.
+          select the active version for PACKAGE from a list
+
+  --refresh
+          Refreshes the zopen-config file
+
+  --releaseline-dev
+          globally configure the release line for package
+          installs to enable Development (DEV) packages; the
+          default is for a system to use STABLE packages
+
+  -v, --verbose
+          run in verbose mode
+
+  -y, --yes
+          automatically answer 'yes' to prompts
+
 Examples:
-  zopen init        
+  zopen init
           interactively bootstrap a zopen environment
 
   zopen init --releaseline-dev
@@ -88,14 +91,14 @@ Examples:
           will use Development Releaseline packages
 
   zopen --yes --append-to-profile --fs-layout fhs /zopen
-          non-interactively create a zopen environment at 
+          non-interactively create a zopen environment at
           location '/zopen' on disk, with packages installed
           to '/zopen/opt'. The user's .profile will be
           updated to source the configuration file at
-          '/zopen/etc/zopen-config' when new terminal 
+          '/zopen/etc/zopen-config' when new terminal
           sessions start
 
-Report bugs at https://github.com/ZOSOpenTools/meta/issues 
+Report bugs at https://github.com/ZOSOpenTools/meta/issues
 
 HELPDOC
 }
@@ -159,7 +162,7 @@ while [ $# -gt 0 ]; do
       zopen-version $ME
       exit 0
       ;;
-    "--debug") 
+    "--debug")
       debug=true
       ;;
     "--yes" | "-y")
@@ -329,8 +332,8 @@ generateFileSystem()
   fi
   printVerbose "Checking for existence of specified root: '${rootfs}'"
   [ -e "${rootfs}" ] || mkdir -p "${rootfs}" || printError "Unable to create zopen root filesystem at '${rootfs}'"
-  [ -d "${rootfs}" ] || printError "Specified location '${rootfs}' is not a directory. Unable to access root file system at '${rootfs}'; check permissions"  
-  [ -w "${rootfs}" ] || printError "Unable to write to root file system at '${rootfs}'; check permissions"  
+  [ -d "${rootfs}" ] || printError "Specified location '${rootfs}' is not a directory. Unable to access root file system at '${rootfs}'; check permissions"
+  [ -w "${rootfs}" ] || printError "Unable to write to root file system at '${rootfs}'; check permissions"
 
   printVerbose "- Populating standard file system"
   [ -e "${rootfs}/bin" ] || mkdir -p "${rootfs}/bin"
@@ -367,7 +370,7 @@ generateFileSystem()
 
 generateZopenConfig()
 {
-  printHeader "Generating zopen-config" 
+  printHeader "Generating zopen-config"
   writeConfigFile "${configFile}" "${rootfs}" "${zopen_pkginstall}" "${ZOPEN_CA_DIR}/${certFileName}"
   printInfo "- Created config in ${configFile}"
   if ${appendToProfile}; then
@@ -393,7 +396,7 @@ generateJsonConfiguration()
   if [ -z "$releaseLine" ]; then
     if ${releaselineDev}; then
       releaseLine="DEV"
-      printInfo "- Configured zopen to use development (DEV) releaseline packages where available" 
+      printInfo "- Configured zopen to use development (DEV) releaseline packages where available"
     else
       releaseLine="STABLE"
       printInfo "- Configured zopen to use stable releaseline packages"

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -25,8 +25,10 @@ printSyntax()
   args=$*
 cat << HELPDOC
 ${ME} is a utility to download/install a z/OS Open Tools package.
+
 Usage: ${ME} [OPION] [PACKAGE]
   [PACKAGE] is a package to install. Multiple packages can be specified.
+
 Options:
   --all                    download/install all z/OS Open Tools packages.
   --cache-only             do not install dependencies.
@@ -37,7 +39,8 @@ Options:
   --local-install          download and unpackage to current directory.
   --no-deps                do not install dependencies.
   --no-set-active          do not change the pinned version.
-  --nosymlink              do not integrate into filesystem through symlink redirection.
+  --nosymlink              do not integrate into filesystem through
+                           symlink redirection.
   -r, --reinstall          reinstall already installed z/OS Open Tools packages.
   --release-line [stable, dev] the release line to build off of.
   --select                 select a version to install.

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -12,7 +12,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -49,6 +49,7 @@ Options:
   -v, --verbose            print verbose messages.
   --version                print version.
   -y, --yes                automatically answer yes to prompts.
+  
 HELPDOC
 }
 

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2023 z/OS Open Tools Community.
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 # set -x
 setupMyself()
@@ -49,7 +49,7 @@ Options:
   -v, --verbose            print verbose messages.
   --version                print version.
   -y, --yes                automatically answer yes to prompts.
-  
+
 HELPDOC
 }
 

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -28,24 +28,24 @@ ${ME} is a utility to download/install a z/OS Open Tools package.
 Usage: ${ME} [OPION] [PACKAGE]
   [PACKAGE] is a package to install. Multiple packages can be specified.
 Options:
+  --all                    download/install all z/OS Open Tools packages.
+  --cache-only             do not install dependencies.
+  --download-only          download package to current directory.
   --help                   print this help.
-  --version                print version.
-  -u, --update, --upgrade  updates installed z/OS Open Tools packages.
   --install-or-upgrade     installs the package if not installed,
                            or upgrades the package if installed.
-  -r, --reinstall          reinstall already installed z/OS Open Tools packages.
-  --nosymlink              do not integrate into filesystem through symlink redirection.
-  --release-line [stable, dev] the release line to build off of.
-  --no-deps                do not install dependencies.
-  --cache-only             do not install dependencies.
-  --no-set-active          do not change the pinned version.
-  --skip-upgrade           do not upgrade.
-  -y, --yes                automatically answer yes to prompts.
-  --select                 select a version to install.
-  -v, --verbose            print verbose messages.
-  --download-only          download package to current directory.
   --local-install          download and unpackage to current directory.
-  --all                    download/install all z/OS Open Tools packages.
+  --no-deps                do not install dependencies.
+  --no-set-active          do not change the pinned version.
+  --nosymlink              do not integrate into filesystem through symlink redirection.
+  -r, --reinstall          reinstall already installed z/OS Open Tools packages.
+  --release-line [stable, dev] the release line to build off of.
+  --select                 select a version to install.
+  --skip-upgrade           do not upgrade.
+  -u, --update, --upgrade  updates installed z/OS Open Tools packages.
+  -v, --verbose            print verbose messages.
+  --version                print version.
+  -y, --yes                automatically answer yes to prompts.
 HELPDOC
 }
 

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -1,7 +1,8 @@
 #!/bin/sh
+#
 # Install utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.
 #

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Install utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 # set -x

--- a/bin/zopen-md2man
+++ b/bin/zopen-md2man
@@ -6,7 +6,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-md2man
+++ b/bin/zopen-md2man
@@ -1,8 +1,7 @@
 #!/bin/sh
+#
 # Generate man1/xxx.1.gz from xxx.md
 # Probably throw-away since we are going to use help2man instead
-#
-# Copyright (C) 2023 z/OS Open Tools Community.
 #
 
 #

--- a/bin/zopen-md2man
+++ b/bin/zopen-md2man
@@ -14,7 +14,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-md2man
+++ b/bin/zopen-md2man
@@ -2,6 +2,9 @@
 # Generate man1/xxx.1.gz from xxx.md
 # Probably throw-away since we are going to use help2man instead
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #

--- a/bin/zopen-migrate-buildenv
+++ b/bin/zopen-migrate-buildenv
@@ -12,7 +12,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-migrate-buildenv
+++ b/bin/zopen-migrate-buildenv
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
-##
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()

--- a/bin/zopen-migrate-buildenv
+++ b/bin/zopen-migrate-buildenv
@@ -4,7 +4,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-migrate-buildenv
+++ b/bin/zopen-migrate-buildenv
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Build environment migration script.
 #
 
 #

--- a/bin/zopen-migrate-groovy
+++ b/bin/zopen-migrate-groovy
@@ -17,7 +17,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-migrate-groovy
+++ b/bin/zopen-migrate-groovy
@@ -9,7 +9,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-migrate-groovy
+++ b/bin/zopen-migrate-groovy
@@ -5,6 +5,9 @@
 # Has no checks in it and requires you fill in the ...'s in the generated files.
 # Also, spacing is a bit off - but easy enough to change post-processing in the editor.
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #

--- a/bin/zopen-migrate-groovy
+++ b/bin/zopen-migrate-groovy
@@ -5,8 +5,6 @@
 # Has no checks in it and requires you fill in the ...'s in the generated files.
 # Also, spacing is a bit off - but easy enough to change post-processing in the editor.
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.

--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -1,5 +1,8 @@
 #!/bin/sh
-# Promote a zopen instance to a different location
+# Promote a zopen instance to a different location.
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
@@ -26,36 +29,45 @@ to a test area, validate the behavior, and promote to a production area.
 Usage: zopen promote [OPTION] [DESTINATION]...
 
 Options:
-  -f, --from  [DIRECTORY]
-                    The zopen environment to copy from; if not present,
-                    the default is taken from ZOPEN_ROOTFS (the current
-                    zopen environment).
-  -y, --yes         Automatically answer 'yes' to prompts; existing
-                    target filesystems will be purged before promote
-                    occurs.
-  -o, --owner [OWNER]
-                    Change owner of promoted environment files from
-                    current user.
-  -g, --group [GROUP]
-                    Change group of promoted environment files from
-                    default.
   -cp, --configperms [PERMISSIONS]
                     Update the permissions for the configuration file
                     <promotedroot>/etc/zopen-config with the given
                     [PERMISSIONS] string, specified in symbolic mode.
+
+  -f, --from  [DIRECTORY]
+                    The zopen environment to copy from; if not present,
+                    the default is taken from ZOPEN_ROOTFS (the current
+                    zopen environment).
+
+  -g, --group [GROUP]
+                    Change group of promoted environment files from
+                    default.
+
+  -h, -?, --help    Display this help and exit.
+
+  --keepzopentooling
+                    Install the zopen admin tools into the promoted
+                    environment for zopen system administration.
+
+  -o, --owner [OWNER]
+                    Change owner of promoted environment files from
+                    current user.
+
+  -v, --verbose     Run in verbose mode.
+
+  --version         Display version information.
+
+  -y, --yes         Automatically answer 'yes' to prompts; existing
+                    target filesystems will be purged before promote
+                    occurs.
+
   -zp, --zopenperms [PERMISSIONS]
                     Update the permissions for all files within the
                     promoted zopen environment with the given
                     [PERMISSIONS] string, specified in symbolic mode.
-  --keepzopentooling
-                    Install the zopen admin tools into the promoted
-                    environment for zopen system administration.
-  -v, --verbose     Run in verbose mode.
-  --version         Display version information.
-  -h, -?, --help    Display this help and exit.
 
 Examples:
-  zopen promote       Interactively promote current zopen environment.
+  zopen promote     Interactively promote current zopen environment.
   zopen promote /prod
                     Promote current zopen environment to '/prod', setting
                     file ownership to current user and group to default.

--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -1,7 +1,6 @@
 #!/bin/sh
-# Promote a zopen instance to a different location.
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Promote a zopen instance to a different location.
 #
 
 #

--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Query utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()
@@ -48,7 +52,7 @@ if ${filter_implemented}; then
   echo "                   green: all pass, blue: most pass, yellow: some pass, red: no pass, gray: skipped"
 fi
   echo "  --help           print this help"
-  echo "  --version        print version" 
+  echo "  --version        print version"
 }
 
 colorizepct()

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -1,7 +1,6 @@
 #!/bin/sh
-# Query utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Query utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
 
 #

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -28,30 +28,33 @@ printSyntax()
 {
   args=$*
   echo "${ME} -  a utility for z/OS Open Tools to query packages and repos."
+  echo ""
   echo "Usage: ${ME} [OPTION] [VERB] [PACKAGE]"
   echo "  VERB is the action to take, which is one of"
   echo "    --list, --remote-search, --installed"
   echo "  PACKAGE is a package, specified for --remote-search"
+  echo ""
   echo "Verbs:"
+  echo "  -i, --installed  list installed z/OS Open Tools."
   echo "  --list           list all available z/OS Open Tools."
   echo "  --remote-search  regex match package against available z/OS Open Tools"
-  echo "  -i, --installed  list installed z/OS Open Tools."
 if ${upgradeable_implemented}; then
   echo "  --upgradeable    list packages where an upgrade is available."
 fi
 if ${whatprovides_implemented}; then
   echo "  -wp, --whatprovides  which installed package provided a file."
 fi
+  echo ""
   echo "Options:"
-  echo "  -v               run in verbose mode."
   echo "  -d, --details    include full details for listings."
-  echo "  --no-header,     suppress the header for the output."
-  echo "  --no-version,    suppress version information, return package names."
 if ${filter_implemented}; then
   echo "  --filter COLOR   apply COLOR (quality) filter."
   echo "                   green: all pass, blue: most pass, yellow: some pass, red: no pass, gray: skipped"
 fi
   echo "  --help           print this help"
+  echo "  --no-header,     suppress the header for the output."
+  echo "  --no-version,    suppress version information, return package names."
+  echo "  -v               run in verbose mode."
   echo "  --version        print version"
 }
 

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -1,7 +1,6 @@
 #!/bin/sh
-# Removal utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Removal utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
 
 #

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -24,28 +24,25 @@ checkWritable
 printHelp()
 {
   cat << HELPDOC
-zopen remove is a utility for z/OS Open Tools to remove an installed package or
+${ME} is a utility for z/OS Open Tools to remove an installed package or
 packages.
 
-Usage: zopen remove [OPTION] [PACKAGE] ...
+Usage: ${ME} [OPTION] [PACKAGE] ...
 
 Options:
   -h, --help, -?    display this help and exit.
-
-  -p, --purge       remove package, the versioned directory and any cached file.
-
+  -p, --purge       remove package, the versioned directory, and any
+                    cached files.
   -v, --verbose     run in verbose mode.
-
   --version         print version.
-
   -y, --yes         automatically answer yes to prompts.
 
 Examples:
   zopen remove foo bar
                     interactively remove the foo and bar packages if installed
   zopen remove --yes foo bar
-                    remove the foo and bar packages if installed, without asking
-                    for confirmation
+                    remove the foo and bar packages if installed, without
+                    asking for confirmation
 
 Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -1,6 +1,10 @@
 #!/bin/sh
 # Removal utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()
@@ -26,11 +30,15 @@ packages.
 Usage: zopen remove [OPTION] [PACKAGE] ...
 
 Options:
+  -h, --help, -?    display this help and exit.
+
+  -p, --purge       remove package, the versioned directory and any cached file.
+
+  -v, --verbose     run in verbose mode.
+
+  --version         print version.
+
   -y, --yes         automatically answer yes to prompts.
-  -p, --purge       remove package, the versioned directory and any cached file
-  -v, --verbose     run in verbose mode
-  -h, -?, --help    display this help and exit
-  --version         print version
 
 Examples:
   zopen remove foo bar
@@ -131,7 +139,7 @@ while [ $# -gt 0 ]; do
     # shellcheck disable=SC2034
     debug=true
     ;;
-  "-y" | "--yes") 
+  "-y" | "--yes")
     yesToPrompts=true
     ;;
   *)

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -12,7 +12,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -26,12 +26,16 @@ printSyntax()
   cat << HELPDOC
 ${ME} - split a patch file into one patch file for each patch.
   Patches are written to ${pd} in the current directory.
+
 Usage: ${ME} [OPTION] [PATCHFILE]
+
 Options:
   --help      display this help and exit.
   --version   print version.
+
 Example:
   ${ME} P1.patch    write P1.patch into multiple patches under ${pd}
+
 HELPDOC
 }
 

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -4,7 +4,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -1,5 +1,9 @@
 #!/bin/env bash
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
+#
 # All zopen-* scripts MUST start with this code to maintain consistency
 #
 setupMyself()

--- a/bin/zopen-split-patch
+++ b/bin/zopen-split-patch
@@ -1,6 +1,6 @@
 #!/bin/env bash
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Split a patch file into multiple patches.
 #
 
 #

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -2,6 +2,9 @@
 #
 # Updates the cacert in zopen meta root directory
 #
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -2,8 +2,6 @@
 #
 # Updates the cacert in zopen meta root directory
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
-#
 
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -43,19 +43,23 @@ printHelp()
 {
   args=$*
 cat << HELPDOC
-${ME}:
-  Update your cacert.pem file to the latest curl CA certificates extracted from Mozilla.
+${ME}: Update your cacert.pem file to the latest CA certificates extracted from Mozilla.
+
 Syntax:
   ${ME} [-fhv] [<directory>]
+
 Options:
   -f, --force           update cacert.pem file even if up to date.
   -h, --help            print this help.
+  -i, --insecure-fallback
+                        (UNSAFE) Skip certificate validation during download.
   -v, --verbose         print verbose messages.
   --version             print version.
 
 Parameters:
   <directory>: the directory where the cacert.pem will be updated.
     The default directory location is: ${default_dir}
+
 HELPDOC
 }
 
@@ -121,12 +125,12 @@ dir="${default_dir}"
 args=$*
 forceUpdate=false
 insecureFallback=false
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   case "$1" in
-  "-f" | "-force" | "--force")
+  "-f" | "--force")
     forceUpdate=true
     ;;
-  "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
+  "-h" | "--help" | "-?")
     printHelp "${args}"
     exit 0
     ;;
@@ -137,7 +141,7 @@ while [[ $# -gt 0 ]]; do
   "-i" | "--insecure-fallback")
     insecureFallback=true
     ;;
-  "-v" | "--v" | "-verbose" | "--verbose")
+  "-v" | "--verbose")
     verbose=true
     ;;
   *)

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -6,7 +6,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-update-cacert
+++ b/bin/zopen-update-cacert
@@ -14,7 +14,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -37,12 +37,10 @@ printVersion()
 {
   cat << VERSIONDOC
 ${tool} (${package}) ${version}
-Copyright (C) 2022-2023 z/OS Open Tools Community.
 
-License: Apache License, Version 2.0,
-<https://directory.fsf.org/wiki/License:Apache2.0>
-
-This is free software: you are free to change and redistribute it.
+This is free software: you are free to change and redistribute it under the
+terms of the Apache License, Version 2.0.
+<https://www.apache.org/licenses/LICENSE-2.0.html>
 There is NO WARRANTY, to the extent permitted by law.
 
 Written by contributors to the z/OS Open Tools Community.

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -37,10 +37,10 @@ HELPDOC
 tool='zopen' # Default name
 package="zopen tools"
 copyright="Copyright (C) 2023 z/OS Open Tools Community."
-license="License Apache: The Apache Software Foundation license, <https://directory.fsf.org/wiki/License:Apache2.0>"
+license="License: Apache License, Version 2.0, <https://directory.fsf.org/wiki/License:Apache2.0>"
 freesw="This is free software: you are free to change and redistribute it."
 warranty="There is NO WARRANTY, to the extent permitted by law."
-authors="Written by contributors to the z/OS Open Tools Community <https://github.com/ZOSOpenTools/meta/graphs/contributors>."
+authors="Written by contributors to the z/OS Open Tools Community. <https://github.com/ZOSOpenTools/meta/graphs/contributors>"
 
 if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
@@ -57,4 +57,4 @@ set -e
 
 version=$(cat "${INCDIR}/zopen_version")
 
-printf "%s %s %s\n%s\n\n%s\n%s\n%s\n\n\n%s\n" "${tool}" "(${package})" "${version}" "${copyright}" "${license}" "${freesw}" "${warranty}" "${authors}"
+printf "%s %s %s\n%s\n\n%s\n%s\n%s\n\n%s\n\n" "${tool}" "(${package})" "${version}" "${copyright}" "${license}" "${freesw}" "${warranty}" "${authors}"

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -5,7 +5,7 @@
 #
 
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -13,7 +13,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -1,7 +1,6 @@
 #!/bin/sh
-# Version utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
-# Copyright (C) 2023 z/OS Open Tools Community.
+# Version utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
 
 #
@@ -38,7 +37,7 @@ printVersion()
 {
   cat << VERSIONDOC
 ${tool} (${package}) ${version}
-Copyright (C) 2023 z/OS Open Tools Community.
+Copyright (C) 2022-2023 z/OS Open Tools Community.
 
 License: Apache License, Version 2.0,
 <https://directory.fsf.org/wiki/License:Apache2.0>

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -23,13 +23,14 @@ setupMyself
 printSyntax()
 {
   cat << HELPDOC
-  ${ME} prints version information for ${package}
-  Usage: ${ME} [OPTION] tool
-     or: ${ME} [OPTION]
-  Syntax: ${ME} [OPTIONS]
-  where OPTIONS can be:
-    --help          print this help
-    --version       print version
+${ME} prints version information for ${package}.
+
+Usage: ${ME} [OPTION] tool
+
+Options:
+  --help          display this help and exit.
+  --version       print version.
+
 HELPDOC
 }
 
@@ -41,7 +42,7 @@ freesw="This is free software: you are free to change and redistribute it."
 warranty="There is NO WARRANTY, to the extent permitted by law."
 authors="Written by contributors to the z/OS Open Tools Community <https://github.com/ZOSOpenTools/meta/graphs/contributors>."
 
-if [[ $# -eq 1 ]]; then
+if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
     printSyntax
     exit 0

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -34,13 +34,27 @@ Options:
 HELPDOC
 }
 
+printVersion()
+{
+  cat << VERSIONDOC
+${tool} (${package}) ${version}
+Copyright (C) 2023 z/OS Open Tools Community.
+
+License: Apache License, Version 2.0,
+<https://directory.fsf.org/wiki/License:Apache2.0>
+
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by contributors to the z/OS Open Tools Community.
+<https://github.com/ZOSOpenTools/meta/graphs/contributors>
+
+VERSIONDOC
+}
+
 tool='zopen' # Default name
 package="zopen tools"
-copyright="Copyright (C) 2023 z/OS Open Tools Community."
-license="License: Apache License, Version 2.0, <https://directory.fsf.org/wiki/License:Apache2.0>"
-freesw="This is free software: you are free to change and redistribute it."
-warranty="There is NO WARRANTY, to the extent permitted by law."
-authors="Written by contributors to the z/OS Open Tools Community. <https://github.com/ZOSOpenTools/meta/graphs/contributors>"
+version=$(cat "${INCDIR}/zopen_version")
 
 if [ $# -eq 1 ]; then
   if [ "x$1" = "x--help" ]; then
@@ -53,8 +67,4 @@ if [ $# -eq 1 ]; then
   fi
 fi
 
-set -e
-
-version=$(cat "${INCDIR}/zopen_version")
-
-printf "%s %s %s\n%s\n\n%s\n%s\n%s\n\n%s\n\n" "${tool}" "(${package})" "${version}" "${copyright}" "${license}" "${freesw}" "${warranty}" "${authors}"
+printVersion

--- a/bin/zopen-version
+++ b/bin/zopen-version
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Version utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+# Copyright (C) 2023 z/OS Open Tools Community.
+#
+
 #
 # All zopen-* scripts MUST start with this code to maintain consistency
 #

--- a/bin/zopen-versions
+++ b/bin/zopen-versions
@@ -1,6 +1,6 @@
 #!/bin/env bash
 #
-# All zopen-* scripts MUST start with this code to maintain consistency
+# All zopen-* scripts MUST start with this code to maintain consistency.
 #
 setupMyself()
 {

--- a/bin/zopen-versions
+++ b/bin/zopen-versions
@@ -8,7 +8,7 @@ setupMyself()
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
-    echo "Internal Error. Unable to find common.sh file to source" >&2
+    echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
   . "${INCDIR}/common.sh"


### PR DESCRIPTION
This PR adds a copyright line to each script file.    It also sorts the command line arguments alphabetically for some of the scripts.  Finally, it continues to speed up help text printing by replacing repeated `echo` calls with a single `cat`.