### PR TITLE
Preserve steplib under ZOPEN_OLD_STEPLIB for compilers

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -1139,6 +1139,7 @@ initDefaultEnvironment()
 {
   export ZOPEN_OLD_PATH="${PATH}"       # Preserve PATH in case scripts need to access it
   export ZOPEN_OLD_LIBPATH="${LIBPATH}" # Preserve LIBPATH in case scripts need to access it
+  export ZOPEN_OLD_STEPLIB="${STEPLIB}" # Preserve STEPLIB in case scripts need to access it
   export PATH="$(getconf PATH)"
   export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
   unset MANPATH


### PR DESCRIPTION
Related PR: https://github.com/ZOSOpenTools/comp_clangport/pull/9