### PR TITLE
fix zopen-promote help so that it can be properly converted to man pages

### DIFF
--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -21,7 +21,7 @@ setupMyself
 
 printHelp(){
 cat << HELPDOC
-"${ME}" is a utility for z/OS Open Tools to generate a clone of
+${ME} is a utility for z/OS Open Tools to generate a clone of
 an existing zopen environment. For example, a user can install
 to a test area, validate the behavior, and promote to a production area.
 
@@ -89,7 +89,6 @@ HELPDOC
 
 args=$*
 
-printHeader "Promoting zopen environment"
 
 verbose=false
 debug=false
@@ -159,6 +158,7 @@ while [ $# -gt 0 ]; do
   shift;
 done
 
+printHeader "Promoting zopen environment"
 printDebug "Validating input parameters"
 
 defaultConfigPerms="u+rwx,g+rx,g-w,o-rwx" # Allow user full access, group read/execute, others no access


### PR DESCRIPTION
Fixes #663 
The issue was that the fancy header was being printed out before the help, and the header fancy characters were causing help2man grief.
Fix was to move the fancy header to after the help/version info was printed out. 

I ran 'zopen build' for metaport against this. It failed the same way as without my fix (looks like metaport is busted).