### PR TITLE
Fix zopen install --all and guard display on zopen-config

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -643,7 +643,8 @@ installArray=""
 if ${all}; then
   if ! ${yesToPrompts}; then
     # Sum up the pax size + expanded size of the latest releases of each port
-    spaceRequiredBytes=$(jq '.release_data | to_entries | map(select(.value | length > 0)) | map(.value[0].assets[0]) | reduce .[] as $item ({}; . + {($item.name): ($item.size + $item.expanded_size)}) | [.[]] | add' ${JSON_CACHE})
+    spaceRequiredBytes=$(jq '.release_data | to_entries | map(select(.value | length > 0)) | map(.value[0].assets[0]) | reduce .[] as $item ({}; . + {($item.name): (($item.size | tonumber)  + ($item.expanded_size | tonumber))}) | [.[]] | add'  ${JSON_CACHE})
+    echo "Space: $spaceRequiredBytes"
     spaceRequiredMB=$(echo "scale=0; ${spaceRequiredBytes} / (1024 * 1024)" | bc)
     availableSpaceMB=$(/bin/df -m ${ZOPEN_ROOTFS} | sed "1d" | awk '{ print $3 }' | awk -F'/' '{ print $1 }')
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -216,19 +216,28 @@ export ZOPEN_LOG_PATH
 # Add any custom parameters for curl
 ZOPEN_CURL_PARAMS=""
 
-# Environment variables
+# Do not display text for non-interactive sessions
+displayText=true
+if [ -n "\$SSH_CONNECTION" ] && [ -z "\$PS1" ] || [ ! -t 1 ]; then
+  displayText=false
+fi
 
 if [ -z "\${ZOPEN_QUICK_LOAD}" ]; then
   if [ -e "\${ZOPEN_ROOTFS}/etc/profiled" ]; then
     dotenvs=\$(find "\${ZOPEN_ROOTFS}/etc/profiled" -type f -name 'dotenv' -print)
-    printf "Processing \$zot configuration..."
+    if \$displayText; then
+      printf "Processing \$zot configuration..."
+    fi
     for dotenv in \$dotenvs; do
       . \$dotenv
     done
-    /bin/echo "DONE"
+    if \$displayText; then
+      /bin/echo "DONE"
+    fi
     unset dotenvs
   fi
 fi
+unset displayText
 PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar \"\${PATH}\" \":\" \"^\${ZOPEN_PKGINSTALL}/.*\$\")
 export PATH=\$(deleteDuplicateEntries \"\${PATH}\" \":\")
 LIBPATH=\${ZOPEN_ROOTFS}/usr/local/lib:\${ZOPEN_ROOTFS}/usr/lib:\$(sanitizeEnvVar "\${LIBPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")


### PR DESCRIPTION
The --all size calculation was concatenating the values. This uses tonumber on the values to convert them to numbers.
This PR also guards the text display for non-interactive sessions.