### PR TITLE
Add port's commit hash to metadata.json

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1650,12 +1650,14 @@ cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
   "zopen_license": "${ZOPEN_REMOTE_URL}/blob/main/LICENSE",
   "categories": "${ZOPEN_CATEGORIES}",
   "buildline": "${ZOPEN_BUILD_LINE}",
+  "source_type": "${ZOPEN_TYPE}",
   "test_status": {
     "total_tests": "${totalTests}",
     "total_success": "${success}"
   },
   "size": "${total_size}",
   "commitsha": "${ZOPEN_COMMIT_SHA}",
+  "community_commitsha": "${ZOPEN_PROJECT_HEAD_COMMIT_SHA}",
 zz
 
 # Build Dependencies
@@ -1843,6 +1845,8 @@ resolveCommands()
       ZOPEN_NAME="${dir}-${branch}"
     fi
   fi
+  ZOPEN_PROJECT_HEAD_COMMIT_SHA="$(git rev-parse HEAD)"
+
   # Check if ZOPEN_NAME contains a "-"
   if [ -z "$(echo "${ZOPEN_NAME}" | grep '-')" ]; then
     # If not, add the '-DEV' suffix so as not to collide with zopen installed packages

--- a/tools/create_release_cache.py
+++ b/tools/create_release_cache.py
@@ -98,7 +98,7 @@ def process_asset(asset, body, metadata_asset_name="metadata.json"):
 
 
 # Cap to 1 thread for now so that we don't hit the secondary rate limit
-num_threads = min(int(multiprocessing.cpu_count() / 2), 1)
+num_threads = min(int(multiprocessing.cpu_count() / 2), 2)
 
 
 # Process a single release

--- a/tools/create_release_cache.py
+++ b/tools/create_release_cache.py
@@ -68,6 +68,10 @@ def process_asset(asset, body, metadata_asset_name="metadata.json"):
         # Extract the info from metadata.json file:
         total_tests = metadata.get("test_status", {}).get("total_tests", -1)
         passed_tests = metadata.get("test_status", {}).get("total_success", -1)
+        source_type = metadata.get("source_type", None)
+        sha = None
+        if source_type is not None and source_type == "GIT":
+            sha = metadata.get("community_commitsha", None)
 
         runtime_dependencies_list = metadata.get("runtime_dependencies", [])
         runtime_dependency_names = [dependency.get("name", "") for dependency in runtime_dependencies_list]
@@ -82,7 +86,8 @@ def process_asset(asset, body, metadata_asset_name="metadata.json"):
             "expanded_size": metadata.get("size", 0),
             "runtime_dependencies": runtime_dependencies,
             "total_tests": total_tests,
-            "passed_tests": passed_tests
+            "passed_tests": passed_tests,
+            "community_commitsha": sha
         }
         print(filtered_asset)
 


### PR DESCRIPTION
In prep for being able to query for vulnerabilities using a commit hash: https://google.github.io/osv.dev/post-v1-query/

Querying based on package/version doesn't yield good results but using commit hashes does.

Related discussion: https://github.com/orgs/ZOSOpenTools/discussions/214

Working on a CI/CD script to generate a vulnerability report (in json)of all the tools