### PR TITLE
Download metadata.json during zopen install + support for installation caveats

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -223,6 +223,9 @@ Optional:
                                     the install_test.sh file. The output of the
                                     function is appended to install_test.sh
                                     script.
+  zopen_install_caveats             This function is run post install. All stdout 
+                                    messages are captured and added to the metadata.json
+                                    as installation caveats.
   zopen_append_to_zoslib_env        This function runs as part of generation of
                                     the C function zoslib_env_hook, which can
                                     be used to set environment variables before

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1636,8 +1636,12 @@ generateMetadataJSON()
     success=-1
   fi
 
-metadata_version_scheme="0.1" # Update if we add breaking changes to the json format
-cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
+  if [ -n "$(command -v zopen_install_caveats)" ]; then
+    caveats="$(zopen_install_caveats)"
+  fi
+    
+  metadata_version_scheme="0.1" # Update if we add breaking changes to the json format
+  cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
 {
 "version_scheme": "${metadata_version_scheme}",
 "product": {
@@ -1657,6 +1661,11 @@ cat <<zz > "${ZOPEN_INSTALL_DIR}/metadata.json"
   "size": "${total_size}",
   "commitsha": "${ZOPEN_COMMIT_SHA}",
 zz
+  if [ -n "${caveats}" ]; then
+cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"
+  "install_caveats": "${caveats}",
+zz
+  fi
 
 # Build Dependencies
 cat <<zz >> "${ZOPEN_INSTALL_DIR}/metadata.json"

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -252,12 +252,14 @@ handlePackageInstall()
   installedReleaseLine=$(validateReleaseLine "${tagname}")
 
   downloadURL=$(/bin/printf "%s" "${asset}" | jq -e -r '.url')
+  metadataJSONURL="$(dirname "${downloadURL}")/metadata.json"
   size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
 
   if [ -z "${downloadURL}" ]; then
     printError "Unable to determine download location for ${name}"
   fi
   downloadFile=$(basename "${downloadURL}")
+  metadataFile="${downloadFile}.json" # use the same basename as the pax + .json to avoid collision
   downloadFileVer=$(echo "${downloadFile}" | sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
   printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
 
@@ -313,6 +315,12 @@ handlePackageInstall()
   else
     printVerbose "Checking cache for already downloaded package [file name comparison]."
     location="zopen package cache"
+  fi
+
+  # Download the metadata json file
+  if ! runAndLog "curlCmd -L '${metadataJSONURL}' -o '${metadataFile}' ${redirectToDevNull}"; then
+    printError "Could not download from ${metadataJSONURL}. Correct any errors and potentially retry."
+    continue
   fi
 
   pax=${downloadFile}
@@ -383,6 +391,13 @@ handlePackageInstall()
     if ${localInstall}; then
       rm -f "${pax}"
     fi
+
+    # Some installation have installation caveats
+    installCaveat=$(jq -r '.product.install_caveats // empty' "${metadataFile}" 2>/dev/null)
+    if [ -n "$installCaveat" ]; then
+      printf "%s:\n%s\n" "${name}" "${installCaveat}" >> ${caveatsFile}
+    fi
+
 
     if ${setactive}; then
       if [ -L "${baseinstalldir}/${name}/${name}" ]; then
@@ -485,9 +500,15 @@ installPorts()
   ports="$1"
   printVerbose "Ports to install: ${ports}"
   mutexReq "zopen" "zopen"
+  caveatsFile=$(mktempfile "caveats")
   echo "${ports}" | xargs | tr ' ' '\n' | while read port; do
     handlePackageInstall "${port}"
   done
+  if [ -s "${caveatsFile}" ]; then
+    printHeader "Installation Caveats"
+    cat "${caveatsFile}"
+  fi
+  rm -f "${caveatsFile}"
   mutexFree "zopen"
 )
 


### PR DESCRIPTION
* Download metadata.json from zopen install 
* The caveats portion covers issue https://github.com/ZOSOpenTools/meta/issues/688