### PR TITLE
Fix zopen install --select

### DIFF
--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -150,7 +150,7 @@ handlePackageInstall()
     printVerbose "List individual releases and allow selection."
     i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
     printInfo "Versions available for install:"
-    /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size/ (1024 * 1024))mb")[]'
+    /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size | tonumber/ (1024 * 1024))mb")[]'
 
     printVerbose "Getting user selection."
     valid=false


### PR DESCRIPTION
Fixes the following issue with `zopen install --select`:
```
- Querying repo for latest package information.
Processing package: which
Versions available for install:
jq: error (at <stdin>:69): string ("882688") and number (1048576) cannot be divided
Enter version to install (0-3):
```