### PR TITLE
Analytics: enable support by default + some fixes

### DIFF
--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -219,9 +219,6 @@ determineRootFileSystem()
 
 determineStatsCollection()
 {
-  if [ -z "$ZOPEN_BETA_FEATURES" ]; then
-    return
-  fi
   isAnalyticsOn
   analyticsRC=$?
   if isIBMHostname; then
@@ -401,14 +398,6 @@ generateJsonConfiguration()
     fi
   fi
 
-  if [ -z "$ZOPEN_BETA_FEATURES" ]; then
-  cat <<zz > "${jsonConfigWorking}"
-  {
-    "release_line": "${releaseLine}",
-    "num_rm_procs": ${RM_FILEPROCS}
-  }
-zz
-  else
   cat <<zz > "${jsonConfigWorking}"
   {
     "release_line": "${releaseLine}",
@@ -416,15 +405,11 @@ zz
     "is_collecting_stats": ${isCollectingStats}
   }
 zz
-  fi
   jq '.' $jsonConfigWorking > $jsonConfig
 }
 
 generateAnalyticsConfiguration()
 {
-  if [ -z "$ZOPEN_BETA_FEATURES" ]; then
-    return;
-  fi
   if ! ${isCollectingStats}; then
     printVerbose "You have chosen to not collect statistics."
     return;

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -234,6 +234,12 @@ determineStatsCollection()
   elif $isHostIBM; then
     printAttention "Attention: Turning on usage statistics as your host is an IBM host. If this is incorrect, rerun with --noenable-stats"
     isCollectingStats=true
+  elif [ -n "${ZOPEN_IS_BOT}" ]; then
+    printAttention "Attention: Turning on usage statistics as you are a CI/CD bot. If this is incorrect, rerun with --noenable-stats"
+    isCollectingStats=true
+  elif [ ! -t 1 ]; then
+    printAttention "Attention: Turning off usage statistics as you are running zopen init in a non-interactive environment. If this is incorrect, rerun with --enable-stats"
+    isCollectingStats=false
   else
     statsMsg="Do you want to contribute ${NC}${BOLD}anonymous${NC} usage statistics (https://zosopentools.github.io/meta/#/Guides/Analytics) to help improve z/OS Open Tools?"
     if promptYesOrNo "${statsMsg}" false; then

--- a/docs/Guides/Analytics.md
+++ b/docs/Guides/Analytics.md
@@ -13,6 +13,9 @@ The usage statistics are viewable at this url: http://163.74.88.212:3000/
 
 Note: IBM hostnames are automatically opted in.
 
+## How to Opt-Out After Opting In
+* If you initially opted in but now wish to opt out, you can set the `is_collecting_stats` field to false in the JSON file located at: `$ZOPEN_ROOTFS/etc/zopen/config.json`.
+
 ## Data Captured
 1. **Package Installations:**
    - **Package Name:** Identifies the installed package.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
     - [Developing tools](/Guides/developing.md)
     - [Updating the Docs](/Guides/../UpdateDocs.md)
     - [Migration Considerations](/Guides/Migration.md)
+    - [Analytics](/Guides/Analytics.md)
   - [Available ports](/Latest.md)
     - [Current Status](/Progress.md)
   - Reference

--- a/include/analytics.sh
+++ b/include/analytics.sh
@@ -21,9 +21,6 @@ generateUUID()
 isAnalyticsOn()
 {
   # Currently in beta more
-  if [ -z "$ZOPEN_BETA_FEATURES" ]; then
-    return 2
-  fi
   jsonConfig="${ZOPEN_ROOTFS}/etc/zopen/config.json"
   if [ ! -f ${jsonConfig} ]; then
     return 2

--- a/web/usage_stats_server/.gitignore
+++ b/web/usage_stats_server/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-package_stats.db
 package-lock.json
+db/*.db

--- a/web/usage_stats_server/README.md
+++ b/web/usage_stats_server/README.md
@@ -1,0 +1,3 @@
+To run:
+* npm install
+* npm start

--- a/web/usage_stats_server/profile_statistics.ejs
+++ b/web/usage_stats_server/profile_statistics.ejs
@@ -50,12 +50,12 @@
       <tbody>
         <% data.installs.forEach(install => { %>
           <tr>
-            <td><%= install.packagename %></td>
-            <td><%= install.version %></td>
-            <td><%= install.isUpgrade %></td>
-            <td><%= install.isBuildInstall %></td>
-            <td><%= install.isRuntimeDependencyInstall %></td>
-            <td><%= new Date(install.timestamp * 1000).toLocaleString() %></td>
+		<td><%= install.packagename %></td>
+		<td><%= install.version %></td>
+		<td><%= install.isUpgrade ? 'true' : 'false' %></td>
+		<td><%= install.isBuildInstall ? 'true' : 'false' %></td>
+		<td><%= install.isRuntimeDependencyInstall ? 'true' : 'false' %></td>
+		<td><%= new Date(install.timestamp * 1000).toLocaleString() %></td>
           </tr>
         <% }); %>
       </tbody>

--- a/web/usage_stats_server/server.js
+++ b/web/usage_stats_server/server.js
@@ -12,8 +12,13 @@ app.use(express.json());
 app.set('view engine', 'ejs');
 app.set('views', __dirname);
 
-// SQLite Database
-const db = new sqlite3.Database('db/package_stats.db');
+const dbDir = path.join(__dirname, 'db');
+if (!fs.existsSync(dbDir)) {
+    fs.mkdirSync(dbDir);
+}
+
+const dbPath = path.join(dbDir, 'package_stats.db');
+const db = new sqlite3.Database(dbPath);
 
 // Create tables if not exists
 db.run(`


### PR DESCRIPTION
* This enables the analytics support in zopen. 
* It also fixes a couple of issues in the web server
* It also exposes the analytics guide in the sidebar of the docs