### PR TITLE
zopen audit utility

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -29,6 +29,7 @@ Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 
 Command:
   alt               manage alternate versions of z/OS Open Tools packages.
+  audit             (beta) reports knonwn vulnerabilities for the installed packages.
   build             builds the enclosing z/OS Open Tools git-cloned package.
   clean             cleans up your zopen environment.
   generate          generates a new zopen project.
@@ -54,6 +55,7 @@ Examples:
 
 SEE ALSO:
   zopen-alt(1)
+  zopen-audit(1)
   zopen-build(1)
   zopen-clean(1)
   zopen-generate(1)
@@ -79,7 +81,7 @@ version=false
 
 for arg in $*; do
   case "${arg}" in
-    "alt"|"build"|"clean"|"generate"|"init"|"install"|\
+    "alt"|"audit"|"build"|"clean"|"generate"|"init"|"install"|\
     "query"|"remove"|"update-cacert")
       subcmd="zopen-${arg}"
       ;;

--- a/bin/zopen
+++ b/bin/zopen
@@ -29,7 +29,7 @@ Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 
 Command:
   alt               manage alternate versions of z/OS Open Tools packages.
-  audit             (beta) reports knonwn vulnerabilities for the installed packages.
+  audit             (beta) reports known vulnerabilities for the installed packages.
   build             builds the enclosing z/OS Open Tools git-cloned package.
   clean             cleans up your zopen environment.
   generate          generates a new zopen project.

--- a/bin/zopen-audit
+++ b/bin/zopen-audit
@@ -69,7 +69,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-JSON_VULNERABILITIES_URL="https://raw.githubusercontent.com/ZOSOpenTools/meta/vulnerability_json/docs/api/zopen_vulnerability.json"
+JSON_VULNERABILITIES_URL="https://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_vulnerability.json"
 
 downloadCVEJSONCache()
 {
@@ -77,8 +77,8 @@ downloadCVEJSONCache()
   [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
   JSON_CVE_CACHE="${cachedir}/zopen_vulnerability.json"
 
-  if ! curlout=$(curlCmd -L --no-progress-meter -o "${JSON_CVE_CACHE}" "${JSON_VULNERABILITIES_URL}"); then
-    printError "Failed to obtain json cache from ${JSON_VULNERABILITIES_URL}; ${curlout}"
+  if ! curlout=$(curlCmd -L --fail --no-progress-meter -o "${JSON_CVE_CACHE}" "${JSON_VULNERABILITIES_URL}"); then
+    printError "Failed to obtain vulnerability json from ${JSON_VULNERABILITIES_URL}; ${curlout}"
   fi
   chtag -tc 819 "${JSON_CVE_CACHE}"
 }

--- a/bin/zopen-audit
+++ b/bin/zopen-audit
@@ -1,0 +1,143 @@
+#!/bin/sh
+#
+# Audit utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+# All zopen-* scripts MUST start with this code to maintain consistency.
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source." >&2
+    exit 8
+  fi
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+
+printHelp()
+{
+  cat << HELPDOC
+${ME} is a utility for z/OS Open Tools to check for vulnerabilities
+in your installed packages.
+
+Usage: ${ME} [OPTION] [PACKAGE]
+
+Options:
+  -v, --verbose     run in verbose mode.
+  --version         print version.
+
+Examples:
+  zopen audit       check for vulnerabilities in your installed packages
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues.
+
+HELPDOC
+}
+
+# Main code start here
+args=$*
+verbose=false
+debug=false
+
+while [ $# -gt 0 ]; do
+  printVerbose "Parsing option: $1"
+  case "$1" in
+  "-h" | "--help" | "-?")
+    printHelp "${args}"
+    exit 0
+    ;;
+  "--version")
+    zopen-version ${ME}
+    exit 0
+    ;;
+  "-v" | "--verbose")
+    verbose=true
+    ;;
+  "--debug")
+    # shellcheck disable=SC2034
+    verbose=true
+    # shellcheck disable=SC2034
+    debug=true
+    ;;
+  *)
+    printError "Invalid option specified."
+    ;;
+  esac
+  shift
+done
+
+JSON_VULNERABILITIES_URL="https://raw.githubusercontent.com/ZOSOpenTools/meta/vulnerability_json/docs/api/zopen_vulnerability.json"
+
+downloadCVEJSONCache()
+{
+  cachedir="${ZOPEN_ROOTFS}/var/cache/zopen"
+  [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
+  JSON_CVE_CACHE="${cachedir}/zopen_vulnerability.json"
+
+  if ! curlout=$(curlCmd -L --no-progress-meter -o "${JSON_CVE_CACHE}" "${JSON_VULNERABILITIES_URL}"); then
+    printError "Failed to obtain json cache from ${JSON_VULNERABILITIES_URL}; ${curlout}"
+  fi
+  chtag -tc 819 "${JSON_CVE_CACHE}"
+}
+
+downloadCVEJSONCache
+
+if [ ! -f "${JSON_CVE_CACHE}" ]; then
+  printError "Vulnerability json cache file not found."
+  exit 1
+fi
+
+# Store vulnerability counts
+total_vulnerabilities=0
+low_vulnerabilities=0
+moderate_vulnerabilities=0
+high_vulnerabilities=0
+critical_vulnerabilities=0
+
+# Check for CVEs in all installed projects
+installedPackages=$(cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)
+while IFS= read -r repo; do
+  repo="${repo##*/}"
+  pkghome="${ZOPEN_PKGINSTALL}/${repo}/${repo}"
+  if [ ! -e "${pkghome}/.active" ]; then
+    printVerbose "Symlink '${repo}' in '${ZOPEN_PKGINSTALL}' is not active; skipping"
+    continue
+  fi
+  printVerbose "Processing '${repo}'"
+
+  if [ ! -f "${pkghome}/metadata.json" ]; then
+    printVerbose "Skipping: Need the metadata.json to obtain the community's commit sha"
+    continue
+  fi
+
+  commit_sha=$(jq -er .product.community_commitsha "${pkghome}/metadata.json")
+  if [ $? -gt 0 ]; then
+    printVerbose "No community_commitsha in $repo"
+    continue
+  fi
+  # Fetch CVEs using the commit_sha from the vulnerabilities JSON
+  cves=$(jq -er 'if .["'$repo'"] then .["'$repo'"][] | select(.commit_sha == "'$commit_sha'") | .CVEs else empty end' $JSON_CVE_CACHE)
+  # Check if any CVEs are found
+  if [ $? -eq 0 ] && [ -n "${cves}" ]; then
+    printHeader "$(echo "${cves}" | jq -r .severity) severity found for $repo:"
+    echo "${cves}" | jq -r .id
+    echo "${cves}" | jq -r .details
+
+    total_vulnerabilities=$((total_vulnerabilities + $(echo "${cves}" | jq -r '.severity' | wc -l)))
+    low_vulnerabilities=$((moderate_vulnerabilities + $(echo "${cves}" | jq -r '.severity' | grep -c "LOW")))
+    moderate_vulnerabilities=$((moderate_vulnerabilities + $(echo "${cves}" | jq -r '.severity' | grep -c "MED")))
+    high_vulnerabilities=$((high_vulnerabilities + $(echo "${cves}" | jq -r '.severity' | grep -c "HIGH")))
+    critical_vulnerabilities=$((critical_vulnerabilities + $(echo "${cves}" | jq -r '.severity' | grep -c "CRITICAL")))
+  fi
+  break;
+done << EOF
+$(printf "%s\n" "$installedPackages" | xargs | tr ' ' '\n' | sort)
+EOF
+
+# Print summary
+echo ""
+printHeader "CVE Summary:"
+echo "${total_vulnerabilities} vulnerabilities (${low_vulnerabilities} low, ${moderate_vulnerabilities} moderate, ${high_vulnerabilities} high, ${critical_vulnerabilities} critical)"


### PR DESCRIPTION
Adding the `zopen audit` command. This tool leverages the zopen audit vulnerability database covered in https://github.com/ZOSOpenTools/meta/pull/704

Example output:
```
HIGH severity found for gitdummy:
CVE-2019-1387
An issue was found in Git before v2.24.1, v2.23.1, v2.22.2, v2.21.1, v2.20.2, v2.19.3, v2.18.2, v2.17.3, v2.16.6, v2.15.4, and v2.14.6. Recursive clones are currently affected by a vulnerability that is caused by too-lax validation of submodule names, allowing very targeted attacks via remote code execution in recursive clones.

Summary:
1 vulnerabilities (0 low, 0 moderate, 1 high, 0 critical)
```