### PR TITLE
Set GIT UTF8 CCSID to 819 for zopen builds

### DIFF
--- a/cicd/build.groovy
+++ b/cicd/build.groovy
@@ -17,6 +17,9 @@ export NO_COLOR=1
 # Tell zopen that we're a CI/CD bot
 export ZOPEN_IS_BOT=1 
 
+# Use 819 as the ccsid for UTF8 files
+export GIT_UTF8_CCSID=819
+
 # source Jenkins environment variables on zot
 . /jenkins/.env
 

--- a/docs/Guides/Porting.md
+++ b/docs/Guides/Porting.md
@@ -53,6 +53,7 @@ Begin first by cloning the https://github.com/ZOSOpenTools/meta repo.  This repo
 
 ```bash
 # Clone the required repositories (using Git from https://github.com/ZOSOpenTools/gitport)
+export GIT_UTF8_CCSID=819 # set the UTF8 ccsid to 819
 git clone git@github.com:ZOSOpenTools/meta.git && cd meta
 ```
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -428,6 +428,7 @@ defineEnvironment()
   export _TAG_REDIR_ERR=txt
   export _TAG_REDIR_IN=txt
   export _TAG_REDIR_OUT=txt
+  export GIT_UTF8_CCSID=819
 
   # Required for proper operation of xlclang
   export _CC_CCMODE=1


### PR DESCRIPTION
Related to the new change https://github.com/ZOSOpenTools/gitport/pull/108

If we do not set the UTF8 CCSID to 819, then we will encounter issues as such:
```
./configure: eval:  3:  17:
                            h
                             X
                              k
                               h&
                                 K
```

or:
```
/bin/sh install-sh -c -d objects
install-sh 1: FSUM7332 syntax error: got (, expecting Newline
```

This is because we set AUTOCVT=ON which means for ebcdic programs and ccsid 1208 (utf8), auto-conversion will not be triggered