### PR TITLE
Improved installer

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -79,17 +79,9 @@ version=false
 
 for arg in $*; do
   case "${arg}" in
-    "alt"|"build"|"clean"|"generate"|"init"|"install"|\
-    "query"|"remove"|"update-cacert")
+    "alt"|"build"|"clean"|"generate"|"init"|"install"|"list"|\
+    "query"|"remove"|"update-cacert"|"upgrade")
       subcmd="zopen-${arg}"
-      ;;
-    "list")
-      subcmd='zopen-query'
-      subopts="${subopts} --list"
-      ;;
-    "upgrade")
-      subcmd='zopen-install'
-      subopts="${subopts} -u"
       ;;
     "--version")
       version=true

--- a/bin/zopen-alt
+++ b/bin/zopen-alt
@@ -55,7 +55,7 @@ mergeNewVersion()
 {
   package="$1"
   newver="$2"
-  oldver="$2"
+  processActionScripts "txn-pre"
   [ -z "${package}" ] && printError "Internal error; no packagename provided to merge."
   [ -d "${ZOPEN_PKGINSTALL}/${package}/${newver}" ] || printError "Version '${newver}' was not available to set as current"
   if [ -e "${ZOPEN_PKGINSTALL}/${package}/${package}" ]; then
@@ -85,6 +85,7 @@ mergeNewVersion()
     version=$(cat "${ZOPEN_PKGINSTALL}/${package}/${package}/.releaseinfo")
   fi
   syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE}" "ALT" "setAlt" "Set '${package}' to version:${version};"
+  processActionScripts "txn-post"
 }
 
 setAlt()
@@ -228,7 +229,9 @@ while [ $# -gt 0 ]; do
     verbose=true
     ;;
   "--debug")
+    # shellcheck disable=SC2034
     verbose=true
+    # shellcheck disable=SC2034
     debug=true
     ;;
   *)

--- a/bin/zopen-clean
+++ b/bin/zopen-clean
@@ -15,6 +15,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
+  # shellcheck disable=SC1091
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -116,6 +117,7 @@ cleanDangling()
     rm -f "${sl}"
   done
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail
+  waitforpid ${ph}  # Make sure it's finished writing to screen
   syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_FILE}" "CLEAN" "cleanDangling" "zopen system at '${ZOPEN_ROOTFS}' scanned for dangling symlinks"
 }
 
@@ -210,7 +212,7 @@ done
 ${dangling} && cleanDangling && exit
 ${meta} && cleanMetadata
 
-getReposFromGithub
+getRepos
 if $all; then
   printVerbose "Generating complete list of all packages"
   # shellcheck disable=SC2154

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -395,7 +395,7 @@ generateJsonConfiguration()
     fi
   fi
 
-  cat <<zz > "${jsonConfigWorking}"
+  cat <<EOF > "${jsonConfigWorking}"
   {
     "release_line": "${releaseLine}",
     "num_rm_procs": ${RM_FILEPROCS},
@@ -403,7 +403,6 @@ generateJsonConfiguration()
     "autocacheclean": 1
   }
 EOF
-  fi
   jq '.' "${jsonConfigWorking}" > "${jsonConfig}"
   echo 1 > "${rootfs}/etc/zopen/autocacheclean"
 }

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -4,9 +4,11 @@
 ME=$(basename "$0")
 
 if [ -z "${utildir}" ]; then
+  # shellcheck disable=SC2155
   export utildir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 fi
 
+# shellcheck disable=SC2034
 ZOPEN_DONT_PROCESS_CONFIG=1
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.
@@ -20,13 +22,14 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
 checkWritable
 
 printHelp(){
-cat << HELPDOC
+  cat << HELPDOC
 zopen init is a utility for z/OS Open Tools to generate a zopen
 environment, bootstrapping initial tools and creating a configuration
 file
@@ -40,20 +43,6 @@ Options:
 
   --[no]enable-stats
           Toggle enabling collection of usage statistics
-
-  -f, --fs-layout <LAYOUT>
-          The filesystem structure to use for installed
-          packages on disk; packages will be installed to
-          this location under <zopen rootfs>.
-
-          <LAYOUT> should be one of:
-
-            usrlclz: /usr/local/zopen (default),
-            zopen: /usr/zopen,
-            prod: legacy zopen standard location,
-            ibm: /usr/lpp,
-            fhs: File Hierarchical Standard (/opt),
-            usrlcl: usr/local
 
   -h, -?, --help
           display this help and exit
@@ -85,24 +74,19 @@ Examples:
           interactively bootstrap a zopen environment
 
   zopen init --releaseline-dev
-          interactively bootstrap a zopen environment that
-          will use Development Releaseline packages
-
-  zopen --yes --append-to-profile --fs-layout fhs /zopen
-          non-interactively create a zopen environment at
-          location '/zopen' on disk, with packages installed
-          to '/zopen/opt'. The user's .profile will be
-          updated to source the configuration file at
-          '/zopen/etc/zopen-config' when new terminal
-          sessions start
+          interactively bootstrap a zopen environment that will use 
+          Development Releaseline packages
+  zopen --yes --append-to-profile /zopen
+          non-interactively create a zopen environment at location 
+          '/zopen' on disk, with packages installed to 
+          '/usr/local/zopen'. The user's .profile will be updated to 
+          source the configuration file at '/zopen/etc/zopen-config' 
+          when new terminal sessions start
 
 Report bugs at https://github.com/ZOSOpenTools/meta/issues
 
 HELPDOC
 }
-
-
-args=$*
 
 
 # Constants
@@ -121,15 +105,10 @@ reinitExisting=false
 appendToProfile=false
 releaselineDev=false
 refresh=false
-fslayout="usrlclz"
 isCollectingStats=false
 isBot=false # used by jenkins, CI/CD
 while [ $# -gt 0 ]; do
   case "$1" in
-    "-f" | "--fs-layout" )
-      fslayout="$2"
-      shift
-      ;;
     "--re-init" )
       reinitExisting=true
       ;;
@@ -154,6 +133,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     "-v" | "--verbose")
+      # shellcheck disable=SC2034
       verbose=true
       ;;
     "--version")
@@ -161,6 +141,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     "--debug")
+      # shellcheck disable=SC2034
       debug=true
       ;;
     "--yes" | "-y")
@@ -270,23 +251,12 @@ init()
     printHeader "Initializing zopen framework"
   fi
 
-  printDebug "Validating input parameters"
-  case "${fslayout}" in
-    "usrlclz") zopen_pkginstall="usr/local/zopen"    ;;
-    "usrlcl")  zopen_pkginstall="usr/local"    ;;
-    "fhs")     zopen_pkginstall="opt"    ;;
-    "ibm")     zopen_pkginstall="usr/lpp"    ;;
-    "prod")    zopen_pkginstall="prod"    ;;
-    "zopen")   zopen_pkginstall="usr/zopen"    ;;
-    *) printError "${NC}${RED}The filesystem layout ${fslayout} is unrecognised" ;;
-  esac
-
   determineRootFileSystem
   determineStatsCollection
 
   if ! ${refresh} && ! ${reinitExisting}; then
     printInfo "- Binaries will be symlinked under \"${rootfs}/usr/local/bin\". Libraries will be symlinked under \"${rootfs}/usr/lib\""
-    printInfo "- Packages will be installed and maintained under the directory structure ${fslayout} (${rootfs}/${zopen_pkginstall}). To change, re-run with the -f <layout> option."
+    printInfo "- Packages will be installed and maintained under the directory '${rootfs}/${zopen_pkginstall}'."
     printInfo "- Collecting usage statistics: $isCollectingStats"
   fi
 
@@ -354,13 +324,34 @@ generateFileSystem()
   printVerbose "- Creating symbolic path for prod redirect files"
   [ -e "${rootfs}/usr/share/zopen/boot" ] || ln -s "${rootfs}/boot" "${rootfs}/usr/share/zopen/boot"
   [ -e "${rootfs}/etc/zopen" ] || mkdir -p "${rootfs}/etc/zopen"
-  echo "${zopen_pkginstall}" > "${rootfs}/etc/zopen/fstype"
-
+  
+  printVerbose "- Creating product installation location"
+  zopen_pkginstall="usr/local/zopen"
   [ -e "${rootfs}/${zopen_pkginstall}" ] || mkdir -p "${rootfs}/${zopen_pkginstall}"
   [ -e "${rootfs}/usr/share/zopen/prod" ] || ln -s "${rootfs}/${zopen_pkginstall}" "${rootfs}/usr/share/zopen/prod"
 
+  printVerbose "- Creating repository directory"
+  repodir="${rootfs}/etc/zopen/repos.d"
+  [ -e "${repodir}" ] || mkdir -p "${repodir}"
+
+  printVerbose "- Creating action scriptlet directories"
+  piaDir="${rootfs}/etc/zopen/scriptlets/preInstall"
+  [ -e "${piaDir}" ] || mkdir -p "${piaDir}"
+  piaDir="${rootfs}/etc/zopen/scriptlets/postInstall"
+  [ -e "${piaDir}" ] || mkdir -p "${piaDir}"
+  praDir="${rootfs}/etc/zopen/scriptlets/preRemove"
+  [ -e "${praDir}" ] || mkdir -p "${praDir}"
+  praDir="${rootfs}/etc/zopen/scriptlets/postRemove"
+  [ -e "${praDir}" ] || mkdir -p "${praDir}"
+  ptaDir="${rootfs}/etc/zopen/scriptlets/preTransaction"
+  [ -e "${ptaDir}" ] || mkdir -p "${ptaDir}"
+  ptaDir="${rootfs}/etc/zopen/scriptlets/postTransaction"
+  [ -e "${ptaDir}" ] || mkdir -p "${ptaDir}"
+
+  printVerbose "- Setting global root envvar"
+  ZOPEN_PKGINSTALL="${rootfs}/${zopen_pkginstall}"
   if [ "${ZOPEN_PKGINSTALL}" = "${rootfs}" ]; then
-    printError "Package install location is the zopen root location; this is not allowed. Exiting".
+    printError "Package install location is the zopen root location; this is not supported. Exiting".
   fi
   printVerbose "- Creating path for certificate lookups: ${rootfs}/${ZOPEN_CA_DIR}"
   [ -e "${rootfs}/${ZOPEN_CA_DIR}" ] || mkdir -p "${rootfs}/${ZOPEN_CA_DIR}"
@@ -390,11 +381,11 @@ generateJsonConfiguration()
   jsonConfigWorking="${jsonConfig}.working"
 
   if [ -e "${jsonConfig}" ]; then
-    releaseLine=$(jq -r '.release_line' $jsonConfig)
-    RM_FILEPROCS=$(jq -r '.num_rm_procs' $jsonConfig)
+    releaseLine=$(jq -r '.release_line' "${jsonConfig}")
+    RM_FILEPROCS=$(jq -r '.num_rm_procs' "${jsonConfig}")
   fi
 
-  if [ -z "$releaseLine" ]; then
+  if [ -z "${releaseLine}" ]; then
     if ${releaselineDev}; then
       releaseLine="DEV"
       printInfo "- Configured zopen to use development (DEV) releaseline packages where available"
@@ -408,10 +399,87 @@ generateJsonConfiguration()
   {
     "release_line": "${releaseLine}",
     "num_rm_procs": ${RM_FILEPROCS},
-    "is_collecting_stats": ${isCollectingStats}
+    "is_collecting_stats": ${isCollectingStats},
+    "autocacheclean": 1
   }
-zz
-  jq '.' $jsonConfigWorking > $jsonConfig
+EOF
+  fi
+  jq '.' "${jsonConfigWorking}" > "${jsonConfig}"
+  echo 1 > "${rootfs}/etc/zopen/autocacheclean"
+}
+
+generateDefaultRepository()
+{
+  # Check for existing repository definition - if present, use.
+  [ -e "${rootfs}/etc/zopen/repos.d/active" ] && return 0
+
+  # If there is no repository definition, generate a default to point to Github
+  [ ! -e "${rootfs}/etc/zopen/repos.d" ] && mkdir -p "${rootfs}/etc/zopen/repos.d"
+
+  if [ -z "${paxrepourl}" ]; then
+    paxrepourl="http://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_releases.json"
+  fi
+
+  repotype="${paxrepourl%://*}"
+  [ "${repotype}" = "${paxrepourl}" ] && printError "Unable to parse repository type from '${paxrepourl}'. Ensure valid format: <http|file>://<path to repo"
+  
+    case "${repotype}" in
+    http|https|file) printDebug "configuring repo type of: '${repotype}'";;
+    *) printError "Unsupported repository type of '${repotype}'"
+  esac
+  
+  repourl="${paxrepourl#*://}"
+  [ "${repourl}" = "${paxrepourl}" ] && printError "Unable to parse repository url from'${paxrepourl}'. Ensure valid format: <http|file>://<path to repo"
+
+  repometafile="${paxrepourl##*/}"
+  [ "${repometafile}" = "${paxrepourl}" ] && printError "Unable to parse repository file from '${paxrepourl}'. Ensure valid format: <http|file>://<path to repo"
+  
+  baserepourl="${repourl%/*}"
+  [ "${baserepourl}" = "${repourl}" ] && printError "Unable to parse repository file from '${paxrepourl}'. Ensure valid format: <http|file>://<path to repo"
+  
+  repoFile="${rootfs}/etc/zopen/repos.d/$(echo "${repourl}" | tr -d "/[:space:]._").json"
+
+  [ -e "${repoFile}" ] && mv "${repoFile}" "${repoFile}.$(date "+%C%m%d%H%M%S")"
+  cat << EOS >  "${repoFile}"
+{ 
+  "type": "${repotype}", 
+  "metadata_baseurl": "${baserepourl}", 
+  "metadata_file": "${repometafile}" 
+}
+EOS
+  (cd "${rootfs}/etc/zopen/repos.d" && ln -s "${repoFile}" "active")
+}
+
+generateDefaultScriptlets()
+{
+  printVerbose "- Generating man-db scriptlet"
+  cat << EOF > "${rootfs}/etc/zopen/scriptlets/postTransaction/man-db"
+#!/bin/false # Expects to be sourced in zopen-* scripts, not run directly!
+# Do not modify this file; changes will be overwritten automatically!
+if ! installed=\$(zopen list --installed | grep "^man-db\$"); then
+  : # No man-db installed
+else
+  echo "- Updating man-db database..."
+  if ! mandb >/dev/null 2>&1; then
+    printWarning "man-db update completed with non-zero return code."
+    printWarning "Re-run 'mandb' manually for additional information."
+  else 
+    echo "- Update of man-db complete."
+  fi
+fi
+EOF
+  printVerbose "- Generating zopen-clean scriptlet"
+  cat << EOF > "${rootfs}/etc/zopen/scriptlets/postTransaction/zopen-clean"
+#!/bin/false # Expects to be sourced in zopen-* scripts, not run directly!
+# Do not modify this file; changes will be overwritten automatically!
+[ -e "\${ZOPEN_ROOTFS}/etc/zopen/autocacheclean" ] || exit 0
+isactive=\$(cat "\${ZOPEN_ROOTFS}/etc/zopen/autocacheclean")
+if [ "\${isactive}" -eq 1 ]; then
+  echo "- Cleaning install cache..."
+  (zopen clean --cache >/dev/null 2>&1)
+  echo "- Cache cleaned."
+fi
+EOF
 }
 
 generateAnalyticsConfiguration()
@@ -502,7 +570,7 @@ installPrereqs()
   cd "${curwd}"  || printError "Could not change to ${curwd}. Re-run 'zopen init' to retry"
 
   printInfo "- Sourcing environment"
-
+  # shellcheck disable=SC1090
   . "${configFile}"
 
   printHeader "Updating CA Certificate"
@@ -520,6 +588,7 @@ updateBootstrappedTools() {
   toolInstall=$(runAndLog "${MYDIR}/zopen-install -y curl jq meta")
   toolInstall=$?
   [ ${toolInstall} -ne 0 ] && printError "Unable to install curl, jq and/or meta; see previous errors and retry the initilisation using the '--re-init' parameter"
+  # shellcheck disable=SC1090
   . "${configFile}"
 }
 
@@ -598,6 +667,9 @@ generateFileSystem
 generateZopenConfig
 ! ${refresh} && installPrereqs
 generateJsonConfiguration
+generateDefaultRepository
 generateAnalyticsConfiguration
+generateDefaultScriptlets
+[ -e "${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json" ] || updatePackageDB
 ! ${refresh} && updateBootstrappedTools
 deinit

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -480,6 +480,15 @@ if [ "\${isactive}" -eq 1 ]; then
   echo "- Cache cleaned."
 fi
 EOF
+  printVerbose "- Generating caveats scriptlet"
+  cat << EOF > "${rootfs}/etc/zopen/scriptlets/postTransaction/list_caveats"
+#!/bin/false # Expects to be sourced in zopen-* scripts, not run directly!
+# Do not modify this file; changes will be overwritten automatically!
+caveats_file="\${ZOPEN_ROOTFS}/var/cache/install_caveats.tmp"
+[ -e "\${caveats_file}" ] || exit 0
+cat "\${caveats_file}"
+rm "\${caveats_file}"
+EOF
 }
 
 generateAnalyticsConfiguration()

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -185,6 +185,7 @@ for installRepo in ${potentials}; do
   [ -e "${installRepo}" ] && fileinstall=true && break
 done
 
+mutexReq "zopen" "zopen"
 if ${downloadOnly}; then
   downloadDir="${PWD}"
   printDebug "Downloading pax to current directory '${downloadDir}'"
@@ -248,5 +249,5 @@ else
   processRepoInstallFile
 
 fi
-
+mutexFree "zopen"
 exit

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -6,706 +6,247 @@
 #
 # All zopen-* scripts MUST start with this code to maintain consistency.
 #
-# set -x
 setupMyself()
 {
-  ME=$(basename $0)
+  ME=$(basename "$0")
   MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
   INCDIR="${MYDIR}/../include"
   if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
 checkWritable
 
-printSyntax()
-{
-  args=$*
-cat << HELPDOC
-${ME} is a utility to download/install a z/OS Open Tools package.
+printHelp(){
+  cat << HELPDOC
+zopen install is a utility for z/OS Open Tools to install and update
+packages
 
-Usage: ${ME} [OPION] [PACKAGE]
-  [PACKAGE] is a package to install. Multiple packages can be specified.
+Usage: zopen install [OPTION] [PARAMETERS] [PACKAGES]
 
 Options:
-  --all                    download/install all z/OS Open Tools packages.
-  --cache-only             do not install dependencies.
-  --download-only          download package to current directory.
-  --help                   print this help.
-  --install-or-upgrade     installs the package if not installed,
-                           or upgrades the package if installed.
-  --local-install          download and unpackage to current directory.
-  --no-deps                do not install dependencies.
-  --no-set-active          do not change the pinned version.
-  --nosymlink              do not integrate into filesystem through
-                           symlink redirection.
-  -r, --reinstall          reinstall already installed z/OS Open Tools packages.
-  --release-line [stable, dev] the release line to build off of.
-  --select                 select a version to install.
-  --skip-upgrade           do not upgrade.
-  -u, --update, --upgrade  updates installed z/OS Open Tools packages.
-  -v, --verbose            print verbose messages.
-  --version                print version.
-  -y, --yes                automatically answer yes to prompts.
+  -u, --upgrade     check for package updates and apply
+      --reinstall   reinstall currently installed package(s)
+  -y, --yes         automatically answer yes to prompts
+      --select      select a version to install from available versions
+      --release-line [stable|dev]
+                    the release line to install from
+      --no-deps     do not install dependencies
+      --install-or-upgrade
+                    installs the package if not installed, or upgrades
+                    the package if installed (deprecated as default behaviour)
+      --nosymlink   do not integrate into filesystem through symlink 
+                    redirection
+      --no-set-active
+                    do not change the currently active version
+      --download-only
+                    download installable package with no install
+      --all         download all available packages and install
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+
+Examples:
+  zopen install foo 
+                    install package foo if not already installed
+  zopen install --release-line DEV foo
+                    install package foo from the DEV releaseline if
+                    available
+  zopen upgrade     upgrade all packages to latest version on their
+                    releaseline
+  zopen install -y foo bar --no-deps
+                    install packages foo and bar without asking for
+                    user confirmation and without installing any
+                    dependencies
+  zopen install /tmp/foo-1.2.3-4.zos.pax.Z
+                    install package foo from the specified location
+  zopen install /tmp/foo-1.2.3-4.zos.pax.Z bar-1.2.3.4.zos.pax.Z
+                    install packages foo and bar from the specified 
+                    locations
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
 
 HELPDOC
 }
 
-installDependencies()
-(
-  name=$1
-  printVerbose "List of dependencies to install: ${dependencies}"
-  skipupgrade_lcl=${skipupgrade}
-  skipupgrade=true
-  echo "${dependencies}" | xargs | tr ' ' '\n' | sort | while read dep; do
-    printVerbose "Removing '${dep}' from dependency queue '${dependencies}'"
-    dependencies=$(echo "${dependencies}" | sed -e "s/${dep}//" | tr -s ' ')
-    handlePackageInstall "${dep}" true
-  done
-  skipupgrade=${skipupgrade_lcl}
-)
-
-handlePackageInstall()
-{
-
-  fullname="$1"
-  isRuntimeDependency=$2
-  if [ -z "$isRuntimeDependency" ]; then
-    isRuntimeDependency=false
-  fi
-  printVerbose "Name to install: ${fullname}, parsing any version ('=') or tag ('%') has been specified"
-  name=$(echo "${fullname}" | sed -e 's#[=%].*##')
-  repo="${name}"
-  versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
-  tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
-  printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
-  printInfo "Processing package: ${name}"
-
-  nameSansPort=$(echo "${name}" | sed -e 's#\(.*\)port$#\1#')
-  # findutilsport -> findutils
-  # findutils -> findutils
-  if [[ "${nameSansPort}" != "${name}" ]] ; then
-    printError "Please install using base project name without port suffix.\nTry: zopen install ${nameSansPort}"
-  fi
-
-  getAllReleasesFromGithub "${repo}"
-
-  if ${localInstall}; then
-    printVerbose "Local install to current directory"
-    rootInstallDir="${PWD}"
-  else
-    printVerbose "Setting install root to: ${ZOPEN_PKGINSTALL}"
-    rootInstallDir="${ZOPEN_PKGINSTALL}"
-  fi
-
-  originalFileVersion=""
-  printVerbose "Checking for meta files in '${rootInstallDir}/${name}/${name}'"
-  printVerbose "Finding version/release information."
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseinfo" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.releaseinfo")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
-  elif [ -e "${rootInstallDir}/${name}/${name}/.version" ]; then
-    originalFileVersion=$(cat "${rootInstallDir}/${name}/${name}/.version")
-    printVerbose "Found originalFileVersion=${originalFileVersion} (port is already installed)."
-  else
-    printVerbose "Could not detect existing installation at ${rootInstallDir}/${name}/${name}"
-  fi
-
-  printVerbose "Finding releaseline information."
-  installedReleaseLine=""
-  if [ -e "${rootInstallDir}/${name}/${name}/.releaseline" ]; then
-    installedReleaseLine=$(cat "${rootInstallDir}/${name}/${name}/.releaseline")
-    printVerbose "Installed product from releaseline: ${installedReleaseLine}"
-  else
-    printVerbose "No current releaseline for package."
-  fi
-
-  releaseMetadata=""
-  downloadURL=""
-  # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
-  # either for a previous package install or system default
-  if [ -n "${versioned}" ]; then
-    printVerbose "Specific version ${versioned} requested - checking existence and URL."
-    requestedMajor=$(echo "${versioned}" | awk -F'.' '{print $1}')
-    requestedMinor=$(echo "${versioned}" | awk -F'.' '{print $2}')
-    requestedPatch=$(echo "${versioned}" | awk -F'.' '{print $3}')
-    requestedSubrelease=$(echo "${versioned}" | awk -F'.' '{print $4}')
-    requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
-    printVerbose "Finding URL for latest release matching version prefix: requestedVersion: ${requestedVersion}"
-    releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.assets[].name | test("'${requestedVersion}'")))[0]')
-  elif [ -n "${tagged}" ]; then
-    printVerbose "Explicit tagged version '${tagged}' specified. Checking for match."
-    releaseMetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '.[] | select(.tag_name == "'${tagged}'")')
-    printVerbose "Use quick check for asset to check for existence of metadata for specific messages."
-    asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
-    if [ $? -ne 0 ]; then
-      printError "Could not find release tagged '${tagged}' in repo '${repo}'"
-    fi
-  elif ${selectVersion}; then
-    # Explicitly allow the user to select a release to install; useful if there are broken installs
-    # as a known good release can be found, selected and pinned!
-    printVerbose "List individual releases and allow selection."
-    i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
-    printInfo "Versions available for install:"
-    /bin/printf "%s" "${releases}" | jq -e -r 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) - size: \(.value.assets[0].expanded_size | tonumber/ (1024 * 1024))mb")[]'
-
-    printVerbose "Getting user selection."
-    valid=false
-    while ! ${valid}; do
-      echo "Enter version to install (0-${i}): "
-      read selection < /dev/tty
-      if [[ ! -z $(echo "${selection}" | sed -e 's/[0-9]*//') ]]; then
-        echo "Invalid input, must be a number between 0 and ${i}."
-      elif [ "${selection}" -ge 0 ] && [ "${selection}" -le "${i}" ]; then
-        valid=true
-      fi
-    done
-    printVerbose "Selecting item ${selection} from array"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[${selection}]")"
-
-  elif [ ! -z "${releaseLine}" ]; then
-    printVerbose "Install from release line '${releaseLine}' specified"
-    validatedReleaseLine=$(validateReleaseLine "${releaseLine}")
-    if [ -z "${validatedReleaseLine}" ]; then
-      printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE."
-    fi
-    printVerbose "Finding latest asset on the release line"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${releaseLine}'")))[0]')"
-    printVerbose "Use quick check for asset to check for existence of metadata."
-    asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-    if [ $? -ne 0 ]; then
-      printError "Could not find release-line ${releaseLine} for repo: ${repo}."
-    fi
-
-  else
-    printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline."
-    if [ -n "${installedReleaseLine}" ]; then
-      printVerbose "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline."
-      validatedReleaseLine="${installedReleaseLine}" # Already validated when stored
-    else
-      printVerbose "Checking for system-configured releaseline."
-      sysrelline=$(getReleaseLine)
-      printVerbose "Validating value: ${sysrelline}"
-      validatedReleaseLine=$(validateReleaseLine "${sysrelline}")
-      if [ -n "${validatedReleaseLine}" ]; then
-        printVerbose "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline."
-      else
-        printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages."
-        printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message."
-        printWarning "Valid values are: DEV | STABLE."
-        validatedReleaseLine="STABLE"
-      fi
-    fi
-    # We have some situations that could arise
-    # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
-    # 2. system is configured for STABLE but only has DEV stream available
-    # 3. system is configured for DEV but only has DEV stream available
-    # 4. the port being installed has got full releaseline tagging
-    # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
-    # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
-    # then that specific releaseline will be used
-    printVerbose "Finding any releases tagged with ${validatedReleaseLine} and getting the first (newest/latest)"
-    releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${validatedReleaseLine}'")))[0]')"
-    printVerbose "Use quick check for asset to check for existence of metadata"
-    asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-    if [ $? -eq 0 ]; then
-      # Case 4...
-      printVerbose "Found a specific '${validatedReleaseLine}' release-line tagged version; installing..."
-    else
-      # Case 2 & 3
-      printVerbose "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline."
-      alt=$(echo "${validatedReleaseLine}" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
-      releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${alt}'")))[0]')"
-      printVerbose "Use quick check for asset to check for existence of metadata"
-      asset="$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')"
-      if [ $? -eq 0 ]; then
-        printVerbose "Found a release on the '${alt}' release line so release tagging is active."
-        if [ "DEV" = "${validatedReleaseLine}" ]; then
-          # The system will be configured to use DEV packages where available but if none, use latest
-          printInfo "No specific DEV releaseline package, using latest available"
-          releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
-        else
-          printVerbose "The system is configured to only use STABLE releaseline packages but there are none."
-          printInfo "No release available on the '${validatedReleaseLine}' releaseline."
-        fi
-      else
-        # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
-        printVerbose "Installing latest release"
-        releaseMetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
-      fi
-    fi
-  fi
-
-  printVerbose "Getting specific asset details from metadata: ${releaseMetadata}"
-  if [ -z "${asset}" ] || [ "null" = "${asset}" ]; then
-    printVerbose "Asset not found during previous logic; setting now."
-    asset=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r '.assets[0]')
-  fi
-  if [ -z "${asset}" ]; then
-    printError "Unable to determine download asset for ${name}"
-  fi
-
-  tagname=$(/bin/printf "%s" "${releaseMetadata}" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
-  installedReleaseLine=$(validateReleaseLine "${tagname}")
-
-  downloadURL=$(/bin/printf "%s" "${asset}" | jq -e -r '.url')
-  metadataJSONURL="$(dirname "${downloadURL}")/metadata.json"
-  size=$(/bin/printf "%s" "${asset}" | jq -e -r '.expanded_size')
-
-  if [ -z "${downloadURL}" ]; then
-    printError "Unable to determine download location for ${name}"
-  fi
-  downloadFile=$(basename "${downloadURL}")
-  metadataFile="${downloadFile}.json" # use the same basename as the pax + .json to avoid collision
-  downloadFileVer=$(echo "${downloadFile}" | sed -E 's/.*-(.*)\.zos\.pax\.Z/\1/')
-  printVerbose "Downloading port from URL: ${downloadURL} to file: ${downloadFile} (ver=${downloadFileVer})"
-
-  if ${downloadOnly}; then
-    printVerbose "Skipping installation, downloading only."
-  else
-    printVerbose "Install=${downloadFileVer};Original=${originalFileVersion};${upgradeInstalled};${installOrUpgrade};${reinstall}"
-    if [ "${downloadFileVer}" = "${originalFileVersion}" ]; then
-      if ! ${reinstall}; then
-        printInfo "${NC}${GREEN}Package ${name} is already installed at the requested version: ${downloadFileVer} and due to the absence of the 'reinstall' flag, will not be reinstalled.${NC}"
-        return
-      fi
-      printInfo "- Reinstalling version '${downloadFileVer}' of ${name}..."
-    fi
-
-    printVerbose "Checking if package is not installed but scheduled for upgrade."
-    if [ -z "${originalFileVersion}" ]; then
-      printVerbose "No previous version found."
-      if ${installOrUpgrade}; then
-        printVerbose "Package ${name} was not installed, so installing instead of upgrading."
-      elif ${upgradeInstalled}; then
-        printError "Package ${name} can not be upgraded as it is not installed."
-        continue
-      fi
-      unInstallOldVersion=false
-      printInfo "- Installing ${name}..."
-    elif ${skipupgrade}; then
-      printInfo "Package ${name} has a newer release '${downloadFileVer}' but was not specified for an upgrade."
-      continue
-    elif ! ${setactive}; then
-      printVerbose "Current version '${originalFileVersion}' will remain active."
-      unInstallOldVersion=false
-    else
-      printVerbose "Previous version '${originalFileVersion}' installed."
-      if [ -e "${rootInstallDir}/${name}/${name}/.pinned" ]; then
-        printWarning "- Version '${originalFileVersion}' has been pinned; upgrade to '${downloadFileVer}' skipped."
-        syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_INSTALL}" "DOWNLOAD" "handlePackageInstall" "Attempt to change pinned package '${name}' skipped."
-        continue
-      else
-        printInfo "- Replacing ${name} version '${originalFileVersion}' with '${downloadFileVer}'"
-        unInstallOldVersion=true
-        currentversiondir=$(cd "${rootInstallDir}/${name}/${name}" && pwd -P)
-        currentlinkfile="${currentversiondir}/.links"
-      fi
-    fi
-  fi
-
-  printVerbose "Ensuring we are in the correct working download location '${downloadDir}'"
-  cd "${downloadDir}" || exit
-  if [ ! -n "${downloadOnly}" ] || [ ! -n "${localInstall}" ]; then
-    printVerbose "Checking current directory for already downloaded package [file name comparison]."
-    location="current directory"
-  else
-    printVerbose "Checking cache for already downloaded package [file name comparison]."
-    location="zopen package cache"
-  fi
-
-  # Download the metadata json file
-  if ! runAndLog "curlCmd -L '${metadataJSONURL}' -o '${metadataFile}' ${redirectToDevNull}"; then
-    printError "Could not download from ${metadataJSONURL}. Correct any errors and potentially retry."
-    continue
-  fi
-
-  pax=${downloadFile}
-  if [ -f "${pax}" ]; then
-    printInfo "- Found existing file '${pax}' in ${location}"
-  else
-    printInfo "- Downloading ${pax} file from remote to ${location}..."
-    if ! ${verbose}; then
-      redirectToDevNull="2>/dev/null"
-    fi
-
-    progressHandler "network" "- Download complete." &
-    ph=$!
-    killph="kill -HUP ${ph}"
-    addCleanupTrapCmd "${killph}"
-
-    if ! runAndLog "curlCmd -L '${downloadURL}' -O ${redirectToDevNull}"; then
-      printError "Could not download from ${downloadURL}. Correct any errors and potentially retry."
-      continue
-    fi
-    ${killph} 2> /dev/null # if the timer is not running, the kill will fail
-    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_NETWORK},${CAT_PACKAGE},${CAT_FILE}" "DOWNLOAD" "handlePackageInstall" "Downloaded remote file '${pax}'"
-  fi
-  if [ ! -f "${pax}" ]; then
-    printError "${pax} was not found after download!?"
-  fi
-
-  if ${downloadOnly}; then
-    printVerbose "Pax was downloaded to local dir '${downloadDir}'"
-  elif ${cacheOnly}; then
-    printVerbose "Pax was downloaded to zopen cache '${downloadDir}'"
-  else
-    printVerbose "Installing ${pax}"
-    installdirname="${name}/${pax%.pax.Z}" # Use full pax name as default
-
-    printInfo "- Processing ${pax}..."
-    baseinstalldir="."
-    paxredirect=""
-    if ! ${localInstall}; then
-      baseinstalldir="${rootInstallDir}"
-      paxredirect="-s %[^/]*/%${rootInstallDir}/${installdirname}/%"
-      printVerbose "Non-local install, extracting with '${paxredirect}'"
-    else
-      printInfo "- Local install specified."
-      paxredirect="-s %[^/]*/%${installdirname}/%"
-      printVerbose "Non-local install, extracting with '${paxredirect}'"
-    fi
-
-    megabytes=$(echo "scale=2; ${size} / (1024 * 1024)" | bc)
-    printInfo "After this operation, ${megabytes} MB of additional disk space will be used."
-    if ! promptYesOrNo "Do you want to continue?" ${yesToPrompts}; then
-      mutexFree "zopen"
-      printInfo "Exiting..."
-      exit 0
-    fi
-
-    printVerbose "Check for existing directory for version '${installdirname}'"
-    if [ -d "${baseinstalldir}/${installdirname}" ]; then
-      printInfo "- Clearing existing directory and contents"
-      rm -rf "${baseinstalldir}/${installdirname}"
-    fi
-
-    if ! runLogProgress "pax -rf ${pax} -p p ${paxredirect} ${redirectToDevNull}" "Expanding ${pax}" "Expanded"; then
-      printWarning "Errors unpaxing, package directory state unknown."
-      printInfo "Use zopen alt to select previous version."
-      continue
-    fi
-    if ${localInstall}; then
-      rm -f "${pax}"
-    fi
-
-    # Some installation have installation caveats
-    installCaveat=$(jq -r '.product.install_caveats // empty' "${metadataFile}" 2>/dev/null)
-    if [ -n "$installCaveat" ]; then
-      printf "${name}:\n${installCaveat}\n" >> ${caveatsFile}
-    fi
-
-
-    if ${setactive}; then
-      if [ -L "${baseinstalldir}/${name}/${name}" ]; then
-        printVerbose "Removing old symlink '${baseinstalldir}/${name}/${name}'"
-        rm -f "${baseinstalldir}/${name}/${name}"
-      fi
-      if ! ln -s "${baseinstalldir}/${installdirname}" "${baseinstalldir}/${name}/${name}"; then
-        printError "Could not create symbolic link name."
-      fi
-    fi
-
-    printVerbose "Adding version '${downloadFileVer}' to info file."
-    # Add file version information as a .releaseinfo file
-    echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.releaseinfo"
-
-    # Check for a .version file from the pax - if present good, if not
-    # generate one from the file name as the tag isn't granular enough to really
-    # be used in dependency checks
-    if [ ! -f "${baseinstalldir}/${installdirname}/.version" ]; then
-      echo "${downloadFileVer}" > "${baseinstalldir}/${installdirname}/.version"
-    fi
-
-    printVerbose "Adding releaseline '${installedReleaseLine}' metadata to ${baseinstalldir}/${installdirname}/.releaseline"
-    echo "${installedReleaseLine}" > "${baseinstalldir}/${installdirname}/.releaseline"
-
-    if ${setactive}; then
-      if ! ${nosymlink}; then
-        mergeIntoSystem "${name}" "${baseinstalldir}/${installdirname}" "${ZOPEN_ROOTFS}"
-        misrc=$?
-        printVerbose "The merge completed with: ${misrc}"
-      fi
-
-      printInfo "- Checking for env file."
-      if [ -f "${baseinstalldir}/${name}/${name}/.env" ] || [ -f "${baseinstalldir}/${name}/${name}/.appenv" ]; then
-        printInfo "- .env file found, adding to profiled processing."
-        mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
-        cat << EOF > "${ZOPEN_ROOTFS}/etc/profiled/${name}/dotenv"
-curdir=\$(pwd)
-cd "\${ZOPEN_ROOTFS}${ZOPEN_PKGINSTALL##"${ZOPEN_ROOTFS}"}/${name}/${name}" >/dev/null 2>&1
-# If .appenv exists, source it as it's quicker
-if [ -f ".appenv" ]; then
-  . ./.appenv
-elif [ -f ".env" ]; then
-  . ./.env
-fi
-cd \${curdir}  >/dev/null 2>&1
-EOF
-        printInfo "- Sourcing environment to run any setup."
-        cd "${baseinstalldir}/${name}/${name}" && ./setup.sh
-      fi
-    fi
-    if ${unInstallOldVersion}; then
-      printVerbose "New version merged; checking for orphaned files from previous version."
-      # This will remove any old symlinks or dirs that might have changed in an upgrade
-      # as the merge process overwrites existing files to point to different version
-      unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}" "${baseinstalldir}/${name}/${name}/.links"
-    fi
-
-    if ${setactive}; then
-      printVerbose "Marking this version as installed."
-      touch "${baseinstalldir}/${name}/${name}/.active"
-      installedList="${name} ${installedList}"
-      syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
-    fi
-
-    registerInstall "$name" "${downloadFileVer}" "${upgradeInstalled}" ${isRuntimeDependency}
-
-    if ${doNotInstallDeps}; then
-      printInfo "- Skipping dependency installation."
-    elif ${reinstall}; then
-      printVerbose "- Reinstalling so no dependency reinstall (unless explicitly listed)."
-    else
-      printInfo "- Checking for runtime dependencies."
-      printVerbose "Checking for .runtimedeps file."
-      if [ -e "${baseinstalldir}/${name}/${name}/.runtimedeps" ]; then
-        dependencies=$(cat "${baseinstalldir}/${name}/${name}/.runtimedeps")
-      fi
-      printVerbose "Checking for runtime dependencies from the git metadata."
-      if echo "${statusline}" | grep "Runtime Dependencies:" > /dev/null; then
-        gitmetadependencies="$(echo "${statusline}" | sed -e "s#.*Runtime Dependencies:<\/b> ##" -e "s#<br />.*##")"
-        if [ ! "${gitmetadependencies}" = "No dependencies" ]; then
-          dependencies="${dependencies} ${gitmetadependencies}"
-        fi
-      fi
-      dependencies=$(deleteDuplicateEntries "${dependencies}" " ")
-      if [ -n "${dependencies}" ]; then
-        printInfo "- ${name} depends on: ${dependencies}"
-        printInfo "- Installing dependencies."
-        installDependencies "${name}" "${dependencies}"
-      else
-        printInfo "- No runtime dependencies found."
-      fi
-    fi
-    printInfo "${NC}${GREEN}Successfully installed: ${name}${NC}"
-  fi # (download only)
-}
-
-installPorts()
-(
-  ports="$1"
-  printVerbose "Ports to install: ${ports}"
-  mutexReq "zopen" "zopen"
-  caveatsFile=$(mktempfile "caveats")
-  echo "${ports}" | xargs | tr ' ' '\n' | while read port; do
-    handlePackageInstall "${port}"
-  done
-  if [ -s "${caveatsFile}" ]; then
-    printHeader "Installation Caveats"
-    cat "${caveatsFile}"
-  fi
-  rm -f "${caveatsFile}"
-  mutexFree "zopen"
-)
-
 # Main code start here
+# Need to set a number of variables for use in the install function
+# which is common between install & upgrade
 args=$*
-upgradeInstalled=false
 verbose=false
 debug=false
+xdebug=false
 selectVersion=false
+# shellcheck disable=SC2034
 setActive=true
-cacheOnly=false
 downloadOnly=false
-localInstall=false
 reinstall=false
 installOrUpgrade=false
 nosymlink=false
-skipupgrade=false
 doNotInstallDeps=false
 all=false
 yesToPrompts=false
 chosenRepos=""
+fileinstall=false
+
 while [ $# -gt 0 ]; do
   case "$1" in
-  "-u" | "--update" | "--upgrade")
-    upgradeInstalled=true # Upgrade packages
-    ;;
-  "-r" | "-reinstall" | "--reinstall")
-    reinstall=true # If package already installed, reinstall
-    ;;
-  "--install-or-upgrade")
-    installOrUpgrade=true # Upgrade package or install if not present
-    ;;
-  "--local-install")
-    localInstall=true # Install the package into current directory
-    ;;
-  "--no-symlink")
-    nosymlink=true # Do not mesh the package into the file system; leave as stand-alone
-    ;;
-  "--no-deps")
-    doNotInstallDeps=true
-    ;;
-  "--cache-only")
-    cacheOnly=true # Download remote pax file to cache only (no install)
-    ;;
-  "--release-line")
-    shift
-    releaseLine=$(echo "$1" | awk '{print toupper($0)}')
-    ;;
-  "--yes" | "-y")
-    yesToPrompts=true # Automatically answer 'yes' to any questions
-    ;;
-  "--download-only")
-    downloadOnly=true # Download remote pax file to current directory only
-    ;;
-  "--no-set-active")
-    setactive=false # Install package as normal but keep existing installation as active
-    ;;
-  "--skip-upgrade")
-    skipupgrade=true # Do not upgrade any packages
-    ;;
-  "--all")
-    all=true # Install all packages
-    ;;
-  "--select")
-    selectVersion=true # Display a selction table to allow version picking
-    ;;
-  "-h" | "--help" | "-?" )
-    printSyntax "${args}"
-    exit 0
-    ;;
-  "--debug")
-    verbose=true
-    debug=true
-    ;;
-  "-v" | "--verbose")
-    verbose=true
+    "-r" | "-reinstall" | "--reinstall")
+      # shellcheck disable=SC2034
+      reinstall=true  # If package already installed, reinstall
+      ;;
+      "--install-or-upgrade")
+      # shellcheck disable=SC2034
+      installOrUpgrade=true  # Upgrade package or install if not present
+      ;;
+    "--no-symlink")
+      # shellcheck disable=SC2034
+      nosymlink=true  # Do not mesh the package into the file system; leave as stand-alone
+      ;;
+    "--no-deps")
+      doNotInstallDeps=true
+      ;;
+    "--release-line")
+      shift
+      # shellcheck disable=SC2034
+      releaseLine=$(echo "$1" | awk '{print toupper($0)}')
+      ;;
+    "--yes" | "-y")
+      # shellcheck disable=SC2034
+      yesToPrompts=true  # Automatically answer 'yes' to any questions
+      ;;
+    "--download-only")
+      downloadOnly=true  # Download remote package files to current directory only
+      ;;
+    "--no-set-active")
+      # shellcheck disable=SC2034
+      setactive=false  # Install package as normal but keep existing installation as active
+      ;;
+    "--all")
+      all=true  # Install all packages
+      ;;
+    "--select")
+      # shellcheck disable=SC2034
+      selectVersion=true  # Display a selction table to allow version picking
+      ;;
+    "-h" | "--help" | "-?")
+      printHelp "${args}"
+      exit 0
+      ;;
+    "--debug")
+      verbose=true
+      # shellcheck disable=SC2034
+      debug=true
+      ;;
+    "-v" | "--verbose")
+      # shellcheck disable=SC2034
+      verbose=true
+      ;;
+    "--xdebug")
+      xdebug=true
     ;;
   "--version")
-    zopen-version ${ME}
+    zopen-version "${ME}"
     exit 0
     ;;
+  -*) printError "Unsupported parameter '$1'";;
   *)
-    chosenRepos="${chosenRepos} $1"
+    # Generate a long @@ separated string to allow for embedded
+    # spaces in hardcoded pax filenames
+    chosenRepos="${chosenRepos}@@$1"
     ;;
   esac
   shift
 done
 
-if [ -z "${chosenRepos}" ]; then
-  if ! ${all} && ! ${upgradeInstalled}; then
-    printInfo "No ports selected for installation."
-    exit 4
-  fi
-  if ${upgradeInstalled}; then
-    printVerbose "No specific port to upgrade, upgrade all installed packages."
-    printInfo "- Querying for installed packages."
-    progressHandler "spinner" "- Query complete." &
-    ph=$!
-    killph="kill -HUP ${ph}"
-    addCleanupTrapCmd "${killph}"
-    chosenRepos="$(${MYDIR}/zopen-query --list --installed --no-header --no-version 2>&1)"
-    zqrc=$?
-    ${killph} 2> /dev/null # if the timer is not running, the kill will fail
-    sleep 1 # give the above process time to clear
-    if [ ${zqrc} -ne 0 ]; then
-      printError "Query for installed packages unexpectedly failed; zopen-query returned message: '${chosenRepos}'"
-    fi
-  fi
+${xdebug} && set -x && printVerbose "Enabled command execution trace" 
+
+if ! ${all} && [ -z "${chosenRepos}" ]; then
+  printInfo "No packages selected for installation."
+  exit 4
 fi
 
 checkIfConfigLoaded
 
-export SSL_CERT_FILE="${ZOPEN_CA}"
-export GIT_SSL_CAINFO="${ZOPEN_CA}"
-export CURL_CA_BUNDLE="${ZOPEN_CA}"
+#export SSL_CERT_FILE="${ZOPEN_CA}"
+#export GIT_SSL_CAINFO="${ZOPEN_CA}"
+#export CURL_CA_BUNDLE="${ZOPEN_CA}"
+
+# If any of the parameters passed in point to an existing file, then
+# the user is attempting to install a port directly from the file system
+# rather than a repo
+printDebug "Checking input parameters for actual files"
+potentials=$(echo "${chosenRepos}" | sed 's/@@/ /g')
+for installRepo in ${potentials}; do
+  [ -e "${installRepo}" ] && fileinstall=true && break
+done
 
 if ${downloadOnly}; then
   downloadDir="${PWD}"
-  printVerbose "Downloading pax to current directory '${downloadDir}'"
-elif ${localInstall}; then
-  downloadDir="${PWD}"
-  printVerbose "Installing to current directory '${downloadDir}'"
+  printDebug "Downloading pax to current directory '${downloadDir}'"
 else
-  printVerbose "Installing to zopen file system: ${ZOPEN_ROOTFS}"
+  printDebug "Installing to zopen file system: ${ZOPEN_ROOTFS}"
   if [ -z "${ZOPEN_ROOTFS}" ]; then
-    printError "Unable to locate zopen file system, \$ZOPEN_ROOTFS is undefined."
+    printError "Unable to locate zopen file system, \${ZOPEN_ROOTFS} is undefined. Re-source zopen-config and retry command."
   fi
   downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
 fi
 
 if [ ! -d "${downloadDir}" ]; then
-  mkdir -p "${downloadDir}"
-  if [ $? -gt 0 ]; then
-    printError "Could not create download directory: ${downloadDir}"
+  if ! mkdir -p "${downloadDir}"; then
+    printError "Could not create download directory: ${downloadDir}. Check permissions and retry command."
   fi
 fi
 
-if [ -n "${downloadDir}" ] && [ -d "${downloadDir}" ]; then
-  cd "${downloadDir}" || exit
+printDebug "Checking if installing from pax files: ${fileinstall}"
+if ! ${fileinstall}; then
+  printVerbose "Querying metadata for latest package information"
+  getRepos
+  grfgRc=$?
+  [ 0 -ne ${grfgRc} ] && exit ${grfgRc};
 fi
 
-printVerbose "Working directory: ${downloadDir}"
-# Parse passed in repositories and check if valid zopen framework repos
-printInfo "- Querying repo for latest package information."
-getReposFromGithub
-grfgRc=$?
-${killph} 2> /dev/null # if the timer is not running, the kill will fail
-[ 0 -ne "${grfgRc}" ] && exit "${grfgRc}"
-
-foundPort=false
-installArray=""
-
-if ${all}; then
-  if ! ${yesToPrompts}; then
-    # Sum up the pax size + expanded size of the latest releases of each port
-    spaceRequiredBytes=$(jq '.release_data | to_entries | map(select(.value | length > 0)) | map(.value[0].assets[0]) | reduce .[] as $item ({}; . + {($item.name): (($item.size | tonumber)  + ($item.expanded_size | tonumber))}) | [.[]] | add'  ${JSON_CACHE})
-    echo "Space: $spaceRequiredBytes"
-    spaceRequiredMB=$(echo "scale=0; ${spaceRequiredBytes} / (1024 * 1024)" | bc)
-    availableSpaceMB=$(/bin/df -m ${ZOPEN_ROOTFS} | sed "1d" | awk '{ print $3 }' | awk -F'/' '{ print $1 }')
-
-    printInfo "You have chosen to install all tools. An estimated ${spaceRequiredMB} MB of additional disk space will be used."
-    if [ $availableSpaceMB -lt $spaceRequiredMB ]; then
-      printWarning "Your zopen file-system ($ZOPEN_ROOTFS) only has ${availableSpaceMB} MB of available space."
-    fi
-    printInfo "Enter 'all' to confirm full installation. (This can take a VERY long time!):"
-    confirmall=$(getInput)
-    if [ ! "xall" = "x${confirmall}" ]; then
-      printError "Cancelling full installation."
-    fi
-  fi
-  for repo in $(echo ${repo_results}); do
-    installArray="${installArray} ${repo}"
-  done
-  installArray=$(strtrim "${installArray}")
+if ${fileinstall}; then
+  printDebug "Installing from files as listed in arguments: '${chosenRepos}'"
+  # generate the install list JSON from the @@-delimited inputs
+  installList=$(echo "${chosenRepos}" \
+    | jq --raw-input --arg d "$(pwd -P)" \
+    'def make_object($url): {asset:{url: ( "file://" + $d + "/" + $url  )}}; . | split("@@") | map(select(.!="")|make_object(.)) | {"installqueue" :.} ')
 else
-  chosenRepos=$(strtrim "${chosenRepos}")
-  invalidlist=""
-  for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' ' | tr -s ' '); do
-    printVerbose "Processing repo: ${chosenRepo}"
-    printVerbose "Stripping any version (%), tag (#) or port suffixes"
-    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##')
-    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}')
-    if [ "${toolfound}" = "${toolrepo}" ]; then
-      printVerbose "Adding '${chosenRepo}' to the install queue."
-      installArray="${installArray} ${chosenRepo}"
-      printVerbose "Removing valid port from input list."
-      chosenRepos=$(echo "${chosenRepos}" | sed -e "s#^${chosenRepo}\$##")
-    else
-      invalidlist=$(printf "%s %s" "${invalidlist}" "${chosenRepo}")
-    fi
-  done
+  if ${all}; then
+    # shellcheck disable=SC2034
+    doNotInstallDeps=true
+    installList=$(jq --raw-output '.release_data| keys[]' "${JSON_CACHE}") 
+    installListCount=$(jq --raw-output '.release_data| keys | length' "${JSON_CACHE}") 
+    printInfo "- Installing all currently-uninstalled packages"
+    printInfo "- Checking installation status for '${installListCount}' packages"
+  else
+    installList=$(echo "$chosenRepos" | sed "s/@@/ /g")
+    validateInstallList "${installList}"
+  fi
+  printInfo "- Generating install graph"
+  progressHandler "spinner" &
+  gigph=$!
+  killph="kill -HUP ${gigph}"
+  addCleanupTrapCmd "${killph}"
+  generateInstallGraph "${installList}"
+  ${killph} 2>/dev/null # if the timer is not running, the kill will fail
+  waitforpid ${gigph}  # Make sure it's finished writing to screen
 fi
 
-printVerbose "Checking whether any invalid ports were specified."
-if [ -n "${invalidlist}" ]; then
-  printSoftError "The following requested port(s) do not exist:\n\t$(echo "${invalidlist}" | tr -s '[:space:]')"
-  printError "Check port name(s), remove any port suffixes and retry command."
+if [ 0 -eq "$(echo "${installList}" | jq --raw-output '.installqueue| length')" ]; then
+  printInfo "- No packages for install"
+else
+  if ${verbose}; then 
+    printInfo " - The following package(s) will be installed:"
+    echo "${installList}" | jq --raw-output '.installqueue | sort| .[] | .portname '
+  fi
+  processRepoInstallFile
+
 fi
 
-installPorts "${installArray}"
+exit

--- a/bin/zopen-list
+++ b/bin/zopen-list
@@ -1,0 +1,311 @@
+#!/bin/sh
+#
+# List utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+
+#
+# All zopen-* scripts MUST start with this code to maintain consistency.
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source." >&2
+    exit 8
+  fi
+  # shellcheck source=/dev/null
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+
+printHelp(){
+  cat << HELPDOC
+zopen list -  list information about local packages
+
+Usage: zopen list [OPTION] [VERB] [PACKAGE]
+
+Options:
+  --available     lists all available z/OS Open Tools
+  --details       provide version information on packages
+  --full          provides more information about packages
+  --installed     list only installed z/OS Open Tools
+  --[no]header    output explanation header for columns
+  --verbose       run in verbose mode
+  --version       print version
+  --version-info  lists version information for installed packages when
+                  combined with the --installed option              
+  -h,-?, --help     display this help and exit
+
+Examples:
+  zopen list --installed
+                    list packages installed on the system
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
+}
+text_center()
+{
+  if [ $# -lt 2 ]; then
+    echo "$1"
+    return
+  fi
+  echo "$1" | awk -v strlen="$2" \
+    '{spc = strlen - length;padding = int(spc / 2);pad = spc - padding;printf "%*s%s%*s\n", pad, "", $0, padding, ""}'
+}
+
+text_padrightr() {
+  padchar="${3:- }" # Default to space char
+  echo "" | awk -v str="$1" -v n="$2" -v pc="$padchar"  \
+      'function padr(n,acc, c){
+          if (++acc>=n) return c;
+          return c padr(n, acc, c);
+        }
+        BEGIN{ print str padr(n,0,pc);}
+      '
+}
+
+
+listLatestForInstalled()
+{
+  wpackage=20
+  wversion=12
+  wrelease=14
+  wtag=36
+  # wurl=11 Note required unless additional columns added
+  if ${header}; then
+    printf "${NC}${UNDERLINE}%-${wpackage}s%-${winstalled}s%-${wtag}s%-${wdownload}s%-${wexpsz}s%-${wqual}s${NC}\n" \
+        "$(text_center "Package")" "$(text_center "Version")" "$(text_center "Release")"\
+        "$(text_center "Tag Name")" "$(text_center "Download URL")" 
+  fi
+  pdb="${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json"
+  installed=$(zopen list --installed | awk -v ORS=',' '{print "\""$0"\""}')
+  installed="[${installed%,}]" # wrap in a JSON array and strip any trailing ',' char
+  jq --raw-output --argjson installed "${installed}" \
+    "$(jqfunctions) .release_data| 
+    to_entries |sort_by(.key) | .[] | 
+    .key as \$key | 
+    select( \$installed | index(\$key)) |
+    .value[0].assets[0] as \$va | 
+    \$va.url as \$url | 
+    (\$url | match(\".*-([^-]*).([0-9]{8}_[0-9]{6}).zos.pax.Z\").captures) as \$caps |
+    \$caps[0].string as \$version |
+    \$caps[1].string as \$release |
+    .value[0].tag_name as \$tn |
+    pr(\$key;\"@\";${wpackage}) +
+     pr(\$version;\"@\"; ${wversion}) +
+     pr(\$release;\"@\"; ${wrelease}) +
+     pr(\$tn;\"@\";${wtag}) +
+     \$url " 
+      "${JSON_CACHE}" | sed 's/@/ /g'
+}
+
+listAvailablePackages()
+{
+  downloadJSONCache
+  wpackage=20
+  wversion=23
+  winstalled=10
+  wtag=36
+  wrellne=12
+  wdownload=10
+  wexpsz=10
+  wqual=7
+  if ${urlinclude}; then
+    wurl=6
+    urltext="URL"
+  else
+    wurl=0
+    urltext=""
+  fi
+  if ${header}; then
+    if ${details} || ${full}; then
+      printf "${NC}${UNDERLINE}%-${wpackage}s%-${winstalled}s%-${wtag}s%-${wdownload}s%-${wexpsz}s%-${wqual}s%-${wurl}s${NC}\n" \
+          "$(text_center "Package")" "$(text_center "Installed")" "$(text_center "Latest Tag")"\
+          "$(text_center "Download size")" "$(text_center "Disk usage")" "$(text_center "Quality")" \
+          "$(text_center "${urltext}")"
+
+    else
+      printf "${NC}${UNDERLINE}%-${wpackage}s%-${winstalled}s%-${wversion}s%-${wtag}s${NC}\n" \
+          "$(text_center "Package")" "$(text_center "Installed")" "$(text_center "Version")" "$(text_center "Latest Tag")"
+    fi  
+  fi
+  installed=$(zopen list --installed | awk -v ORS=',' '{print "\""$0"\""}')
+  installed="[${installed%,}]" # wrap in a JSON array and strip any trailing ',' char
+
+  if ${details} || ${full}; then
+    if ${urlinclude}; then
+      urltext='$url'
+    else
+      urltext=""
+    fi
+    jq --raw-output --argjson installed "${installed}" \
+        "$(jqfunctions) .release_data| 
+        to_entries |sort_by(.key) | .[] |
+        .key as \$key | 
+        .value[0].assets[0] as \$va |
+        \$va.url as \$url |
+        (\$url | match(\".*-([^-]*).[0-9]{8}_[0-9]{6}.zos.pax.Z\").captures[0].string) as \$version |
+        .value[0].tag_name as \$tn |
+        (if (\$installed | index(\$key)) then \"true\" else \"false\" end) as \$ins |
+        \$va.expanded_size as \$es |
+        \$va.size as \$ds |
+        (\$va.passed_tests | if (.==\"\") then \"0\" else . end | tonumber) as \$pt |
+        (\$va.total_tests | if (.==\"\") then \"99999\" else . end |tonumber) as \$tt |
+        ((\$pt/\$tt*100|r(2))|tostring + \"%\") as \$q |
+        pr(\$key;\"@\";${wpackage}) + 
+         c(\$ins;\"@\";${winstalled}) +
+         c(\$tn;\"@\";${wtag}) + 
+         c(\$ds;\"@\";${wdownload}) + 
+         c(\$es;\"@\";${wexpsz}) + 
+         c((\$q);\"@\";${wqual}) +
+         ${urltext} " \
+        "${JSON_CACHE}" | sed 's/@/ /g'
+  else
+    jq --raw-output  --argjson installed "${installed}" \
+        "$(jqfunctions) .release_data|
+        to_entries |sort_by(.key) | .[] |
+        .key as \$key |
+        .value[0].assets[0].url as \$url |
+        (\$url | match(\".*-([^-]*).[0-9]{8}_[0-9]{6}.zos.pax.Z\").captures[0].string) as \$version |
+        .value[0].tag_name as \$tn |
+        (if (\$installed | index(\$key)) then \"true\" else \"false\" end) as \$ins |
+        .value[0].assets[0] as \$va |
+        pr(\$key;\"@\";${wpackage}) +
+         c(\$ins;\"@\";${winstalled}) +
+          c(\$version;\"@\";${wversion}) +
+           c(\$tn;\"@\";${wtag}) " \
+        "${JSON_CACHE}" | sed 's/@/ /g'
+  fi    
+}
+
+listInstalledEntries()
+{
+  wpackage=20
+  wversion=26
+  wrelease=14
+  wrellne=12
+  wexpsz=12
+  wqual=8
+  if ${urlinclude}; then
+    wurl=6
+    urltext="URL"
+  else
+    wurl=0
+    urltext=""
+  fi
+  if ${header} && ${details}; then
+    if ${full}; then
+      printf "${NC}${UNDERLINE}%-${wpackage}s%-${wversion}s%-${wrelease}s%-${wrellne}s%-${wexpsz}s%-${wqual}s%-${wurl}s${NC}\n" \
+          "$(text_center "Package")" "$(text_center "Version")" "$(text_center "Release")" \
+          "$(text_center "Releaseline")" "$(text_center "Disk usage")" \
+          "$(text_center "Quality")" "$(text_center "${urltext}")"
+    else
+      printf "${NC}${UNDERLINE}%-${wpackage}s%-${wversion}s%-${wrelease}s${NC}\n" \
+          "$(text_center "Package")" "$(text_center "Version")" "$(text_center "Release")"
+    fi  
+  fi
+  pdb="${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json"
+  if ! [ -e "${pdb}" ]; then
+    printWarning "No package database found. Regenerating (subsequent calls will be faster)"
+    updatePackageDB
+  fi
+  if ${details}; then
+    if ${full}; then
+      jq --raw-output \
+        "$(jqfunctions) .[] |
+          keys[] as \$key |
+          .[\$key].product.test_status as \$ts |
+          pr(\$key;\"@\";${wpackage}) +
+           c((.[\$key].product?.version? // \"unknown\");\"@\";${wversion}) +
+           c((.[\$key].product?.release? // \"unknown\");\"@\";${wrelease}) +
+           c((.[\$key].product.buildline? // \"unknown\");\"@\";${wrellne}) +
+           c((.[\$key].product.size? // \"unknown\");\"@\";${wexpsz}) +
+           c(((if (\$ts? and (\$ts.total_tests | tonumber?) and (\$ts.total_success | tonumber?)) then (\$ts.total_success | tonumber) / (\$ts.total_tests | tonumber) else 0 end | .*100)| r(2) |tostring);\"@\";${wqual})" \
+        "${pdb}" | sed 's/@/ /g'
+    else
+      jq --raw-output \
+          "$(jqfunctions) .[] |
+          keys[] as \$key |
+          pr(\$key;\"@\";${wpackage}) +
+           c(.[\$key].product.version;\"@\";${wversion}) +
+           c(.[\$key].product.release;\"@\";${wrelease})" \
+          "${pdb}" | sed 's/@/ /g'
+    fi
+  else
+    jq --raw-output \
+        '[.[] | keys[] as $key | $key] | unique[] ' \
+        "${pdb}"
+  fi  
+}
+
+# Main code start here
+# Note that functions use padding chars of '@' to work round a quirk of jq in that
+# it will collapse repeated spaces into tab characters - which proves irksome when tryinh
+# to pad/format column layouts; '@' chars get post-processed into spaces
+
+verbose=false
+header=false
+details=false
+full=false
+installed=false
+urlinclude=false  # whether to include download url in output information
+versioninfo=false
+
+if [ $# -eq 0 ]; then
+  printError "No option provided"
+fi
+
+while [ $# -gt 0 ]; do
+  printVerbose "Parsing option: $1"
+  case "$1" in
+  "--available") available=true ;;
+  "--installed") installed=true ;;
+  "--details") details=true ;;
+  "--full") full=true; details=true ;;
+  "--header") header=true ;;
+  "--noheader") header=false ;;
+  "--url") urlinclude=true ;;
+  "--version-info") versioninfo=true ;;
+  "-h" | "--help" | "-?")
+    printHelp
+    exit 0
+    ;;
+  "--version")
+    zopen-version "${ME}"
+    exit 0
+    ;;
+  "--verbose")
+    # shellcheck disable=SC2034
+    verbose=true
+    ;;
+  "--xdebug")
+    set -x
+    ;;
+  -*)
+    printError "Unknown option '$1'"
+    ;;
+  *)
+    chosenRepos="${chosenRepos} $1"
+    ;;
+  esac
+  shift
+done
+
+checkIfConfigLoaded
+if ${installed}; then
+  if ${versioninfo}; then
+    listInstalledVerInfo
+  else
+    listInstalledEntries
+  fi
+  exit 0
+fi
+if ${available}; then
+  listAvailablePackages
+  exit 0
+fi
+
+

--- a/bin/zopen-promote
+++ b/bin/zopen-promote
@@ -282,6 +282,7 @@ while read OUTMSG; do
 done < "${FIFO_PIPE_STDOUT}"
 [ -n "${FIFO_PIPE_STDOUT}" ] && [ -e "${FIFO_PIPE_STDOUT}" ] && rm -f "${FIFO_PIPE_STDOUT}"
 ${killph} 2>/dev/null  # if the timer is not running, the kill will fail
+waitforpid ${ph}  # Make sure it's finished writing to screen
 
 printVerbose "Grabbing pkginstall location from within promoted env"
 if [ -e "${promotefs}/etc/zopen/fstype" ]; then
@@ -311,6 +312,7 @@ if ! ${keepzopentooling}; then
     flecnt=$(expr ${flecnt} + 1)
   done
   ${killph} 2>/dev/null  # if the timer is not running, the kill will fail
+  waitforpid ${ph}  # Make sure it's finished writing to screen
   syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_ZOPEN}" "PROMOTE" "mainline" "meta tooling checked for and removed from promoted environment; ${flecnt} link(s) removed"
 fi
 

--- a/bin/zopen-query
+++ b/bin/zopen-query
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh 
 #
 # Query utility for z/OS Open Tools - https://github.com/ZOSOpenTools
 #
@@ -15,6 +15,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
+  # shellcheck source=/dev/null
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -23,38 +24,42 @@ filter_implemented=false
 upgradeable_implemented=false
 whatprovides_implemented=false
 
-printSyntax()
-{
-  args=$*
-  echo "${ME} -  a utility for z/OS Open Tools to query packages and repos."
-  echo ""
-  echo "Usage: ${ME} [OPTION] [VERB] [PACKAGE]"
-  echo "  VERB is the action to take, which is one of"
-  echo "    --list, --remote-search, --installed"
-  echo "  PACKAGE is a package, specified for --remote-search"
-  echo ""
-  echo "Verbs:"
-  echo "  -i, --installed  list installed z/OS Open Tools."
-  echo "  --list           list all available z/OS Open Tools."
-  echo "  --remote-search  regex match package against available z/OS Open Tools"
+printHelp(){
+  cat << HELPDOC
+zopen query -  a utility for z/OS Open Tools to query packages and repos.
+
+Usage: zopen query [OPTION] [VERB] [PACKAGE]
+
+Options:
+  -d, --details     include full details for listings
+  -i, --installed   list only installed z/OS Open Tools
+      --list        list all available z/OS Open Tools
+      --no-header   suppress the header for the output
+      --no-version  suppress version information, return package names
+      --remote-search
+                    regex match package against available packages
+      --verbose     run in verbose mode
+      --version     print version
+  -h,-?, --help     display this help and exit
+HELPDOC
+if ${filter_implemented}; then
+  echo "  --filter COLOR   apply COLOR (quality) filter."
+  echo "                   green: all pass, blue: most pass, yellow: some pass, red: no pass, gray: skipped"
+fi
 if ${upgradeable_implemented}; then
   echo "  --upgradeable    list packages where an upgrade is available."
 fi
 if ${whatprovides_implemented}; then
   echo "  -wp, --whatprovides  which installed package provided a file."
 fi
-  echo ""
-  echo "Options:"
-  echo "  -d, --details    include full details for listings."
-if ${filter_implemented}; then
-  echo "  --filter COLOR   apply COLOR (quality) filter."
-  echo "                   green: all pass, blue: most pass, yellow: some pass, red: no pass, gray: skipped"
-fi
-  echo "  --help           print this help"
-  echo "  --no-header,     suppress the header for the output."
-  echo "  --no-version,    suppress version information, return package names."
-  echo "  -v               run in verbose mode."
-  echo "  --version        print version"
+  cat << HELPDOC
+Examples:
+  zopen query
+                    queries
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
 }
 
 colorizepct()
@@ -306,6 +311,7 @@ noheader=false
 noversion=false
 localoption=true
 upgradeable=false
+list=false
 details=0
 needle=
 if [ $# -eq 0 ]; then
@@ -316,13 +322,13 @@ while [ $# -gt 0 ]; do
   printVerbose "Parsing option: $1"
   case "$1" in
   "--list")
-    list=1
+    list=true
     localoption=false
     ;;
   "-i" | "--installed")
     localoption=true
     installed=1
-    list=
+    list=true
     ;;
   "-wp" | "--whatprovides")
     localoption=true
@@ -355,17 +361,20 @@ while [ $# -gt 0 ]; do
   "-d" | "--details")
     details=1
     ;;
-  "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
-    printSyntax "${args}"
+  "-h" | "--help" | "-?")
+    printHelp
     exit 0
     ;;
   "--version")
     zopen-version "${ME}"
     exit 0
     ;;
-  "-v" | "--v" | "-verbose" | "--verbose")
+  "--verbose")
     # shellcheck disable=SC2034
     verbose=true
+    ;;
+  "--xdebug")
+    set -x
     ;;
   -*)
     printError "Unknown option '$1'"
@@ -396,14 +405,26 @@ fi
 
 if ! ${localoption}; then
   # Retrieve all repositories
-  getReposFromGithub
+  getRepos
   grfgRc=$?
   [ 0 -ne "${grfgRc}" ] && exit "${grfgRc}"
   repoArray="${repo_results}"
 fi
 
-! ${upgradeable} || printDetailListEntries "${details}" "" 1
-[ -z "${remotesearch}" ] || printDetailListEntries "${details}" "${needle}" 0
-[ -z "${list}" ] || printDetailListEntries "${details}" "" 0
-[ -z "${installed}" ] || printInstalledEntries "${details}" "" 0
-[ -z "${whatprovides}" ] || whatProvides "${needle}"
+# Use dedicated zopen-list script for listing system packages, passing
+# appropriate parameters to mimic the old query behaviour
+if ${list}; then
+  if ${installed}; then
+    if [ "${details}" -eq 0 ]; then
+      (zopen list --installed)
+    else
+      (zopen list --installed --details --header)
+    fi
+  else
+    (zopen list )
+  fi
+else
+  ! ${upgradeable} || printDetailListEntries "${details}" "" 1
+  [ -z "${remotesearch}" ] || printDetailListEntries "${details}" "${needle}" 0
+  [ -z "${whatprovides}" ] || whatProvides "${needle}"
+fi

--- a/bin/zopen-remove
+++ b/bin/zopen-remove
@@ -15,6 +15,7 @@ setupMyself()
     echo "Internal Error. Unable to find common.sh file to source." >&2
     exit 8
   fi
+  # shellcheck disable=SC1091
   . "${INCDIR}/common.sh"
 }
 setupMyself
@@ -51,11 +52,15 @@ HELPDOC
 removePackages()
 {
   pkglist=$*
-
+  processActionScripts "txn-pre"
+  # Create a temp file name to trigger the post-transaction action script
+  # triggering - run only if an action was taken (which creates the file)
+  runpostTxnActionScripts=$(mktempfile "txnpost" "run")
   echo "${pkglist}" | xargs | tr ' ' '\n' | sort | while read pkg; do
     printHeader "Removing package: ${pkg}"
+    processActionScripts "remove-pre"
     printInfo "- Checking status of package '${pkg}'"
-    if [ ! -f ${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active ]; then
+    if [ ! -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active" ]; then
       printInfo "${NC}${YELLOW}Package '${pkg}' is not installed${NC}"
     else
       printInfo "- Away to remove '${pkg}',"
@@ -83,27 +88,34 @@ removePackages()
         if ${purge}; then
           printInfo "- Purging package"
           printVerbose "Checking if we are currently in a directory that is to be purged"
-          [ "${PWD##"${ZOPEN_PKGINSTALL}"/"${pkg}"/"${pkg}"}" != "${PWD}" ] && cd ${ZOPEN_PKGINSTALL}
-          rm -rf $(cd "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" && pwd -P)
-          syslog ${ZOPEN_LOG_PATH}/audit.log ${LOG_A} "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Purging package:'${needle};version:${version};"
+          [ "${PWD##"${ZOPEN_PKGINSTALL}"/"${pkg}"/"${pkg}"}" != "${PWD}" ] && cd "${ZOPEN_PKGINSTALL}"
+          rm -rf "$(cd "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}" && pwd -P)"
+          syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Purging package:'${needle};version:${version};"
           registerRemove "${pkg}" "${version}"
         else
-          printInfo "- Removing metadata file to mark uninstall"
+          printVerbose "- Removing metadata file to mark uninstall"
           rm -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/.active"
-          printInfo "- Breaking link from current to versioned"
+          printVerbose "- Breaking link from current to versioned"
           rm -f "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}"
         fi
         printVerbose "Main symlink removed, removing dangling symlinks"
         unsymlinkFromSystem "${pkg}" "${ZOPEN_ROOTFS}" "${installedlinksfile}"
       fi
 
-      printInfo "- Removing profiled entry"
+      printVerbose "- Removing profiled entry"
       [ -d "${ZOPEN_ROOTFS}/etc/profiled/${pkg}" ] && rm -rf "${ZOPEN_ROOTFS}/etc/profiled/${pkg}"
 
+      removeFromInstallTracker "${pkg}"
+      processActionScripts "remove-post"
       syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_PACKAGE},${CAT_REMOVE}" "REMOVE" "removePackage" "Removed package:'${needle};version:${version};"
+      touch "${runpostTxnActionScripts}"
       printInfo "${NC}${GREEN}Successfully removed: ${pkg}${NC}"
     fi
   done
+  if [ -e "${runpostTxnActionScripts}" ]; then 
+    processActionScripts "txn-post"; 
+    rm "${runpostTxnActionScripts}"  
+  fi
 }
 
 # Main code start here

--- a/bin/zopen-upgrade
+++ b/bin/zopen-upgrade
@@ -103,7 +103,7 @@ ${xdebug} && set -x && printVerbose "Enabled command execution trace"
 if [ -z "${chosenRepos}" ]; then
     printVerbose "No specific port to upgrade, upgrade all installed packages"
     printInfo "- Querying installed packages"
-    progressHandler "mirror" &
+    progressHandler "pkgcheck" &
     ph=$!
     killph="kill -HUP ${ph}"
     addCleanupTrapCmd "${killph}"

--- a/bin/zopen-upgrade
+++ b/bin/zopen-upgrade
@@ -1,0 +1,183 @@
+#!/bin/sh
+# Upgrade utility for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+# All zopen-* scripts MUST start with this code to maintain consistency
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source" >&2
+    exit 8
+  fi
+  # shellcheck disable=SC1091
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+checkWritable
+
+printHelp(){
+  cat << HELPDOC
+zopen upgrade is a utility for z/OS Open Tools to upgrade packages to
+a later release
+
+Usage: zopen upgrade [OPTION] [PARAMETERS] [PACKAGES]
+
+Options:
+  -y, --yes         automatically answer yes to prompts
+  -v, --verbose     run in verbose mode
+  -h,-?, --help     display this help and exit
+
+Examples:
+  zopen upgrade foo 
+                    upgrade package foo if installed
+  zopen upgrade -y  upgrade all packages to latest version on their
+                    releaseline
+
+Report bugs at https://github.com/ZOSOpenTools/meta/issues .
+
+HELPDOC
+}
+
+
+
+# Main code start here
+# Need to set a number of variables for use in the install function
+# which is common between install & upgrade
+args=$*
+verbose=false
+debug=false
+xdebug=false
+# shellcheck disable=SC2034
+selectVersion=false
+# shellcheck disable=SC2034
+setActive=true
+# shellcheck disable=SC2034
+downloadOnly=false
+# shellcheck disable=SC2034
+reinstall=false
+nosymlink=false
+doNotInstallDeps=true
+yesToPrompts=false
+chosenRepos=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    "--yes" | "-y")
+      yesToPrompts=true  # Automatically answer 'yes' to any questions
+      ;;
+    "--no-set-active")
+      setactive=false  # Install package as normal but keep existing installation as active
+      ;;
+    "-h" | "--help" | "-?")
+      printHelp "${args}"
+      exit 0
+      ;;
+     "-v" | "--verbose")
+      verbose=true
+      ;;
+    "--debug")
+      verbose=true
+      debug=true
+      ;;
+    "--xdebug")
+      verbose=true
+      debug=true
+      xdebug=true
+    ;;
+    "--version")
+      zopen-version "${ME}"
+      exit 0
+      ;;
+    -*) printError "Unsupported parameter '$1'" ;;
+    *)
+      chosenRepos=" ${chosenRepos} $1 ";
+      ;;
+  esac
+  shift;
+done
+
+${xdebug} && set -x && printVerbose "Enabled command execution trace" 
+
+if [ -z "${chosenRepos}" ]; then
+    printVerbose "No specific port to upgrade, upgrade all installed packages"
+    printInfo "- Querying installed packages"
+    progressHandler "mirror" &
+    ph=$!
+    killph="kill -HUP ${ph}"
+    addCleanupTrapCmd "${killph}"
+    chosenRepos=$(zopen list --installed)
+    ${killph} 2>/dev/null # if the timer is not running, the kill will fail
+    waitforpid ${ph}  # Make sure it's finished writing to screen
+fi
+
+checkIfConfigLoaded
+
+export SSL_CERT_FILE="${ZOPEN_CA}"
+export GIT_SSL_CAINFO="${ZOPEN_CA}"
+export CURL_CA_BUNDLE="${ZOPEN_CA}"
+
+printDebug "Installing to zopen file system: ${ZOPEN_ROOTFS}"
+if [ -z "${ZOPEN_ROOTFS}" ]; then
+  printError "Unable to locate zopen file system, \${ZOPEN_ROOTFS} is undefined"
+fi
+downloadDir="${ZOPEN_ROOTFS}/var/cache/zopen"
+
+
+if [ ! -d "${downloadDir}" ]; then
+  mkdir -p "${downloadDir}"
+  if [ $? -gt 0 ]; then
+    printError "Could not create download directory: ${downloadDir}"
+  fi
+fi
+
+# Parse passed in repositories and check if valid zopen framework repos
+printVerbose "Querying remote repo for latest package information"
+getRepos
+grfgRc=$?
+[ 0 -ne ${grfgRc} ] && exit ${grfgRc};
+installArray=""
+
+mutexReq "zopen" "zopen"
+printDebug "Parsing list of packages to install and verifying validity"
+
+if [ -z "${chosenRepos}" ]; then
+  badportlist=""
+  for chosenRepo in $(echo "${chosenRepos}" | tr ',' ' '); do
+    printVerbose "Processing repo: ${chosenRepo}"
+    printDebug "Stripping any version (%), tag (#) or port suffixes and trim"
+    toolrepo=$(echo "${chosenRepo}" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="${toolrepo}" '$0 == toolrepo {print}') 
+    if [ "${toolfound}" = "${toolrepo}" ]; then
+      printVerbose "Adding '${chosenRepo}' to the install queue"
+      installArray=$(printf "%s\n%s" "${installArray}" "${chosenRepo}")
+    else
+      badportlist=$(printf "%s %s" "${badportlist}" "${toolrepo}")
+    fi
+  done
+
+  if [ -z "${badportlist}" ]; then
+    printSoftError "The following requested port(s) do not exist:\n\t${badportlist}"
+  fi
+  upgradeList=$(jq --raw-output '.release_data| keys[]' "${JSON_CACHE}")
+  generateInstallGraph "${upgradeList}"
+else
+  validateInstallList "${chosenRepos}"
+  printInfo "- Generating install graph"
+  progressHandler "spinner" &
+  ph=$!
+  killph="kill -HUP ${ph}"
+  addCleanupTrapCmd "${killph}"
+  generateInstallGraph "${chosenRepos}"
+  ${killph} 2>/dev/null # if the timer is not running, the kill will fail
+  waitforpid ${ph}  # Make sure it's finished writing to screen
+fi
+
+if [ 0 -eq "$(echo "${installList}" | jq --raw-output '.installqueue| length')" ]; then
+  printInfo "- No packages to upgrade"
+else
+  processRepoInstallFile
+fi
+
+mutexFree "zopen"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1260,8 +1260,79 @@ promptYesOrNo() {
   return 0
 }
 
+promptYesNoAlways() {
+  message="$1"
+  skip=$2
+  if ! ${skip}; then
+    while true; do
+      printInfo "${message} [y/n/a]"
+      read answer < /dev/tty
+      answer=$(echo "${answer}" | tr '[A-Z]' '[a-z]')
+      case "${answer}" in
+       y|Y) return 0;;
+       n|N) return 1;;
+       a|A) ye
+      esac
 
-. ${INCDIR}/analytics.sh
+      if [ "y" = "${answer}" ] || [ "yes" = "${answer}" ]; then
+        return 0
+      fi
+      if [ "n" = "${answer}" ] || [ "no" = "${answer}" ]; then
+        return 1
+      fi
+
+    done
+  fi
+  return 0
+}
+
+
+parseRepoName()
+{
+  fullname="$1"
+  printDebug "Name to install: ${fullname}, parsing any version ('=') or tag ('%') that has been specified"
+  name=$(echo "${fullname}" | sed -e 's#[=%].*##')
+  repo="${name}"
+  versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
+  tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
+  printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
+}
+
+dedupStringList()
+{ delim="$1" && shift
+  str="$1"
+  echo "${str}"| awk -v delim="${delim}" '                                                                                                      
+    { dlm=""; for (i=1; i<=NF; i++) {if (!seen[$i]++) {printf "%s%s", dlm, $i};dlm=delim};print ""}'
+}
+
+spaceValidate(){
+  spaceRequiredBytes=$1
+  spaceRequiredMB=$(echo "scale=0; ${spaceRequiredBytes} / (1024 * 1024)" | bc)
+  availableSpaceMB=$(/bin/df -m "${ZOPEN_ROOTFS}" | sed "1d" | awk '{ print $3 }' | awk -F'/' '{ print $1 }')
+
+  printInfo "After this operation, ${spaceRequiredMB} MB of additional disk space will be used."
+  if [ "${availableSpaceMB}" -lt "${spaceRequiredMB}" ]; then
+    printWarning "Your zopen file-system (${ZOPEN_ROOTFS}) only has ${availableSpaceMB} MB of available space."
+  fi
+  if ! ${yesToPrompts} || [ "${availableSpaceMB}" -lt "${spaceRequiredMB}" ]; then
+    while true; do
+      printInfo "Do you want to continue? [y/n/a]"
+      read continueInstall < /dev/tty
+      case "${continueInstall}" in
+        "y") break;;
+        "n") mutexFree "zopen"; printInfo "Exiting..."; exit 0 ;;
+        "a") yesToPrompts=true; break;;
+        *) echo "?";;
+      esac
+    done
+  fi
+}
+
+getActivePackageDirs()
+{
+  (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)
+}
+
 
 jqfunctions()
 {
@@ -1279,4 +1350,6 @@ jqfunctions()
   'def r(dp):.*pow(10;dp)|round/pow(10;dp)'
 }
 
+# shellcheck disable=SC1091
+. "${INCDIR}/analytics.sh"
 zopenInitialize

--- a/include/common.sh
+++ b/include/common.sh
@@ -1642,6 +1642,45 @@ spaceValidate(){
   fi
 }
 
+processRepoInstallFile(){
+  printVerbose "Beginning port installation"
+  mutexReq "zopen"
+  
+  processActionScripts "txn-pre"
+  if [ 0 -eq "$(echo "${installList}" | jq --raw-output '.installqueue| length')" ]; then
+    printInfo "- No packages to install"
+    return 0
+  fi
+
+  # shellcheck disable=SC2154
+  if ${fileinstall}; then
+    : 
+  else
+    spaceRequiredBytes=$(echo "${installList}" | jq --raw-output '.installqueue| map(.asset.size, .asset.expanded_size)| reduce .[] as $total (0; .+($total|tonumber))')
+    spaceValidate "${spaceRequiredBytes}"
+  fi
+
+  processActionScripts "txn-pre"
+  for installurl in $(echo "${installList}" | jq --raw-output '.installqueue |map( (.asset.url| sub(" ";"") ))| @sh'); do
+    printVerbose "Analysing :'${installurl}'"
+    installurl=$(echo "${installurl}" | tr -d "' ")
+    getInstallFile "${installurl}"
+    if $downloadOnly; then
+      continue
+    fi
+    installFile="${installurl##*/}"
+    if [ ! "${installFile%.zos.pax.Z}" = "${installFile}" ]; then
+      # Found zos.pax.Z format
+      installFromPax "${installFile}"
+    else
+      printError "Unrecognised install file format"
+    fi
+  done
+  processActionScripts "txn-post"
+  mutexFree "zopen"
+  printVerbose "Port installation complete"
+}
+
 getActivePackageDirs()
 {
   (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)

--- a/include/common.sh
+++ b/include/common.sh
@@ -425,7 +425,7 @@ findrev()
 {
   haystack="$1"
   needle="$2"
-  while [[ "${haystack}" != "" && "${haystack}" != "/" && "${haystack}" != "./" && ! -e "${haystack}/${needle}" ]]; do
+  while [ "${haystack}" != "" ] && [ "${haystack}" != "/" ] && [ "${haystack}" != "./" ] && [ ! -e "${haystack}/${needle}" ]; do
     haystack=${haystack%/*}
   done
   echo "${haystack}"
@@ -480,7 +480,7 @@ mutexReq()
     lockedpid=$(cat ${mutex})
     {
       [ ! "${lockedpid}" = "${mypid}" ] && [ ! "${lockedpid}" = "${PPID}" ]
-    } && kill -0 "${lockedpid}" 2> /dev/null && echo "Aborting, Active process '${lockedpid}' holds the '$2' lock: '${mutex}'" && exit -1
+    } && kill -0 "${lockedpid}" 2> /dev/null && echo "Aborting, Active process '${lockedpid}' holds the '$2' lock: '${mutex}'" && exit 4
   fi
   addCleanupTrapCmd "rm -rf ${mutex}"
   echo "${mypid}" > ${mutex}
@@ -541,7 +541,6 @@ mergeIntoSystem()
   [ -z "${rebaseusr}" ] && rebaseusr="usr/local"
 
   currentDir="${PWD}"
-  targetdir="${rootfs}/${rebaseusr}" # The main rootfs/usr location
 
   printDebug "Calculating the offset path to store from root"
   offset=$(dirname "${versioneddir#"${rootfs}"/}")
@@ -558,7 +557,7 @@ mergeIntoSystem()
   mv "${versioneddir}" "${virtualStore}"
 
   printDebug "Creating main linked directory in store"
-  $(cd "${virtualStore}" && ln -s "${version}" "${name}")
+  cd "${virtualStore}" && ln -s "${version}" "${name}"
 
   printDebug "Creating virtual root directory structure"
   mkdir -p "${processingDir}/${rebaseusr}"
@@ -570,8 +569,7 @@ mergeIntoSystem()
   printDebug "Generating symlink tree"
 
   printDebug "Creating directory structure"
-  curdir="${PWD}"
-  cd "${virtualStore}/${name}" || exit
+  cd "${virtualStore}/${name}" || printError "Unable to change to virtual store at '${virtualStore}/${name}'"
   # since 'ln *' doesn't invoke globbing to allow multiple files at once,
   # abuse the Recurse option; this results in "already exists" errors but
   # ignore them as the first call should generate the correct link but
@@ -580,9 +578,9 @@ mergeIntoSystem()
   zosfind . -type d | sort -r | while read dir; do
     dir=$(echo "${dir}" | zossed "s#^./##")
     printDebug "Processing dir: ${dir}"
-    [ ${dir} = "." ] && continue
+    [ "${dir}" = "." ] && continue
     mkdir -p "${processingDir}/${rebaseusr}/${dir}"
-    cd "${processingDir}/${rebaseusr}/${dir}" || exit
+    cd "${processingDir}/${rebaseusr}/${dir}" || printError "Unable to change to processing directory '${processingDir}/${rebaseusr}/${dir}'"
     dirrelpath=$(relativePath2 "${virtualStore}/${name}/${dir}" "${processingDir}/${rebaseusr}/${dir}")
     ln -Rs "${dirrelpath}/" "." 2> /dev/null
   done
@@ -598,7 +596,7 @@ mergeIntoSystem()
 
   printDebug "Generating intermediary tar file"
   # Need '-S' to allow long symlinks
-  $(cd "${processingDir}" && tar -S -cf "${tarfile}" "usr")
+  cd "${processingDir}" && tar -S -cf "${tarfile}" "usr"
 
   printDebug "Generating listing for remove processing (including main symlink)."
   listing=$(tar tf "${processingDir}/${tarfile}" 2> /dev/null | sort -r)
@@ -611,8 +609,8 @@ mergeIntoSystem()
   printDebug "Cleaning temp resources."
   rm -rf "${processingDir}" 2> /dev/null
 
-  printDebug "Switching to previous cwd - current work dir was purged."
-  cd "${currentDir}" || exit
+  printDebug "Switching to previous cwd - current work dir was purged"
+  cd "${currentDir}" || printError "Unable to change to '${currentDir}'"
 
   printInfo "- Integration complete."
   return 0
@@ -725,20 +723,22 @@ EOF
 printDebug()
 {
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
+  # shellcheck disable=SC2154
   if ${debug}; then
     printColors "${NC}${BLUE}${BOLD}:DEBUG:${NC}: '${1}'" >&2
   fi
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
 printVerbose()
 {
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
+  # shellcheck disable=SC2154
   if ${verbose}; then
     printColors "${NC}${GREEN}${BOLD}VERBOSE${NC}: ${1}" >&2
   fi
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
@@ -746,7 +746,7 @@ printHeader()
 {
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "${NC}${HEADERCOLOR}${BOLD}${UNDERLINE}${1}${NC}" >&2
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
@@ -754,7 +754,7 @@ printAttention()
 {
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "${NC}${MAGENTA}${BOLD}${UNDERLINE}${1}${NC}" >&2
-  [ ! -z "${xtrc}" ] && set -x
+  [ -n "${xtrc}" ] && set -x
   return 0
 }
 
@@ -788,8 +788,8 @@ runLogProgress()
   addCleanupTrapCmd "${killph}"
   eval "$1"
   rc=$?
-  if [ ! -z "${SSH_TTY}" ]; then
-    chtag -r ${SSH_TTY}
+  if [ -n "${SSH_TTY}" ]; then
+    chtag -r "${SSH_TTY}"
   fi
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail
   waitforpid ${ph}  # Make sure it's finished writing to screen
@@ -883,14 +883,14 @@ runInBackgroundWithTimeoutAndLog()
     kill -0 "${PID}" 2> /dev/null
     if [ $? != 0 ]; then
       wait "${PID}"
-      if [ ! -z "${SSH_TTY}" ]; then
-        chtag -r ${SSH_TTY}
+      if [ -n "${SSH_TTY}" ]; then
+        chtag -r "${SSH_TTY}"
       fi
       rc=$?
-      return "${rc}"
+      return ${rc}
     else
       sleep 1
-      n=$(expr ${n} + 1)
+      n=$(( n + 1))
     fi
   done
   kill -9 "${PID}" 2>/dev/null
@@ -920,7 +920,7 @@ printWarning()
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "${NC}${WARNINGCOLOR}${BOLD}***WARNING: ${NC}${YELLOW}${1}${NC}" >&2
   [ -n "${xtrc}" ] && set -x
-  return 0
+  return 0;
 }
 
 printInfo()
@@ -928,7 +928,7 @@ printInfo()
   [ -z "${-%%*x*}" ] && set +x && xtrc="-x" || xtrc=""
   printColors "$1" >&2
   [ -n "${xtrc}" ] && set -x
-  return 0
+  return 0;
 }
 
 # Used to input sensitive data - turns off echo to the screen for the input
@@ -940,14 +940,14 @@ getInputHidden()
   addCleanupTrapCmd "stty echo"
   stty -echo
   read zopen_input
-  echo ${zopen_input}
+  echo "${zopen_input}"
   stty echo
 }
 
 getInput()
 {
   read zopen_input
-  echo ${zopen_input}
+  echo "${zopen_input}"
 }
 
 printElapsedTime()
@@ -955,7 +955,7 @@ printElapsedTime()
   printType=$1
   functionName=$2
   startTime=$3
-  elapsedTime=$((${SECONDS} - ${startTime}))
+  elapsedTime=$((SECONDS - startTime))
 
   elapsedTimeOutput="${functionName} completed in ${elapsedTime} seconds."
 
@@ -975,6 +975,7 @@ processConfig()
   if [ -z "${ZOPEN_ROOTFS}" ]; then
     relativeRootDir="$(cd "$(dirname "$0")/../.." > /dev/null 2>&1 && pwd -P)"
     if [ -f "${relativeRootDir}/etc/zopen-config" ]; then
+      # shellcheck source=/dev/null
       . "${relativeRootDir}/etc/zopen-config"
     else
       printError "Source the zopen-config prior to running $0."
@@ -991,7 +992,7 @@ checkIfConfigLoaded()
     errorMessage="Certificate at ${ZOPEN_CA} could not be accessed. Ensure zopen init has run and zopen-config has been sourced."
   fi
 
-  if [ ! -z "${errorMessage}" ]; then
+  if [ -n "${errorMessage}" ]; then
     if [ -r "${mydir}/../../../etc/zopen-config" ]; then
       relativeConfigDir="$(cd "$(dirname "${mydir}")/../../etc/" > /dev/null 2>&1 && pwd -P)"
       errorMessage="${errorMessage} Run '. ${relativeConfigDir}/zopen-config'  or add it to your .profile."
@@ -1003,28 +1004,28 @@ checkIfConfigLoaded()
 parseDeps()
 {
   dep="$1"
-  version=$(echo ${dep} | awk -F '[>=<]+' '{print $2}')
+  version=$(echo "${dep}" | awk -F '[>=<]+' '{print $2}')
   if [ -z "${version}" ]; then
     operator=""
-    dep=$(echo ${dep} | awk -F '[>=<]+' '{print $1}')
+    dep=$(echo "${dep}" | awk -F '[>=<]+' '{print $1}')
   else
-    operator=$(echo ${dep} | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
-    dep=$(echo ${dep} | awk -F '[>=<]+' '{print $1}')
+    operator=$(echo "${dep}" | awk -F '[0-9.]+' '{print $1}' | awk -F '^[a-zA-Z]+' '{print $2}')
+    dep=$(echo "${dep}" | awk -F '[>=<]+' '{print $1}')
     case ${operator} in
     ">=") ;;
     "=") ;;
     *) printError "${operator} is not supported." ;;
     esac
-    major=$(echo ${version} | awk -F. '{print $1}')
-    minor=$(echo ${version} | awk -F. '{print $2}')
+    major=$(echo "${version}" | awk -F. '{print $1}')
+    minor=$(echo "${version}" | awk -F. '{print $2}')
     if [ -z "${minor}" ]; then
       minor=0
     fi
-    patch=$(echo ${version} | awk -F. '{print $3}')
+    patch=$(echo "${version}" | awk -F. '{print $3}')
     if [ -z "${patch}" ]; then
       patch=0
     fi
-    prerelease=$(echo ${version} | awk -F. '{print $4}')
+    prerelease=$(echo "${version}" | awk -F. '{print $4}')
     if [ -z "${prerelease}" ]; then
       prerelease=0
     fi
@@ -1206,31 +1207,19 @@ checkWritable()
   fi
 }
 
-getReleaseLine()
+generateUUID() 
 {
-  jsonConfig="${ZOPEN_ROOTFS}/etc/zopen/config.json"
-  if [ ! -f "${jsonConfig}" ]; then
-    jq -r '.release_line' $jsonConfig
-  else
-    echo "STABLE"
-  fi
-}
-
-getRMProcs()
-{
-  jsonConfig="${ZOPEN_ROOTFS}/etc/zopen/config.json"
-  if [ ! -f "${jsonConfig}" ]; then
-    jq -r '.num_rm_procs' $jsonConfig
-  else
-    echo "5" # default
-  fi
+  date_part=$(date +%s)
+  random_part=$((RANDOM))
+  uuid="${date_part}-${random_part}"
+  echo "${uuid}"
 }
 
 isURLReachable() {
   url="$1"
   timeout=5
 
-  if curl -s --fail --max-time $timeout "$url" > /dev/null; then
+  if curlCmd -s --fail --max-time $timeout "$url" > /dev/null; then
     return 0
   else
     return 1

--- a/include/common.sh
+++ b/include/common.sh
@@ -1540,6 +1540,76 @@ processActionScripts()
   )
 }
 
+updatePackageDB()
+{
+  printVerbose "Updating the installed package tracker db"
+  if ! pkgdirs=$(getActivePackageDirs); then
+    printError "Unable to update the package db"
+  fi
+
+  pdb="${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json"
+  if [ -e "${pdb}" ]; then
+    backup=$(mktempfile "updatepdb" "bkk")
+    cp "${pdb}" "${backup}"
+    rm "${pdb}"
+  fi
+  pkgdirs=$(getActivePackageDirs)
+  for pkgdir in ${pkgdirs}; do
+    if [ ! -e "${ZOPEN_PKGINSTALL}/${pkgdir}/metadata.json" ]; then
+      printWarning "No metadata.json found in '${ZOPEN_PKGINSTALL}/${pkgdir}'. Bad package install?"
+      continue
+    fi
+    metadata=$(cat "${ZOPEN_PKGINSTALL}/${pkgdir}/metadata.json")
+    if [ ! -e "${pdb}" ]; then
+      echo "[]" > "${pdb}"
+    fi
+
+    mdj=$(echo "${metadata}" | jq '. as $metadata | .product.repo | match(".*/ZOSOpenTools/(.*)port").captures[0].string | [{(.):$metadata}]')
+    if ! jq --argjson mdj "${mdj}" '. += $mdj' \
+            "${pdb}" > \
+            "${pdb}.working"; then
+      printError "Could not add metadata for '${pkg}' to install tracker. Run zopen --re-init to attempt regeneration."
+    fi
+    mv "${pdb}.working" "${pdb}"
+  done
+}
+
+addToInstallTracker()
+{
+  pkg=$1
+  pdb="${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json"
+  if [ ! -e "${pdb}" ]; then
+    # Generate the packageDB
+    printWarning "No package tracker found, regenerating [subsequent runs will be faster]"
+    updatePackageDB
+  fi
+  metadataJson=$(cat "${ZOPEN_PKGINSTALL}/${pkg}/${pkg}/metadata.json")
+  if ! jq --argjson mdj "[{\"${pkg}\":${metadataJson}}]" \
+      "if any(.[]; has(\"${pkg}\")) then . |= map( if has(\"${pkg}\") then \$mdj[] else  . end ) else . + \$mdj end" \
+        "${pdb}" > \
+        "${pdb}.working"; then
+    printError "Could not update metadata for '${pkg}' in package tracker. Run zopen -init -re-init to attempt regeneration."
+  fi
+  mv "${pdb}.working" "${pdb}"
+}
+
+removeFromInstallTracker()
+{
+  pkg=$1
+  pdb="${ZOPEN_ROOTFS}/var/lib/zopen/packageDB.json"
+  if [ ! -e "${pdb}" ]; then
+    # Generate the packageDB
+    printWarning "No package tracker found, regenerating [subsequent runs will be faster]"
+    updatePackageDB
+  fi
+  if ! jq \
+      "map(select(has(\"${pkg}\") | not))" \
+        "${pdb}" > \
+        "${pdb}.working"; then
+    printError "Could not add metadata for '${pkg}' to install tracker. Run zopen --re-init to attempt regeneration."
+  fi
+  mv "${pdb}.working" "${pdb}"
+}
 
 jqfunctions()
 {

--- a/include/common.sh
+++ b/include/common.sh
@@ -1477,6 +1477,19 @@ getPortMetaData(){
   return 0
 }
 
+validateInstallList(){
+  installees="$1"
+  # shellcheck disable=SC2086 # Using set -f disables globbing
+  installees=$(set -f; echo ${installees} |awk  -v ORS=, -v RS=' ' '{$1=$1; sub(/[=%].*/,x); print "\""$1"\""}')
+  invalidPortList=$(jq -r --argjson needles "[${installees%%,}]" \
+    '.release_data| keys as $haystack | $needles | map(select(. as $needle | $haystack | index($needle)|not)) | .[]'  "${JSON_CACHE}")
+  if [ -n "${invalidPortList}" ]; then
+    printSoftError "The following ports could not be installed:"
+    printSoftError "    $(echo "${invalidPortList}" | awk -v OFS=' ' -v ORS=' ' '{$1=$1};1' )"
+    printError "Check port name(s), remove any extra 'port' suffixes and retry command."
+  fi
+}
+
 dedupStringList()
 { delim="$1" && shift
   str="$1"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1118,14 +1118,26 @@ syslog()
   echo "$(date +"%F %T") $(id | cut -d' ' -f1)::${module}:${type}:${categories}:${location}:${msg}" >> "${fd}"
 }
 
+getJSONCacheURL(){
+  activeRepo="${ZOPEN_ROOTFS}/etc/zopen/repos.d/active"
+  [ ! -e "${activeRepo}" ] && printError "Could not access repository configuration at '${activeRepo}'. Check file to ensure valid repository configuration or refresh default configuration with zopen init --refresh -y."
+
+  type=$(jq -r ".type" "${activeRepo}")
+  base=$(jq -r ".metadata_baseurl" "${activeRepo}")
+  filename=$(jq -r ".metadata_file" "${activeRepo}")
+  case "${type}" in
+    http|https) printf "%s://%s/%s" "${type}" "${base}" "${filename}";;
+    file)     printf "%s:%s/%s" "${type}" "${base}" "${filename}";;
+    *)        printError "Unsupported repository type '${type}'.";;
+  esac
+}
+
 downloadJSONCache()
 {
   if [ -z "${JSON_CACHE}" ]; then
-    cachedir="${ZOPEN_ROOTFS}/var/cache/zopen"
-    [ ! -e "${cachedir}" ] && mkdir -p "${cachedir}"
-    JSON_CACHE="${cachedir}/zopen_releases.json"
-    JSON_TIMESTAMP="${cachedir}/zopen_releases.timestamp"
-    JSON_TIMESTAMP_CURRENT="${cachedir}/zopen_releases.timestamp.current"
+    JSON_CACHE="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.json"
+    JSON_TIMESTAMP="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.timestamp"
+    JSON_TIMESTAMP_CURRENT="${ZOPEN_ROOTFS}/var/cache/zopen/zopen_releases.timestamp.current"
 
     # Need to check that we can read & write to the JSON timestamp cache files
     if [ -e "${JSON_TIMESTAMP_CURRENT}" ]; then
@@ -1138,26 +1150,30 @@ downloadJSONCache()
       [ ! -w "${JSON_CACHE}" ] || [ ! -r "${JSON_CACHE}" ] && printError "Cannot access cache at '${JSON_CACHE}'. Check permissions and retry request."
     fi
 
-    if ! curlout=$(curlCmd -L --no-progress-meter -I "${ZOPEN_JSON_CACHE_URL}" -o "${JSON_TIMESTAMP_CURRENT}"); then
-      printError "Failed to obtain json cache timestamp from ${ZOPEN_JSON_CACHE_URL}; ${curlout}"
+    jsonCacheURL=$(getJSONCacheURL)
+    if ! curlCmd -f -L -s -I "${jsonCacheURL}" -o "${JSON_TIMESTAMP_CURRENT}"; then
+      printError "Failed to obtain json cache timestamp from ${jsonCacheURL}."
     fi
     chtag -tc 819 "${JSON_TIMESTAMP_CURRENT}"
 
-    if [ -f "${JSON_CACHE}" ] && [ -f "${JSON_TIMESTAMP}" ] && grep -q 'ETag' "${JSON_TIMESTAMP_CURRENT}" && [ "$(grep 'ETag' "${JSON_TIMESTAMP_CURRENT}")" = "$(grep 'ETag' "${JSON_TIMESTAMP}")" ]; then
+    if [ -f "${JSON_CACHE}" ] \
+       && [ -f "${JSON_TIMESTAMP}" ] \
+       && [ "$(grep 'Last-Modified' "${JSON_TIMESTAMP_CURRENT}")" = "$(grep 'Last-Modified' "${JSON_TIMESTAMP}")" ]; then
+      # Metadata cache unchanged
       return
     fi
 
     printVerbose "Replacing old timestamp with latest."
     mv -f "${JSON_TIMESTAMP_CURRENT}" "${JSON_TIMESTAMP}"
 
-    if ! curlout=$(curlCmd -L --no-progress-meter -o "${JSON_CACHE}" "${ZOPEN_JSON_CACHE_URL}"); then
-      printError "Failed to obtain json cache from ${ZOPEN_JSON_CACHE_URL}; ${curlout}"
+    if ! curlCmd -f -L -s -o "${JSON_CACHE}" "${jsonCacheURL}"; then
+      printError "Failed to obtain json cache from '${jsonCacheURL}'"
     fi
     chtag -tc 819 "${JSON_CACHE}"
   fi
 
   if [ ! -f "${JSON_CACHE}" ]; then
-    printError "Could not download json cache from ${ZOPEN_JSON_CACHE_URL}"
+    printError "Could not download json cache from '${jsonCacheURL}"
   fi
 }
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -310,6 +310,7 @@ defineANSI()
 
   # Color-type codes, needs explicit terminal settings
   if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
+    ANSION=true
     esc="\047"
     BLACK="${esc}[30m"
     RED="${esc}[31m"
@@ -335,15 +336,18 @@ defineANSI()
     fi
   else
     # unset esc RED GREEN YELLOW BOLD UNDERLINE NC
-
+    ANSION=false
     esc=''
+    # shellcheck disable=SC2034
     BLACK=''
     RED=''
     GREEN=''
     YELLOW=''
     BLUE=''
     MAGENTA=''
+    # shellcheck disable=SC2034
     CYAN=''
+    # shellcheck disable=SC2034
     GRAY=''
     BOLD=''
     UNDERLINE=''
@@ -358,19 +362,31 @@ ansiline()
 {
   deltax=$1
   deltay=$2
-  echostr=$3
-  if [ ${deltax} -gt 0 ]; then
-    echostr="${ESC}[${deltax}A${echostr}"
-  elif [ ${deltax} -lt 0 ]; then
-    echostr="${ESC}[$(expr ${deltax} \* -1)A${echostr}"
-  fi
-  if [ ${deltay} -gt 0 ]; then
-    echostr="${ESC}[${deltax}C${echostr}"
-  elif [ ${deltay} -lt 0 ]; then
-    echostr="${ESC}[$(expr ${deltax} \* -1)D${echostr}"
-  fi
-  /bin/echo "${echostr}"
+  echostr="$3"
+  ansimove $1 $2
+  /bin/echo "${echostr}\c"
+}
 
+ansimove()
+{
+  deltax=$1
+  deltay=$2
+  movestr=""
+  if [ -n "${deltax}" ]; then
+    if [ "${deltax}" -gt 0 ]; then
+      movestr="${ESC}[${deltax}C"
+    elif [ "${deltax}" -lt 0 ]; then
+      movestr="${ESC}[$(expr "${deltax}" \* -1)D"
+    fi
+  fi
+  if [ -n "${deltay}" ]; then
+    if [ "${deltay}" -gt 0 ]; then
+      movestr="${movestr}${ESC}[${deltay}B"
+    elif [ "${deltay}" -lt 0 ]; then
+      movestr="${movestr}${ESC}[$(expr "${deltay}" \* -1)A"
+    fi
+  fi
+  /bin/echo "${movestr}\c"
 }
 
 getScreenCols()
@@ -635,6 +651,7 @@ unsymlinkFromSystem()
         fi 
       done
       ${killph} 2>/dev/null # if the timer is not running, the kill will fail
+      waitforpid ${ph}  # Make sure it's finished writing to screen
       sleep 1 # give spinner time to exit if running
     else
       # Slower method needed to analyse each link to see if it has
@@ -653,9 +670,9 @@ unsymlinkFromSystem()
       [ -e "${tempTrash}" ] && rm -f "${tempTrash}" >/dev/null 2>&1
       addCleanupTrapCmd "rm -rf ${tempDirFile}"
       printDebug "Using temporary file ${tempDirFile}"
-      printInfo "- Checking ${nfiles} potential links"
+      printInfo "- Checking ${nfiles} potentially obsolete file links"
       printDebug "Starting spinner..."
-      progressHandler "spinner" "- Complete" &
+      progressHandler "linkcheck" "- Complete" &
       ph=$!
       killph="kill -HUP ${ph}"
       addCleanupTrapCmd "${killph}"
@@ -684,7 +701,7 @@ unsymlinkFromSystem()
 $(zossed '1d;$d' "${dotlinks}")
 EOF
       ${killph} 2>/dev/null # if the timer is not running, the kill will fail
-      sleep 1 # ensure the spinner has stopped if running
+      waitforpid ${ph}  # Make sure it's finished writing to screen
       if [ -e "${tempDirFile}" ]; then
         ndirs=$(uniq < "${tempDirFile}" | wc -l  | tr -d ' ')
         printVerbose "- Checking ${ndirs} dir links"
@@ -767,7 +784,7 @@ runLogProgress()
   fi
   progressHandler "spinner" "- ${completeText}" &
   ph=$!
-  killph="kill -HUP ${ph} 2>/dev/null"
+  killph="kill -HUP ${ph}"
   addCleanupTrapCmd "${killph}"
   eval "$1"
   rc=$?
@@ -775,6 +792,7 @@ runLogProgress()
     chtag -r ${SSH_TTY}
   fi
   ${killph} 2> /dev/null # if the timer is not running, the kill will fail
+  waitforpid ${ph}  # Make sure it's finished writing to screen
   return "${rc}"
 }
 
@@ -794,7 +812,7 @@ progressAnimation()
   [ $# -eq 0 ] && printError "Internal error: no animation strings."
   animcnt=$#
   anim=1
-  ansiline 0 0 "$1"
+#  ansiline 0 0 "$1\n\c"
   while :; do
     spinloop 1000
     # Check for daemonization of this process (ie. orphaned and PPID=1)
@@ -805,34 +823,49 @@ progressAnimation()
     [ "${ppid}" -eq 1 ] && kill INT "${ppid}" >/dev/null 2>&1
     anim=$((anim + 1))
     [ ${anim} -gt ${animcnt} ] && anim=1
-    ansiline 1 -1 $(getNthArrayArg "${anim}" "$@")
+    ansiline -10 0 "$(getNthArrayArg "${anim}" "$@")"
+    ansimove -10 0
   done
 }
 
-getNthArrayArg () {
+getNthArrayArg ()
+{
     shift "$1"
-    echo "$1"
+    echo "$1\c"
+}
+
+waitforpid()
+{
+while kill -0 "$1" >/dev/null 2>&1; do
+  sleep 1
+done
 }
 
 progressHandler()
 {
-  if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
+ # if [ ! "${_BPX_TERMPATH-x}" = "OMVS" ] && [ -z "${NO_COLOR}" ] && [ ! "${FORCE_COLOR-x}" = "0" ] && [ -t 1 ] && [ -t 2 ]; then
+  if ${ANSION}; then
     [ -z "${-%%*x*}" ] && set +x # Disable -x debug if set for this process
     type=$1
     completiontext=$2 # Custom end text (when the process is complete)
     trapcmd="exit;"
     if [ -n "${completiontext}" ]; then
-      trapcmd="/bin/echo \"\047[1A\047[30D\047[2K${completiontext}\"; ${trapcmd}"
+    ansiline
+      #trapcmd="/bin/echo \"\047[0A\047[10D\047[2K${completiontext}\n\c\"; ${trapcmd}"
+      trapcmd="/bin/echo \"\047[10D\047[K${completiontext}\n\c\"; ${trapcmd}"
+    else
+      #trapcmd="/bin/echo \"\047[0A\047[10D\c\"; ${trapcmd}"
+      trapcmd="/bin/echo \"\047[10D\047[K\c\"; ${trapcmd}"
     fi
     # shellcheck disable=SC2064
     trap "${trapcmd}" HUP
     case "${type}" in
-      "spinner") progressAnimation '-' '\' '|' '/'
-      ;;
-      "network") progressAnimation '-----' '>----' '->---' '-->--' '--->-' '---->' '-----' '----<' '---<-' '--<--' '-<---' '<----'
-      ;;
-      *) progressAnimation '.' 'o' 'O' 'O' 'o' '.'
-      ;;
+      "spinner")  progressAnimation '-' '>' '|' '>' ;;
+      "network")  progressAnimation '-----' '>----' '->---' '-->--' '--->-' '---->' '-----' '----<' '---<-' '--<--' '-<---' '<----' ;;
+      "mirror")   progressAnimation '#______' '##_____' '#=#____' '#==#___' '#===#__' '#====#_' '#=====#' '#_====#' '#__===#' '#___==#' '#____=#' '#_____#' ;;
+      "trash")    progressAnimation 'O________' '_O_______' '__O______' '___o_____' '____o____' '_____o___' '______.__' '_______._' '________.' ;;
+      "linkcheck")progressAnimation '------>' '?----->' '-?---->' '--?--->' '---?-->' '----?->' '-----?>';;
+      *)          progressAnimation '.' 'o' 'O' 'O' 'o' '.' ;;
     esac
   fi
 }

--- a/include/common.sh
+++ b/include/common.sh
@@ -1286,6 +1286,145 @@ promptYesNoAlways() {
   return 0
 }
 
+getVersionedMetadata()
+{
+  printDebug "Specific version ${versioned} requested - checking existence and URL"
+  requestedMajor=$(echo "${versioned}" | awk -F'.' '{print $1}')
+  requestedMinor=$(echo "${versioned}" | awk -F'.' '{print $2}')
+  requestedPatch=$(echo "${versioned}" | awk -F'.' '{print $3}')
+  requestedSubrelease=$(echo "${versioned}" | awk -F'.' '{print $4}')
+  requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
+  printDebug "Finding URL for latest release matching version prefix: requestedVersion: ${requestedVersion}"
+  releasemetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.assets[].name | test("'${requestedVersion}'")))[0]')
+}
+
+getTaggedMetadata()
+{
+  printDebug "Explicit tagged version '${tagged}' specified. Checking for match"
+  releasemetadata=$(/bin/printf "%s" "${releases}" | jq -e -r '.[] | select(.tag_name == "'"${tagged}"'")')
+  printDebug "Use quick check for asset to check for existence of metadata for specific messages"
+  asset=$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')
+  if [ $? -ne 0 ]; then
+    printError "Could not find release tagged '${tagged}' in repo '${repo}'"
+  fi
+}
+
+getSelectMetadata()
+{
+  # As this is running within the generate... logic, a progress handler will have been started.
+  # This needs to be terminated before trying to write to screen
+  # shellcheck disable=SC2154
+  kill -HUP "${gigph}" 2>/dev/null # if the timer is not running, the kill will fail
+  waitforpid "${gigph}"  # Make sure it's finished writing to screen
+
+  # Explicitly allow the user to select a release to install; useful if there are broken installs
+  # as a known good release can be found, selected and pinned!
+  printDebug "List individual releases and allow selection"
+  i=$(/bin/printf "%s" "${releases}" | jq -r 'length - 1')
+  printInfo "Versions available for install:"
+  /bin/printf "%s" "${releases}" | jq --raw-output 'to_entries | map("\(.key): \(.value.tag_name) - \(.value.assets[0].name) [\( ( .value.assets[0].expanded_size|tonumber)*1000 / (1024 * 1024) | ceil | . / 1000)Mb]")[]'
+  printDebug "Getting user selection"
+  valid=false
+  while ! ${valid}; do
+    echo "Enter version to install (0-${i}): "
+    read selection < /dev/tty
+    if [ ! -z $(echo "${selection}" | sed -e 's/[0-9]*//') ]; then
+      echo "Invalid input, must be a number between 0 and ${i}"
+    elif [ "${selection}" -ge 0 ] && [ "${selection}" -le "${i}" ]; then
+      valid=true
+    fi
+  done
+  printVerbose "Selecting item ${selection} from array"
+  releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[${selection}]")"
+}
+
+getReleaseLineMetadata()
+{ 
+  printDebug "Install from release line '${releaseLine}' specified"
+  validatedReleaseLine=$(validateReleaseLine "${releaseLine}")
+  if [ -z "${validatedReleaseLine}" ]; then
+    printError "Invalid releaseline specified: '${releaseLine}'; Valid values: DEV or STABLE"
+  fi
+  printDebug "Finding latest asset on the release line"
+  releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${releaseLine}'")))[0]')"
+  printDebug "Use quick check for asset to check for existence of metadata"
+  asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
+  if [ $? -ne 0 ]; then
+    printError "Could not find release-line ${releaseLine} for repo: ${repo}"
+  fi
+}
+
+calculateReleaseLineMetadata()
+{
+  printDebug "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
+  if [ -n "${installedReleaseLine}" ]; then
+    printDebug "Found existing releaseline '${installedReleaseLine}', restricting to only that releaseline"
+    validatedReleaseLine="${installedReleaseLine}"  # Already validated when stored
+  else 
+    printDebug "Checking for system-configured releaseline"
+    if [ -e "${ZOPEN_ROOTFS}/etc/zopen/config.json" ]; then
+      printDebug "Using v2 configuration: '${ZOPEN_ROOTFS}/etc/zopen/config.json}'"
+      sysrelline=$(jq -re '.release_line' "${ZOPEN_ROOTFS}/etc/zopen/config.json")
+    elif [ -e "${ZOPEN_ROOTFS}/etc/zopen/releaseline" ] ; then
+      printDebug "Using legacy file-based config"
+      sysrelline=$(awk ' {print toupper($1)}') < "${ZOPEN_ROOTFS}/etc/zopen/releaseline"
+    fi
+    printDebug "Validating value: ${sysrelline}"
+    validatedReleaseLine=$(validateReleaseLine "${sysrelline}")
+    if [ -n "${validatedReleaseLine}" ]; then
+      printDebug "zopen system configured to use releaseline '${sysrelline}'; restricting to that releaseline"
+    else
+      printWarning "zopen misconfigured to use an unknown releaseline of '${sysrelline}'; defaulting to STABLE packages"
+      printWarning "Set the contents of '${ZOPEN_ROOTFS}/etc/zopen/releaseline' to a valid value to remove this message"
+      printWarning "Valid values are: DEV | STABLE"
+      validatedReleaseLine="STABLE"
+    fi
+  fi
+
+  printDebug "Parsing releases: ${releases}"
+    # We have some situations that could arise
+    # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
+    # 2. system is configured for STABLE but only has DEV stream available
+    # 3. system is configured for DEV but only has DEV stream available
+    # 4. the port being installed has got full releaseline tagging
+    # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
+    # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
+    # then that specific releaseline will be used
+  printDebug "Finding any releases tagged with ${validatedReleaseLine} and getting the first (newest/latest)"
+  releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${validatedReleaseLine}'")))[0]')"
+
+  printDebug "Use quick check for asset to check for existence of metadata"
+  asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
+  [ "${asset}" = "null" ] && asset="" # jq uses null, translate to sh's empty
+
+  if [ -n "${asset}" ]; then
+    # Case 4...
+    printVerbose "Found a specific '${validatedReleaseLine}' release-line tagged version; installing..."
+  else
+    # Case 2 & 3
+    printDebug "No releases on releaseline '${validatedReleaseLine}'; checking alternative releaseline"
+    alt=$(echo "${validatedReleaseLine}" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
+    releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r '. | map(select(.tag_name | startswith("'${alt}'")))[0]')"
+    printDebug "Use quick check for asset to check for existence of metadata"
+    asset="$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')"
+    [ "${asset}" = "null" ] && asset=""  # jq uses null, translate to sh's empty
+    if [ $? -eq 0 ]; then
+      printDebug "Found a release on the '${alt}' release line so release tagging is active"
+      if [ "DEV" = "${validatedReleaseLine}" ]; then
+        # The system will be configured to use DEV packages where available but if none, use latest
+        printInfo "No specific DEV releaseline package, using latest available"
+        releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
+      else
+        printVerbose "The system is configured to only use STABLE releaseline packages but there are none"
+        printInfo "No release available on the '${validatedReleaseLine}' releaseline."
+      fi
+    else
+      # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
+      printVerbose "Installing latest release"
+      releasemetadata="$(/bin/printf "%s" "${releases}" | jq -e -r ".[0]")"
+    fi
+  fi
+}
 
 parseRepoName()
 {
@@ -1296,6 +1435,46 @@ parseRepoName()
   versioned=$(echo "${fullname}" | cut -s -d '=' -f 2)
   tagged=$(echo "${fullname}" | cut -s -d '%' -f 2)
   printDebug "Name:${name};version:${versioned};tag:${tagged};repo:${repo}"
+}
+
+getPortMetaData(){
+  portRequested="$1"
+  invalidPortAssetFile="$2"
+  printDebug "Removing any version (%) or tag (#) suffixes fron '${portRequested}"
+  portName=$(echo "${portRequested}" | sed -e 's#%.*##' -e 's#=.*##')
+  validatedPort=$(echo "${repo_metadata}" | awk -vportName="${portName}" '$0 == portName {print}')
+  if [ -z "${validatedPort}" ]; then
+    echo "${portName}: no matching port found" >> "${invalidPortAssetFile}"
+    return 1
+  fi
+  parseRepoName "${portRequested}" # To set the various status flags below
+  getRepoReleases "${validatedPort}"
+  if [ -n "${versioned}" ]; then
+    getVersionedMetadata
+  elif [ -n "${tagged}" ]; then
+    getTaggedMetadata    
+  elif # shellcheck disable=SC2154
+       ${selectVersion}; then
+    getSelectMetadata
+  elif [ -n "${releaseLine}" ]; then  
+    getReleaseLineMetadata      
+  else
+    calculateReleaseLineMetadata
+  fi
+  if [ -z "${releasemetadata}" ]; then 
+    echo "${portName}: metadata could not be found" >> "${invalidPortAssetFile}"
+    return 1
+  fi
+  printDebug "Getting specific asset details using metadata: ${releasemetadata}"
+  if [ -z "${asset}" ] || [ "null" = "${asset}" ]; then
+    printDebug "Asset not found during previous logic; setting now"
+    asset=$(/bin/printf "%s" "${releasemetadata}" | jq -e -r '.assets[0]')
+  fi
+  if [ -z "${asset}" ]; then
+    echo "${portName} asset metadata could not be found" >> "${invalidPortAssetFile}"
+    return 1
+  fi
+  return 0
 }
 
 dedupStringList()

--- a/include/common.sh
+++ b/include/common.sh
@@ -598,12 +598,11 @@ mergeIntoSystem()
   # Need '-S' to allow long symlinks
   cd "${processingDir}" && tar -S -cf "${tarfile}" "usr"
 
-  printDebug "Generating listing for remove processing (including main symlink)."
-  listing=$(tar tf "${processingDir}/${tarfile}" 2> /dev/null | sort -r)
+  printDebug "Generating listing for remove processing (including main symlink)"
   echo "Installed files:" > "${versioneddir}/.links"
-  echo "${listing}" >> "${versioneddir}/.links"
-
-  printDebug "Extracting tar to rootfs."
+  tar tf "${processingDir}/${tarfile}" 2> /dev/null| sort -r >> "${versioneddir}/.links"
+  
+  printDebug "Extracting tar to rootfs"
   cd "${processingDir}" && tar xf "${tarfile}" -C "${rootfs}" 2> /dev/null
 
   printDebug "Cleaning temp resources."
@@ -627,10 +626,10 @@ unsymlinkFromSystem()
   rootfs=$2
   dotlinks=$3
   newfilelist=$4
-  if [ -e "${dotlinks}" ]; then
-    printInfo "- Checking for obsoleted files in ${rootfs}/usr/ tree from ${pkg}"
 
+  if [ -e "${dotlinks}" ]; then
     if [ -e "${newfilelist}" ]; then
+      printInfo "- Checking for file differences switching versions of '${pkg}'"
       printDebug "Release change, so the list of changes to physically remove should be smaller"
       printDebug "Starting spinner..."
       progressHandler "spinner" "- Check complete" &

--- a/include/common.sh
+++ b/include/common.sh
@@ -849,20 +849,19 @@ progressHandler()
     trapcmd="exit;"
     if [ -n "${completiontext}" ]; then
     ansiline
-      #trapcmd="/bin/echo \"\047[0A\047[10D\047[2K${completiontext}\n\c\"; ${trapcmd}"
       trapcmd="/bin/echo \"\047[10D\047[K${completiontext}\n\c\"; ${trapcmd}"
     else
-      #trapcmd="/bin/echo \"\047[0A\047[10D\c\"; ${trapcmd}"
       trapcmd="/bin/echo \"\047[10D\047[K\c\"; ${trapcmd}"
     fi
     # shellcheck disable=SC2064
     trap "${trapcmd}" HUP
     case "${type}" in
-      "spinner")  progressAnimation '-' '>' '|' '>' ;;
+      "spinner")  progressAnimation '-' '>' '|' '<' ;;
       "network")  progressAnimation '-----' '>----' '->---' '-->--' '--->-' '---->' '-----' '----<' '---<-' '--<--' '-<---' '<----' ;;
       "mirror")   progressAnimation '#______' '##_____' '#=#____' '#==#___' '#===#__' '#====#_' '#=====#' '#_====#' '#__===#' '#___==#' '#____=#' '#_____#' ;;
       "trash")    progressAnimation 'O________' '_O_______' '__O______' '___o_____' '____o____' '_____o___' '______.__' '_______._' '________.' ;;
       "linkcheck")progressAnimation '------>' '?----->' '-?---->' '--?--->' '---?-->' '----?->' '-----?>';;
+      "pkgcheck") progressAnimation '?###?###' '#?###?##' '##?###?#' '###?###?';;
       *)          progressAnimation '.' 'o' 'O' 'O' 'o' '.' ;;
     esac
   fi

--- a/include/common.sh
+++ b/include/common.sh
@@ -811,7 +811,6 @@ progressAnimation()
   [ $# -eq 0 ] && printError "Internal error: no animation strings."
   animcnt=$#
   anim=1
-#  ansiline 0 0 "$1\n\c"
   while :; do
     spinloop 1000
     # Check for daemonization of this process (ie. orphaned and PPID=1)
@@ -1721,12 +1720,17 @@ installFromPax()
   pax="${downloadToDir}/$1"
   printDebug "Installing from '${pax}'"
   processActionScripts "install-pre"
+
   metadatafile=$(extractMetadataFromPax "${pax}")
   # Ideally we would use the following, but name does not always map
   # to the actual repo package name at present.  The repo name is in the
   # repo field so can extract from there instead
   #name=$(jq --raw-output '.product.name' "${metadatafile}")
   name=$(jq --raw-output '.product.repo | match(".*/ZOSOpenTools/(.*)port").captures[0].string' "${metadatafile}")
+
+  # Store current installation directory (if exists)
+  currentderef=$(cd "${ZOPEN_PKGINSTALL}/${name}/${name}" > /dev/null 2>&1 && pwd -P)
+
   paxname="${installurl##*/}"
   installdirname="${name}/${paxname%.pax.Z}" # Use full pax name as default
 
@@ -1788,7 +1792,7 @@ EOF
     printDebug "New version merged; checking for orphaned files from previous version"
     # This will remove any old symlinks or dirs that might have changed in an upgrade
     # as the merge process overwrites existing files to point to different version
-    unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}" "${baseinstalldir}/${name}/${name}/.links"
+    unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentderef}/.links" "${baseinstalldir}/${name}/${name}/.links"
   fi
 
   if ${setactive}; then
@@ -1797,6 +1801,12 @@ EOF
     installedList="${name} ${installedList}"
     syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
     addToInstallTracker "${name}"    
+        # Some installation have installation caveats
+    installCaveat=$(jq -r '.product.install_caveats // empty' "${metadatafile}" 2>/dev/null)
+    if [ -n "$installCaveat" ]; then
+      printf "${name}:\n%s\n" "${installCaveat}">> "${ZOPEN_ROOTFS}/var/cache/install_caveats.tmp"
+    fi
+
     processActionScripts "install-post"
   fi
   printInfo "${NC}${GREEN}Successfully installed ${name}${NC}"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1333,6 +1333,34 @@ getActivePackageDirs()
   (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)
 }
 
+processActionScripts()
+{
+  phase=$1
+  case $phase in
+    "install-post") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/postInstall";;
+    "remove-post") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/postRemove";;
+    "txn-post") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/postTransaction";;
+    "install-pre") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/preInstall";;
+    "remove-pre") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/preRemove";;
+    "txn-pre") scriptDir="${ZOPEN_ROOTFS}/etc/zopen/scriptlets/preTransaction";;
+    *) printError "Internal error; invalid post action phase '${phase}'"
+  esac
+  (
+    [ -d "${scriptDir}" ] || return 0 # No script directory
+    unset CDPATH;
+    cd "${scriptDir}" || exit # the subshell
+    find . | while read scriptFile;
+    do
+      if [ ! -e "${scriptFile}" ]; then
+        printWarning "Script '${scriptDir}/${scriptFile}' is not executable. Check permissions"
+        continue
+      fi
+      # shellcheck disable=SC1090
+      . "${scriptFile}"
+    done
+  )
+}
+
 
 jqfunctions()
 {

--- a/include/common.sh
+++ b/include/common.sh
@@ -1477,6 +1477,61 @@ getPortMetaData(){
   return 0
 }
 
+# createDependancyGraph
+# analyzes the input file to create the list of all packages that are to
+# be pulled in during install - and recurses if any added packages themselves
+# pull in dependancies, dependencies being added to the front of the install queue
+# inputs: $1 the file to use for install ports
+#         $2 an error file for outputing failures
+# return: 0  for success (output of pwd -P command)
+#         8  if error
+createDependancyGraph(){
+  invalidPortAssetFile=$1 && shift 
+  printDebug "Getting list of dependencies"
+  dependencies=$(echo "${installList}" | jq --raw-output '.installqueue[] | select(.asset.runtime_dependencies | test("No dependencies") | not )| map(try(.runtime_dependencies |= split(" ")))| .[] | .runtime_dependencies[] ')
+  printDebug "Removing any dependencies already on install queue"
+  installing=$(echo "${installList}" | jq --raw-output '.installqueue[] | .portname')
+  missing=$(diffList "${installing}" "${dependencies}" )
+  if [ -z "${missing}" ]; then
+    printDebug "All dependencies are in the install graph"
+    return 0
+  fi
+  printDebug "Adding dependencies to install graph"
+  addToInstallGraph "${invalidPortAssetFile}" "${missing}"
+  # Recurse in case the now-installing dependencies themselves have dependencies
+  # Recursive dependencies should not break as the initial package will have been
+  # marked for installation
+  createDependancyGraph "${invalidPortAssetFile}"
+}
+
+# addToInstallGraph
+# Finds appropriate metadata for the specified port(s) and
+# includes that in the installation file
+# inputs: $1 the file to use for validated ports
+#         $2 an error file for outputing failures
+#         $* requested list of packages to install
+# return: 0  for success (output of pwd -P command)
+#         8  if error
+addToInstallGraph(){
+  invalidPortAssetFile=$1 && shift 
+  pkgList="$1"
+  printDebug "Adding pkgList to install graph"
+  for portRequested in ${pkgList}; do
+    if ! getPortMetaData "${portRequested}" "${invalidPortAssetFile}"; then
+      continue
+    fi
+    ## Merge asset into output file - note the lack of inline file edit hence the mv
+    installList=$(echo "${installList}" | jq ".installqueue += [{\"portname\":\"${validatedPort}\", \"asset\":${asset}}]")
+  done
+  if [ -e "${invalidPortAssetFile}" ]; then
+    printSoftError "The following ports cannot be installed: "
+    while read invalidPort; do
+      printf "${WARNING} %s\n" "${invalidPort}"
+    done < "${invalidPortAssetFile}"
+    printError "Confirm port names, remove any 'port' suffixes and retry command."
+  fi
+}
+
 validateInstallList(){
   installees="$1"
   # shellcheck disable=SC2086 # Using set -f disables globbing
@@ -1495,6 +1550,73 @@ dedupStringList()
   str="$1"
   echo "${str}"| awk -v delim="${delim}" '                                                                                                      
     { dlm=""; for (i=1; i<=NF; i++) {if (!seen[$i]++) {printf "%s%s", dlm, $i};dlm=delim};print ""}'
+}
+
+# generateInstallGraph
+# generates a file with details for packages that are to be installed from
+# the in-use repository, reporting errors if ports were invalid and
+# triggering dependency graph population
+# inputs: $1 the file to use for validated ports
+#         $* requested list of packages to install
+# return: 0  for success (output of pwd -P command)
+#         8  if error
+generateInstallGraph(){
+  installList="{}"
+  printDebug "Parsing list of packages to install and verifying validity"
+  portsToInstall="$1" # start with the initial list
+  portsToInstall=$(dedupStringList ' ' "${portsToInstall}")
+  repo_metadata="${repo_results}"
+  # Create the following file here to trigger cleanup - otherwise, multiple
+  # tempfiles could be created depending on dependency graph depth
+  invalidPortAssetFile=$(mktempfile "invalid" "port")
+  addCleanupTrapCmd "rm -rf ${invalidPortAssetFile}"
+  addToInstallGraph "${invalidPortAssetFile}" "${portsToInstall}"
+  if  
+    # shellcheck disable=SC2154
+    ${doNotInstallDeps}; then
+      printVerbose "- Skipping dependency analysis"
+  else
+    # calculate dependancy graph
+    createDependancyGraph "${invalidPortAssetFile}"
+  fi
+  pruneGraph
+}
+
+pruneGraph()
+{
+  printDebug "Pruning entries in graph if already installed"
+  if "${reinstall}"; then 
+    # Reinstall packages if they are already installed - no prune needed
+    return 0
+  fi
+  if "${downloadOnly}"; then
+    # Download the pax files, even if already installed as they are not 
+    # being reinstalled so no prune required
+    return 0
+  fi
+    # Prune already installed packages at the requested level; compare the 
+    # incoming file name against the port name, version and release already on the system
+    # - seems to be the easiest comparison since some data is not in zopen_release vs metadata.json
+    # and a local pax won't have a remote repo but should have a file name!
+    installed=$(zopen list --installed --details)
+    # Ignore the version string - it varies across ports so use name and build time as that
+    # should be unique enough
+    installed=$(echo "${installed}"| awk 'BEGIN{ORS = "," } {print "\"" $1 "@=@" $3 "\""}')
+    installed="[${installed%,}]"
+    
+    installList=$(echo "${installList}" | \
+      jq  --argjson installees "${installed}" \
+        '.installqueue |=
+          map(
+            select(.asset.url |
+              capture(".*/ZOSOpenTools/(?<name>[^/]*)port.*-(?<ver>[^-]*)\\.(?<rel>\\d{8}_\\d{6}?)\\.zos\\.pax\\.Z$") |.rel as $rel | .name as $name |
+              $installees | map(
+                .|capture("(?<iname>[^@]*)@=@(?<irel>\\d{8}_\\d{6}?)$")|.iname as $iname | .irel as $irel |
+                ($iname+"-"+$irel) == ($name+"-"+$rel)
+              ) | any == false
+            )
+          )'\
+    )
 }
 
 spaceValidate(){

--- a/include/common.sh
+++ b/include/common.sh
@@ -1716,6 +1716,93 @@ extractMetadataFromPax()
   fi
 }
 
+installFromPax()
+{
+  pax="${downloadToDir}/$1"
+  printDebug "Installing from '${pax}'"
+  processActionScripts "install-pre"
+  metadatafile=$(extractMetadataFromPax "${pax}")
+  # Ideally we would use the following, but name does not always map
+  # to the actual repo package name at present.  The repo name is in the
+  # repo field so can extract from there instead
+  #name=$(jq --raw-output '.product.name' "${metadatafile}")
+  name=$(jq --raw-output '.product.repo | match(".*/ZOSOpenTools/(.*)port").captures[0].string' "${metadatafile}")
+  paxname="${installurl##*/}"
+  installdirname="${name}/${paxname%.pax.Z}" # Use full pax name as default
+
+  baseinstalldir="${ZOPEN_PKGINSTALL}"
+  paxredirect="-s %[^/]*/%${ZOPEN_PKGINSTALL}/${installdirname}/%"
+
+  printDebug "Check for existing directory for version '${installdirname}'"
+  if [ -d "${ZOPEN_PKGINSTALL}/${installdirname}" ]; then 
+    printVerbose "- Clearing existing directory and contents"
+    rm -rf "${ZOPEN_PKGINSTALL}/${installdirname}"
+  fi
+
+  # shellcheck disable=SC2154
+  if ! runLogProgress "pax -rf ${pax} -p p ${paxredirect} ${redirectToDevNull}" "Expanding ${pax}" "Expanded"; then
+    printSoftError "Unexpected errors during unpaxing, package directory state unknown"
+    printError "Use zopen alt to select previous version to ensure known state"
+  fi
+
+  if [ -e "${ZOPEN_PKGINSTALL}/${name}/${name}/.pinned" ]; then
+    printWarning "Current version of ${name} is pinned; not setting updated version as active"
+    setactive=false
+    unInstallOldVersion=false
+  fi
+  # shellcheck disable=SC2154
+  if ${setactive}; then
+    if [ -L "${ZOPEN_PKGINSTALL}/${name}/${name}" ]; then
+      printDebug "Removing old symlink '${ZOPEN_PKGINSTALL}/${name}/${name}'"
+      rm -f "${ZOPEN_PKGINSTALL}/${name}/${name}"
+    fi
+    if ! ln -s "${ZOPEN_PKGINSTALL}/${installdirname}" "${ZOPEN_PKGINSTALL}/${name}/${name}"; then
+      printError "Could not create symbolic link name"
+    fi 
+    if ! ${nosymlink}; then
+      mergeIntoSystem "${name}" "${ZOPEN_PKGINSTALL}/${installdirname}" "${ZOPEN_ROOTFS}" 
+      misrc=$?
+      printDebug "The merge complete with: ${misrc}"
+    fi
+
+    printVerbose "- Checking for env file"
+    if [ -f "${ZOPEN_PKGINSTALL}/${name}/${name}/.env" ] || [ -f "${ZOPEN_PKGINSTALL}/${name}/${name}/.appenv" ]; then
+      printVerbose "- .env file found, adding to profiled processing"
+      mkdir -p "${ZOPEN_ROOTFS}/etc/profiled/${name}"
+      cat << EOF > "${ZOPEN_ROOTFS}/etc/profiled/${name}/dotenv"
+curdir=\$(pwd)
+cd "${ZOPEN_PKGINSTALL}/${name}/${name}" >/dev/null 2>&1
+# If .appenv exists, source it as it's quicker
+if [ -f ".appenv" ]; then
+  . ./.appenv
+elif [ -f ".env" ]; then
+  . ./.env
+fi
+cd \${curdir}  >/dev/null 2>&1
+EOF
+      printVerbose "- Running any setup scripts"
+      cd "${ZOPEN_PKGINSTALL}/${name}/${name}" && [ -r "./setup.sh" ] && ./setup.sh >/dev/null
+    fi
+  fi
+  if ${unInstallOldVersion}; then
+    printDebug "New version merged; checking for orphaned files from previous version"
+    # This will remove any old symlinks or dirs that might have changed in an upgrade
+    # as the merge process overwrites existing files to point to different version
+    unsymlinkFromSystem "${name}" "${ZOPEN_ROOTFS}" "${currentlinkfile}" "${baseinstalldir}/${name}/${name}/.links"
+  fi
+
+  if ${setactive}; then
+    printDebug "Marking this version as installed"
+    touch "${ZOPEN_PKGINSTALL}/${name}/${name}/.active"
+    installedList="${name} ${installedList}"
+    syslog "${ZOPEN_LOG_PATH}/audit.log" "${LOG_A}" "${CAT_INSTALL},${CAT_PACKAGE}" "DOWNLOAD" "handlePackageInstall" "Installed package:'${name}';version:${downloadFileVer};install_dir='${baseinstalldir}/${installdirname}';"
+    addToInstallTracker "${name}"    
+    processActionScripts "install-post"
+  fi
+  printInfo "${NC}${GREEN}Successfully installed ${name}${NC}"
+}
+
+
 getActivePackageDirs()
 {
   (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)

--- a/include/common.sh
+++ b/include/common.sh
@@ -1681,6 +1681,26 @@ processRepoInstallFile(){
   printVerbose "Port installation complete"
 }
 
+getInstallFile()
+{
+  installurl="$1"
+  downloadToDir="${ZOPEN_ROOTFS}/var/cache/zopen"
+  if $downloadOnly; then
+    downloadToDir="."
+  else
+    downloadToDir="${ZOPEN_ROOTFS}/var/cache/zopen"
+  fi
+  if [ -e "${downloadToDir}/${installurl##*/}" ]; then
+    :
+  else
+    [ -e "${downloadToDir}" ] || mkdir -p "${downloadToDir}"
+    [ -w "${downloadToDir}" ] || printError "No permission to save install file to '${downloadToDir}'. Check permissions and retry command."
+    if ! runAndLog "cd ${downloadToDir} && curlCmd --no-progress-meter -L ${installurl} -O ${redirectToDevNull}"; then
+      printError "Could not download from ${installurl}. Correct any errors and potentially retry"
+    fi
+  fi
+}
+
 getActivePackageDirs()
 {
   (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)

--- a/include/common.sh
+++ b/include/common.sh
@@ -1177,13 +1177,13 @@ downloadJSONCache()
   fi
 }
 
-getReposFromGithub()
+getRepos()
 {
   downloadJSONCache
-  repo_results="$(cat "${JSON_CACHE}" | jq -r '.release_data | keys[]')"
+  repo_results="$(jq -r '.release_data | keys[]' "${JSON_CACHE}")"
 }
 
-getAllReleasesFromGithub()
+getRepoReleases()
 {
   downloadJSONCache
   repo="$1"

--- a/include/common.sh
+++ b/include/common.sh
@@ -1701,6 +1701,21 @@ getInstallFile()
   fi
 }
 
+extractMetadataFromPax()
+{
+  if ! pax -rf "$1" -s "%[^/]*/%/tmp/%" '*/metadata.json' ; then
+    if ! details=$(pax -rf "$1" -s "%[^/]*/%/tmp/%" '*/package.json'); then
+      printSoftError "Could not extract package metadata from file '$1'."
+      [ -n "${details}" ] && printSoftError "Details: ${details}"
+      exit 8
+    else
+      echo "/tmp/package.json"
+    fi
+  else
+    echo "/tmp/metadata.json"
+  fi
+}
+
 getActivePackageDirs()
 {
   (unset CD_PATH; cd "${ZOPEN_PKGINSTALL}" && zosfind  ./*/. ! -name . -prune -type l)

--- a/include/common.sh
+++ b/include/common.sh
@@ -1263,4 +1263,20 @@ promptYesOrNo() {
 
 . ${INCDIR}/analytics.sh
 
+jqfunctions()
+{
+  # Return a set of helper functions for jq that can be prepended to
+  # any jq query
+  # pl(s;c;n) - padLeft with character 'c' to length 'n'
+  # pr(s;c;n) - padRight with chacater 'c' to length 'n'
+  # c(s;l) - center the string 's' in a string of length 'l'
+  # r(dp) - round decimal to 'dp' decimal places (needs '*' & '/' 10^dp hack) 
+  # shellcheck disable=SC2016
+  printf "%s;%s;%s;%s;" \
+  'def pl(s;c;n):c*(n-(s|length))+s' \
+  'def pr(s;c;n):s+c*(n-(s|length))' \
+  'def c(s;c;l):(((l - (s|length))/2 | floor ) // 0) as $lp|((l - (s|length) - $lp) // 0 )as $rp|pl("";c; $lp) + s + pr("";c; $rp)' \
+  'def r(dp):.*pow(10;dp)|round/pow(10;dp)'
+}
+
 zopenInitialize


### PR DESCRIPTION
Update to the installer primarily to handle install direct from file but includes:
- analyzes install packages to determine if any are local files
- implements capability to allow for custom repositories, currently complete GitHub mirror or a local directory; defaults to z/OS Open Tools main GH repo
- generates install graph in advance to allow for space calculation up-front 
- implements pre/post phases to allow scripts to run at certain times. Default scripts:
-- auto-cache-clean - clean package cache after installation transaction completes [enabled by default]
-- man-db - run man-db automagically after install/alt/remove transactions [enabled if man-db package is installed]
-- caveats - display any "caveats" that a package might have after installation [a caveat being something an end user has to either run, configure or be aware of when using a certain package]
- implements an a/all option for y/n questions to automatically answer yes 
- generates a package database, updated during install/alt/removal
- performance improvements to queries, utilising package db and jq
- split install into "upgrade" and "install" scripts
- split query into "query" and "list" scripts
- multiple bug fixes and shellcheck updates
- removes [broken] customized filesystem type logic; always use default of usr/local/zopen for package installation

Should resolve/improve:  #733 #717 #701 #694 #688 #675 #673 #661 #643 #633 #619 #617 #605 #567 #566 #558 #533 #472 #431 #381 #339 #240 
