### PR TITLE
doc: the command zopen search is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ zopen list [--installed]
 With no parameters, will list the available packages against the currently installed versions; more usefully, using the `--installed` parameter lists the actually locally-installed packages rather than all potential packages
 
 ```bash
-zopen search <package>
+zopen query --remote-search <package>
 ```
 
 Searches the remote repository for the specified package, returning appropriate meta-data about the package if found.


### PR DESCRIPTION
The readme shows the command "zopen search" which isn't valid in the current version of zopen.
"zopen query --remote-search" seems to provide the equivalent functionality.