### PR TITLE
Only generate zoslib hooks if CC is set

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2056,6 +2056,16 @@ generateZOSLIBHooks()
   #LIBPATH|prepend|PROJECT_ROOT/lib
   #"
 
+  if [ -z "${CC}" ]; then
+    printVerbose "Skipping GenerateZOSLIBHooks since CC is not set"
+    return
+  fi
+
+  if ! command -v "${CC}" > /dev/null 2>&1; then
+    printVerbose "Skipping GenerateZOSLIBHooks since CC is not a command"
+    return
+  fi
+
   if command -V "${ZOPEN_APPEND_TO_ZOSLIB_ENV_CODE}" > /dev/null 2>&1; then
     printVerbose "Appending additional environment zoslib variables..."
     zoslib_env="${zoslib_env}$(${ZOPEN_APPEND_TO_ZOSLIB_ENV_CODE})"


### PR DESCRIPTION
Fixes this error when building Go apps:
```
***WARNING: No patches in /data/workspace/Port-Build/murex/patches to apply
Generating ZOSLIB Environment Hooks
***ERROR:  must have 2 '|' seperators only
```