### PR TITLE
Add alternate path for tools that conflict with /bin tools + mechanism to add them to your PATH

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -1456,7 +1456,7 @@ export ${projectName}_HOME="\${PWD}"
 zz
 
   if [ -d "${ZOPEN_INSTALL_DIR}/bin" ]; then
-    echo "PATH=\"\${${projectName}_HOME}/bin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
+    echo "PATH=\"\${${projectName}_HOME}/bin:\${${projectName}_HOME}/altbin:\$PATH\"" >> "${ZOPEN_INSTALL_DIR}/.env"
     echo "export PATH=\"\$(deleteDuplicateEntries \"\$PATH\" \":\")\"" >> "${ZOPEN_INSTALL_DIR}/.env"
   fi
   if [ -d "${ZOPEN_INSTALL_DIR}/lib" ]; then

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -398,6 +398,10 @@ handlePackageInstall()
       printf "${name}:\n${installCaveat}\n" >> ${caveatsFile}
     fi
 
+    if [ -d "${baseinstalldir}/${installdirname}/altbin" ]; then
+      printf "${name}:\n${name} has tools provided under altbin that conflict with tools under /bin.\nTo use them set ZOPEN_TOOLSET_OVERRIDE.\n" >> ${caveatsFile}
+    fi
+
 
     if ${setactive}; then
       if [ -L "${baseinstalldir}/${name}/${name}" ]; then

--- a/bin/zopen-install
+++ b/bin/zopen-install
@@ -395,11 +395,11 @@ handlePackageInstall()
     # Some installation have installation caveats
     installCaveat=$(jq -r '.product.install_caveats // empty' "${metadataFile}" 2>/dev/null)
     if [ -n "$installCaveat" ]; then
-      printf "${name}:\n${installCaveat}\n" >> ${caveatsFile}
+      printf "${NC}${HEADERCOLOR}${BOLD}${name}${NC}:\n ${installCaveat}\n" >> ${caveatsFile}
     fi
 
     if [ -d "${baseinstalldir}/${installdirname}/altbin" ]; then
-      printf "${name}:\n${name} has tools provided under altbin that conflict with tools under /bin.\nTo use them set ZOPEN_TOOLSET_OVERRIDE.\n" >> ${caveatsFile}
+      printf "${NC}${HEADERCOLOR}${BOLD}${name}${NC}:\n${name} has tools provided under altbin/ that conflict with tools under /bin.\nTo use them set ZOPEN_TOOLSET_OVERRIDE and then re-source the zopen-config.\n" >> ${caveatsFile}
     fi
 
 

--- a/include/common.sh
+++ b/include/common.sh
@@ -196,6 +196,10 @@ fi
 ZOPEN_ROOTFS="${rootfs}"
 export ZOPEN_ROOTFS
 
+if [ "\$1" = "--override-zos-tools" ]; then
+  export ZOPEN_TOOLSET_OVERRIDE=1
+fi
+
 if [ -z "\${_BPXK_AUTOCVT}" ]; then
   export _BPXK_AUTOCVT=ON
 else
@@ -210,7 +214,8 @@ fi
 
 zot="z/OS Open Tools"
 
-sanitizeEnvVar(){
+sanitizeEnvVar()
+{
   # remove any envvar entries that match the specified regex
   value="\$1"
   delim="\$2"

--- a/include/common.sh
+++ b/include/common.sh
@@ -261,7 +261,10 @@ if [ -z "\${ZOPEN_QUICK_LOAD}" ]; then
   fi
 fi
 unset displayText
-PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/local/altbin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
+PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
+if [ -n "\$ZOPEN_TOOLSET_OVERRIDE" ]; then
+  PATH="\${ZOPEN_ROOTFS}/usr/local/altbin:\$PATH"
+fi
 export PATH=\$(deleteDuplicateEntries "\${PATH}" ":")
 LIBPATH=\${ZOPEN_ROOTFS}/usr/local/lib:\${ZOPEN_ROOTFS}/usr/lib:\$(sanitizeEnvVar "\${LIBPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 export LIBPATH=\$(deleteDuplicateEntries "\${LIBPATH}" ":")

--- a/include/common.sh
+++ b/include/common.sh
@@ -261,7 +261,7 @@ if [ -z "\${ZOPEN_QUICK_LOAD}" ]; then
   fi
 fi
 unset displayText
-PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
+PATH=\${ZOPEN_ROOTFS}/usr/local/bin:\${ZOPEN_ROOTFS}/usr/local/altbin:\${ZOPEN_ROOTFS}/usr/bin:\${ZOPEN_ROOTFS}/bin:\${ZOPEN_ROOTFS}/boot:\$(sanitizeEnvVar "\${PATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 export PATH=\$(deleteDuplicateEntries "\${PATH}" ":")
 LIBPATH=\${ZOPEN_ROOTFS}/usr/local/lib:\${ZOPEN_ROOTFS}/usr/lib:\$(sanitizeEnvVar "\${LIBPATH}" ":" "^\${ZOPEN_PKGINSTALL}/.*\$")
 export LIBPATH=\$(deleteDuplicateEntries "\${LIBPATH}" ":")


### PR DESCRIPTION
We're making modifications to move tools conflicting with /bin tools like Gawk's awk to an altbin/ directory.

To add altbin to their PATH, users can set ZOPEN_TOOLSET_OVERRIDE=1 and then source zopen-config.

You can also do this:
```
. /home/itodoro/zopen/etc/zopen-config --override-zos-tools
```

* Tools that conflict with /bin tools
  - coreutils - https://github.com/ZOSOpenTools/coreutilsport/pull/72/files
  - Sed - https://github.com/ZOSOpenTools/sedport/pull/12
  - findutils - https://github.com/ZOSOpenTools/findutilsport/pull/20
  - diffutils - https://github.com/ZOSOpenTools/diffutilsport/pull/31
  - Grep - https://github.com/ZOSOpenTools/grepport/pull/17
  - Awk - https://github.com/ZOSOpenTools/gawkport/blob/main/buildenv
  - Make - https://github.com/ZOSOpenTools/makeport/pull/42/files
  - Openssh - https://github.com/ZOSOpenTools/opensshport/pull/11
  - gawk: https://github.com/ZOSOpenTools/gawkport/pull/21/files