### PR TITLE
Consolidation of install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make sure the character device `/dev/tty` is untagged or you may experience unex
 
 ## Installation and sample usage
 
-Start with [Quick start guide](https://zosopentools.org/#/Guides/QuickStart?id=getting-the-zopen-package-manager).
+Start with [quick start guide](https://zosopentools.org/#/Guides/QuickStart?id=getting-the-zopen-package-manager).
 
 ## Important usage notes
 

--- a/README.md
+++ b/README.md
@@ -19,32 +19,9 @@ export _TAG_REDIR_OUT=txt
 
 Make sure the character device `/dev/tty` is untagged or you may experience unexpected behaviour. Run `chtag -r /dev/tty` to remove any tags.
 
-## Installation
+## Installation and sample usage
 
-* Download the meta pax to a suitable location (for example /tmp).
-* Expand the pax using the command `pax -rvf <filename>.pax.Z`.  This will expand the pax to the current directory, listing the various included files as it does so.
-* From the `meta-<ver>` directory run the following command, answering the questions appropriately:
-
-```bash
-. ./.env
-zopen init
-```
-
-You can now safely remove `meta-<version>.pax.Z` and the extracted `meta-<version>` directory
-
-## Sample usage
-
-```bash
-. ./.env # Source the .env from meta
-zopen init
-. <zopen_root_path>/etc/zopen-config
-zopen list --installed
-zopen install which
-zopen list --installed
-which which
-zopen upgrade
-zopen install git vim # install both git and vim
-```
+Start with [Quick start guide](https://zosopentools.org/#/Guides/QuickStart?id=getting-the-zopen-package-manager).
 
 ## Important usage notes
 

--- a/docs/Guides/QuickStart.md
+++ b/docs/Guides/QuickStart.md
@@ -13,7 +13,8 @@ please note you will need to [migrate to the new package manager](Migration.md).
 
 ## Getting the zopen package manager
 
-- Download the latest [meta pax](https://github.com/ZOSOpenTools/meta/releases) to your desktop, then upload to z/OS
+- Download the latest [meta pax](https://github.com/ZOSOpenTools/meta/releases) to your desktop, then upload to z/OS.
+  - Note: it is recommended that you use sftp to transfer the pax file from a non-z/OS machine to z/OS. This will ensure that there is no ASCII/EBCDIC conversion.
 - On z/OS, expand the pax file: `pax -rf meta-<version>.pax.Z`. 
 - cd to the unpax'ed directory: `cd meta-<version>`
 - Set up the PATH to the `zopen` tool: `cd meta-<version>; . ./.env`


### PR DESCRIPTION
As @ijmitch expressed, we have a number of places that document how to install zopen. Let's consolidate it all and point to https://zosopentools.org/#/Guides/QuickStart?id=getting-the-zopen-package-manager as the source of truth.