### PR TITLE
Zopen config helper capabilities

### DIFF
--- a/bin/zopen
+++ b/bin/zopen
@@ -28,36 +28,38 @@ ${ME} is a utility for managing a z/OS Open Tools environment.
 Usage: ${ME} [COMMAND] [OPTION] [PARAMETERS]...
 
 Command:
-  alt               manage alternate versions of z/OS Open Tools packages.
-  audit             (beta) reports known vulnerabilities for the installed packages.
-  build             builds the enclosing z/OS Open Tools git-cloned package.
-  clean             cleans up your zopen environment.
-  generate          generates a new zopen project.
-  init              initializes a zopen environment at the specified location.
-  install           installs one or more z/OS Open Tools packages.
-  list              lists information about z/OS Open Tools packages.
-  query             list local or remote info about z/OS Open Tools packages.
-  remove            removes installed z/OS Open Tools packages.
-  update-cacert     update the cacert.pem file used by z/OS Open Tools.
-  upgrade           upgrades existing z/OS Open Tools packages.
+  alt               manage alternate versions of z/OS Open Tools packages
+  audit             (beta) reports known vulnerabilities for the installed packages
+  build             builds the enclosing z/OS Open Tools git-cloned package
+  clean             cleans up your zopen environment
+  config            change zopen runtime environment settings
+  generate          generates a new zopen project
+  init              initializes a zopen environment at the specified location
+  install           installs one or more z/OS Open Tools packages
+  list              lists information about z/OS Open Tools packages
+  query             list local or remote info about z/OS Open Tools packages
+  remove            removes installed z/OS Open Tools packages
+  update-cacert     update the cacert.pem file used by z/OS Open Tools
+  upgrade           upgrades existing z/OS Open Tools packages
 
 Options:
-  -h, --help, -?    display this help and exit.
-  -v, --verbose     run in verbose mode.
+  -h, --help, -?    display this help and exit
+  -v, --verbose     run in verbose mode
 
 Examples:
-  zopen --help      displays zopen help.
-  zopen --version   displays the installed zopen version.
-  zopen install git install the latest z/OS Open Tools git package.
+  zopen --help      displays zopen help
+  zopen --version   displays the installed zopen version
+  zopen install git install the latest version of the 'git' package
   zopen upgrade -y  upgrade all installed packages to the latest release,
-                    without prompting.
-  zopen alt bash    list installed alternative bash z/OS Open Tools packages.
+                    without prompting
+  zopen alt bash    list installed alternative bash packages
 
 SEE ALSO:
   zopen-alt(1)
   zopen-audit(1)
   zopen-build(1)
   zopen-clean(1)
+  zopen-config-helper(1)
   zopen-generate(1)
   zopen-init(1)
   zopen-install(1)
@@ -92,6 +94,9 @@ for arg in $*; do
     "upgrade")
       subcmd='zopen-install'
       subopts="${subopts} -u"
+      ;;
+    "config")
+      subcmd="zopen-${arg}-helper"
       ;;
     "--version")
       version=true

--- a/bin/zopen-config-helper
+++ b/bin/zopen-config-helper
@@ -1,0 +1,147 @@
+#!/bin/sh -x
+#
+# Configuration helper for z/OS Open Tools - https://github.com/ZOSOpenTools
+#
+
+#
+# All zopen-* scripts MUST start with this code to maintain consistency.
+#
+setupMyself()
+{
+  ME=$(basename $0)
+  MYDIR="$(cd "$(dirname "$0")" > /dev/null 2>&1 && pwd -P)"
+  INCDIR="${MYDIR}/../include"
+  if ! [ -d "${INCDIR}" ] && ! [ -f "${INCDIR}/common.sh" ]; then
+    echo "Internal Error. Unable to find common.sh file to source." >&2
+    exit 8
+  fi
+  # shellcheck disable=SC1091
+  . "${INCDIR}/common.sh"
+}
+setupMyself
+checkWritable
+
+printHelp()
+{
+  cat << HELPDOC
+${ME} is a utility for z/OS Open Tools to change the zopen runtime environment.
+ 
+
+Usage: ${ME} [OPTION] [KEY]
+
+Options:
+  --delete          unset and remove the named KEY property from the store
+  --get             display the current value for the named KEY property or 
+                    the empty string if the property is not found/set
+  --set             set the configuration value for the named KEY property
+  --list            list all current configuration values
+  -v, --verbose     run in verbose mode.
+  --version         print version.
+
+Examples:
+  zopen --get autocacheclean  
+                    get the value for the autocachclean setting
+  zopen --set is_collecting_stats false
+                    disable the is_collecting_stats functionality
+
+Notes:
+  Configuration options are not validated such that any key/value pairs can
+  be added into the global configuration. 3rd-party utilities can store their
+  global configuration into the zopen runtime environment store and use the
+  zopen config tooling to set/retrieve values
+  
+  
+Report bugs at https://github.com/ZOSOpenTools/meta/issues.
+
+HELPDOC
+}
+
+
+# Main code start here
+args=$*
+cmdtype=""
+verbose=false
+debug=false
+
+if [ $# -eq 0 ]; then
+  printError "No option provided for cleaning"
+fi
+while [ $# -gt 0 ]; do
+  printVerbose "Parsing option: $1"
+  case "$1" in
+  "--set")
+    [ $# -lt 3 ] && \
+        printError "Parameter error trying to set configuration value"
+    cmdtype="set"
+    setting="$2"
+    newvalue="$3"
+    shift 2
+    ;;
+  "--get")
+    shift
+    setting="$1"
+    cmdtype="get"
+    ;;
+  "--list")
+    cmdtype="list"
+    ;;
+  "--delete")
+    shift
+    cmdtype="delete"
+    setting="$1"
+    ;;
+  "-h" | "--help" | "-?")
+    printHelp "${args}"
+    exit 0
+    ;;
+  "--version")
+    zopen-version ${ME}
+    exit 0
+    ;;
+  "-v" | "--verbose")
+    verbose=true
+    ;;
+  "--debug")
+    # shellcheck disable=SC2034
+    verbose=true
+    # shellcheck disable=SC2034
+    debug=true
+    ;;
+  "--xdebug")
+    set -x
+    ;;
+  *)
+    printError "Unexpected parameter '$1'"
+    ;;
+  esac
+  shift
+done
+
+case "${cmdtype}" in
+  get)  if ! jq -r ".${setting}" "${ZOPEN_JSON_CONFIG}"; then
+          printError "Unable to retrieve value for '${setting}'. See previous errors for more information and retry command."
+        fi
+  ;;
+  set)  if ! current=$(jq ".${setting}" "${ZOPEN_JSON_CONFIG}"); then
+          printError "Unable to retrieve current value for '${setting}'. See previous errors for more information and retry command."
+        fi
+        [ "${current}" = "${newvalue}" ] && printInfo "New value '${newvalue}' is already configured." && exit 0
+        if ! jq --arg newvalue "${newvalue}" \
+                ".${setting} = \"$newvalue\"" \
+                "${ZOPEN_JSON_CONFIG}" > "${ZOPEN_JSON_CONFIG}.working"; then
+          printError "Errors setting new value '${newvalue}' for setting '${setting}'. See previous errors for more information and retry command."
+        fi
+  ;;
+  list) if ! jq -r 'to_entries[] | "\(.key): \(.value)"' "${ZOPEN_JSON_CONFIG}"; then
+          printError "Unable to display current configuration. See previous errors for more information and retry command."
+        fi
+  ;;
+  delete) if ! jq "del(.${setting})" "${ZOPEN_JSON_CONFIG}"  > "${ZOPEN_JSON_CONFIG}.working"; then
+            printError "Unable to remove property '${setting}' from configuration. See previous errors for more information and retry command."
+          fi
+          mv "${ZOPEN_JSON_CONFIG}.working" "${ZOPEN_JSON_CONFIG}"
+  ;;
+  *) printError "Required action not specified. Check parameters and retry command."
+esac
+# At this point, commands completed successfully
+exit 0


### PR DESCRIPTION
Provides a "zopen config  --get/--set" capbility to allow for set/get of zopen runtime environment variables, held in the <zopenrootfs>/etc/zopen/config.json file.  This is a naive --set in that there is [currently] no key/parameter validation, allowing storage of any configuration data in config.json as a key/value pair.  If a key already exists, it will be updated on a --set.
