### PR TITLE
Ensure true/false consistency for knv

### DIFF
--- a/include/common.sh
+++ b/include/common.sh
@@ -189,7 +189,9 @@ if [ \$# -gt 0 ]; then
     *) echo "Error. Unknown parameter '\$1' passed to zopen-config." >&2; return 8;;
   esac
 fi
-[ \${knv} ] && /bin/env | /bin/sort > /tmp/zopen-config-env-orig.\$\$
+if "\${knv}"; then
+  /bin/env | /bin/sort > /tmp/zopen-config-env-orig.\$\$
+fi
 
 ZOPEN_ROOTFS=\"${rootfs}\"
 export ZOPEN_ROOTFS


### PR DESCRIPTION
Replace the [...] test as there seem to be differences between shells that results in the *.orig.* file being left in /tmp
