### PR TITLE
Add quick install similar to brew

### DIFF
--- a/docs/Guides/QuickStart.md
+++ b/docs/Guides/QuickStart.md
@@ -11,8 +11,15 @@ Whether you want to _use_ the tools or also _improve_ the tools is up to you.
 If you have installed a version of the zopen package manager prior to September 2023, 
 please note you will need to [migrate to the new package manager](Migration.md). 
 
-## Getting the zopen package manager
+## Installing zopen package manager
 
+If you have curl and bash on your system, you can use this one liner:
+```
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZOSOpenTools/meta/HEAD/tools/zopen_install.sh)"
+
+```
+
+Otherwise, follow these steps:
 - Download the latest [meta pax](https://github.com/ZOSOpenTools/meta/releases) to your desktop, then upload to z/OS.
   - Note: it is recommended that you use sftp to transfer the pax file from a non-z/OS machine to z/OS. This will ensure that there is no ASCII/EBCDIC conversion.
 - On z/OS, expand the pax file: `pax -rf meta-<version>.pax.Z`. 

--- a/docs/Guides/QuickStart.md
+++ b/docs/Guides/QuickStart.md
@@ -16,7 +16,6 @@ please note you will need to [migrate to the new package manager](Migration.md).
 If you have curl and bash on your system, you can use this one liner:
 ```
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZOSOpenTools/meta/HEAD/tools/zopen_install.sh)"
-
 ```
 
 Otherwise, follow these steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ## Welcome to z/OS Open Tools
 
 The [z/OS Open Tools community](https://github.com/ZOSOpenTools/meta/discussions) is here to provide popular Open Source tools and to encourage z/OS Open Source tools development. 
-We currently host **180+ z/OS Open Source projects** and we're looking for more! 
+We currently host **2000+ z/OS Open Source projects** and we're looking for more! 
 
 <section class="layout">
 <div style="float: right; box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19); width: 50%">
@@ -10,13 +10,17 @@ We currently host **180+ z/OS Open Source projects** and we're looking for more!
 </div>
 <div class="grow1" style="float: left; width: 50%">
 
+### Install zopen
+```
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZOSOpenTools/meta/HEAD/tools/zopen_install.sh)"
+```
 
-* Our [z/OS Open Tools repositories](https://github.com/ZOSOpenTools) shows what's available
- * Want to see the latest [build status and quality](Guides/../Latest.md) ?
 * [Getting Started](/Guides/QuickStart.md) will get you going fast.
- * Want to [use the tools](/Guides/ThePackageManager.md) ?
- * Want to [develop the tools](/Guides/developing.md) ?
- * Want to [improve our documentation](./UpdateDocs.md) ?
+* Our [z/OS Open Tools repositories](https://github.com/ZOSOpenTools) shows what's available
+* Want to see the latest [build status and quality](Guides/../Latest.md) ?
+* Want to [use the tools](/Guides/ThePackageManager.md) ?
+* Want to [develop the tools](/Guides/developing.md) ?
+* Want to [improve our documentation](./UpdateDocs.md) ?
 
 ### Your Feedback Matters!
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,22 @@
 ## Welcome to z/OS Open Tools
 
 The [z/OS Open Tools community](https://github.com/ZOSOpenTools/meta/discussions) is here to provide popular Open Source tools and to encourage z/OS Open Source tools development. 
-We currently host **2000+ z/OS Open Source projects** and we're looking for more! 
+We currently host **200+ z/OS Open Source projects** and we're looking for more! 
 
 <section class="layout">
 <div style="float: right; box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19); width: 50%">
+
  <h2 align="center" style="margin-bottom:0px; padding-bottom:0px;">Installation made easy!</h2>
+
+```
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZOSOpenTools/meta/HEAD/tools/zopen_install.sh)"
+```
+
  <img src="images/demo.gif"  style="box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);" />
 </div>
 <div class="grow1" style="float: left; width: 50%">
 
-### Install zopen
-```
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZOSOpenTools/meta/HEAD/tools/zopen_install.sh)"
-```
+### Explore & Engage
 
 * [Getting Started](/Guides/QuickStart.md) will get you going fast.
 * Our [z/OS Open Tools repositories](https://github.com/ZOSOpenTools) shows what's available

--- a/tools/zopen_install.sh
+++ b/tools/zopen_install.sh
@@ -1,0 +1,54 @@
+#!/bin/env bash
+# 
+# Quick Install tool for zopen's meta package
+# Assumes you have Curl and Bash installed (likely through Open Enterprise Foundation)
+
+if [[ $(uname) != "OS/390" ]]; then
+  echo "Error: This script is only for z/OS systems."
+  exit 1
+fi
+
+if ! command -v curl > /dev/null 2>&1; then
+  echo "Error: 'curl' command not found. Please install curl."
+  exit 1
+fi
+
+# Download the latest json
+url=$(curl --fail-with-body --silent -L https://raw.githubusercontent.com/ZOSOpenTools/meta/main/docs/api/zopen_releases_latest.json)
+if [ $? -gt 0 ]; then
+  echo "Error: Curl failed due to: \"$url\""
+fi
+
+# TODO: check if jq is present, and use it instead of this
+url=$(echo "$url" | /bin/tr ' ' '\n' |  grep "https://github.com/ZOSOpenTools/metaport/releases/download/" |  /bin/sed -e 's/.*\(https:\/\/github.com\/ZOSOpenTools\/metaport\/releases\/download\/[^"]*\.pax\.Z\).*/\1/')
+paxFile=$(basename "$url");
+
+echo "Downloading z/OS Open Tools meta.pax.Z..."
+
+url=$(curl --fail-with-body -O -L "$url")
+if [ $? -gt 0 ]; then
+  echo "Error: Curl failed due to: \"$url\""
+fi
+
+if [ ! -f $paxFile ]; then
+  echo "Error: $paxFile not present"
+fi
+
+# Extract meta.pax.Z
+echo "Extracting $paxFile..."
+paxOutput=$(pax -rvf "$paxFile" 2>&1)
+if [ $? -gt 0 ]; then
+   echo "Error: Failed to unpax"
+fi
+
+dir=$(echo "$paxOutput" | head -1)
+
+set -e
+echo "Moving to extracted directory..."
+cd "$dir"
+
+echo "Setting up environment..."
+source ./.env
+
+echo "Initializing zopen tools..."
+zopen init

--- a/tools/zopen_install.sh
+++ b/tools/zopen_install.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # 
 # Quick Install tool for zopen's meta package
 # Assumes you have Curl and Bash installed (likely through Open Enterprise Foundation)


### PR DESCRIPTION
Similar to brew's one-liner: https://brew.sh/

Now that bash and curl are more accessible (provided via IBM Open Enterprise Foundation and Rocket Software), provide a one-liner to install zopen.

<img width="2109" alt="Screenshot 2024-06-13 at 1 26 56 PM" src="https://github.com/ZOSOpenTools/meta/assets/39890068/40ac8923-40a6-411c-b644-4a8de7467c05">

Since our intention is to deprecate/remove the [meta](https://github.com/ZOSOpenTools/meta/releases) release, the script downloads from metaport instead.