### PR TITLE
Enable file system setting for how /bin tools are overriden via zopen-init

### DIFF
--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -430,8 +430,8 @@ generateJsonConfiguration()
 {
   "release_line": "${releaseLine}",
   "num_rm_procs": ${RM_FILEPROCS},
-  "is_collecting_stats": ${isCollectingStats}
-  "override_zos_tools": ${OVERRIDE_ZOS_TOOLS},
+  "is_collecting_stats": ${isCollectingStats},
+  "override_zos_tools": ${OVERRIDE_ZOS_TOOLS}
 }
 zz
     jq '.' "${jsonConfigWorking}" > "${jsonConfig}"
@@ -440,9 +440,9 @@ zz
     # In case 3rd-party edits have been made (adding custom keys for
     # example), just update the values that zopen itself knows about inline
     if ! jq --arg releaseLine "${releaseLine}" \
-            --arg isCollectingStats "${isCollectingStats}" \
-            --arg overrideZOSTools "${OVERRIDE_ZOS_TOOLS}" \
-                ".release_line = \"${releaseLine}\" | .is_collecting_stats = ${isCollectingStats}" | .override_zos_tools = ${overrideZOSTools}" \
+        --arg isoverrideZOSTools ${OVERRIDE_ZOS_TOOLS} \
+        --arg isCollectingStats ${isCollectingStats} \
+                ".release_line = \$releaseLine | .override_zos_tools = \$isoverrideZOSTools | .is_collecting_stats = \$isCollectingStats" \
                 "${ZOPEN_JSON_CONFIG}" > "${ZOPEN_JSON_CONFIG}.working"; then
       printError "Errors updating existing configuration file. See previous errors for more information and retry command."
     fi

--- a/bin/zopen-init
+++ b/bin/zopen-init
@@ -41,6 +41,10 @@ Options:
   --[no]enable-stats
           Toggle enabling collection of usage statistics
 
+  --[no]override-zos-tools
+          Toggle default mode for overriding z/OS /bin tools
+          in the zopen-config. Default is --nooverride-zos-tools
+
   -f, --fs-layout <LAYOUT>
           The filesystem structure to use for installed
           packages on disk; packages will be installed to
@@ -145,6 +149,12 @@ while [ $# -gt 0 ]; do
       ;;
     "--enable-stats" )
       enableStats=true
+      ;;
+    "--override-zos-tools" )
+      OVERRIDE_ZOS_TOOLS=true
+      ;;
+    "--nooverride-zos-tools" )
+      OVERRIDE_ZOS_TOOLS=false
       ;;
     "--noenable-stats" )
       enableStats=false
@@ -374,7 +384,7 @@ generateFileSystem()
 generateZopenConfig()
 {
   printHeader "Generating zopen-config"
-  writeConfigFile "${configFile}" "${rootfs}" "${zopen_pkginstall}" "${ZOPEN_CA_DIR}/${certFileName}"
+  writeConfigFile "${configFile}" "${rootfs}" "${zopen_pkginstall}" "${ZOPEN_CA_DIR}/${certFileName}" $OVERRIDE_ZOS_TOOLS
   printInfo "- Created config in ${configFile}"
   if ${appendToProfile}; then
     if ! grep -q ". ${rootfs}/etc/zopen-config" "${HOME}/.profile"; then
@@ -395,6 +405,13 @@ generateJsonConfiguration()
     releaseLine=$(jq -r '.release_line' "${jsonConfig}")
     RM_FILEPROCS=$(jq -r '.num_rm_procs' "${jsonConfig}")
     # note that is_collecting_stats is set earlier
+    if [ -z "${OVERRIDE_ZOS_TOOLS}" ] && jq -er ".override_zos_tools" $jsonConfig >/dev/null; then
+      OVERRIDE_ZOS_TOOLS=$(jq -r '.override_zos_tools' $jsonConfig)
+    fi
+  fi
+
+  if [ -z "${OVERRIDE_ZOS_TOOLS}" ]; then
+    OVERRIDE_ZOS_TOOLS=false
   fi
 
   if [ -z "$releaseLine" ]; then
@@ -414,6 +431,7 @@ generateJsonConfiguration()
   "release_line": "${releaseLine}",
   "num_rm_procs": ${RM_FILEPROCS},
   "is_collecting_stats": ${isCollectingStats}
+  "override_zos_tools": ${OVERRIDE_ZOS_TOOLS},
 }
 zz
     jq '.' "${jsonConfigWorking}" > "${jsonConfig}"
@@ -423,7 +441,8 @@ zz
     # example), just update the values that zopen itself knows about inline
     if ! jq --arg releaseLine "${releaseLine}" \
             --arg isCollectingStats "${isCollectingStats}" \
-                ".release_line = \"${releaseLine}\" | .is_collecting_stats = ${isCollectingStats}" \
+            --arg overrideZOSTools "${OVERRIDE_ZOS_TOOLS}" \
+                ".release_line = \"${releaseLine}\" | .is_collecting_stats = ${isCollectingStats}" | .override_zos_tools = ${overrideZOSTools}" \
                 "${ZOPEN_JSON_CONFIG}" > "${ZOPEN_JSON_CONFIG}.working"; then
       printError "Errors updating existing configuration file. See previous errors for more information and retry command."
     fi
@@ -612,9 +631,9 @@ deinit()
 
 init
 generateFileSystem
+generateJsonConfiguration
 generateZopenConfig
 ! ${refresh} && installPrereqs
-generateJsonConfiguration
 generateAnalyticsConfiguration
 ! ${refresh} && updateBootstrappedTools
 deinit

--- a/docs/Guides/ThePackageManager.md
+++ b/docs/Guides/ThePackageManager.md
@@ -87,8 +87,51 @@ If you prefer to use the tools without the prefix, you can specify the `--overri
 
 Alternatively, you can add `$ZOPEN_ROOTFS/usr/local/altbin` to your $PATH.
 
+### Adjusting the default override mode for your zopen installation
+
+zopen init provides the following option which can adjust the default override mode.
+```
+  --[no]override-zos-tools
+          Toggle default mode for overriding z/OS /bin tools
+          in the zopen-config. Default is --nooverride-zos-tools
+```
+
+For examples:
+```bash
+zopen init --override-zos-tools
+```
+
+If you have a zopen fileystem already configured, you can use the `zopen config` command to set the value:
+```bash
+zopen config --set override_zos_tools true
+zopen init --refresh # to refresh the zopen-config file
+```
+
+### Selecting a Specific Set of Packages to Override
+If you want to override only a specific set of packages, you can create a file that lists the packages you want to override. This allows for more fine-grained control over which packages are overridden.
+
+**Creating the override list file**
+
+* Create a file named `zopen.subset` in your home directory ($HOME/zopen.subset). Add one tool per line to the file, without any leading or trailing whitespace. For example:
+```bash
+gawk
+coreutils
+sed
+```
+When sourcing zopen-config, use the `--override-zos-tools-subset` option followed by the path to your zopen.subset file:
+```
+. $ZOPEN_ROOTFS/etc/zopen-config --override-zos-tools-subset $HOME/zopen.subset
+```
+This will override only the packages listed in the zopen.subset file.
+
+**Format of the override list file**
+* One tool per line
+* No leading or trailing whitespace
+* Names must match the package names (e.g., gawk, coreutils, sed)
+
  
 # Upgrading the meta zopen package manager
+
 The meta package, which include zopen, can be upgraded via the `zopen upgrade` command as follows:
 ```bash
 > zopen upgrade meta


### PR DESCRIPTION
* Also adds an --override-zos-tools-subset option
  * Override a subset of /bin zos tools rather than all. Contains a subset of packages to override, delimited by newlines."