### PR TITLE
Added a flag to handle generation of ZOSLIB Hooks

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2305,7 +2305,9 @@ if [ -n "${ZOPEN_SRC_DIR}" ]; then
   cd "${ZOPEN_SRC_DIR}" || exit 99
 fi
 
-generateZOSLIBHooks
+if [ "${ZOPEN_SKIP_ZOSLIB_ENV_HOOK}x" != "skipx" ]; then
+        generateZOSLIBHooks
+fi
 
 if ! resolveCommands; then
   exit 4

--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -2305,8 +2305,8 @@ if [ -n "${ZOPEN_SRC_DIR}" ]; then
   cd "${ZOPEN_SRC_DIR}" || exit 99
 fi
 
-if [ "${ZOPEN_SKIP_ZOSLIB_ENV_HOOK}x" != "skipx" ]; then
-        generateZOSLIBHooks
+if [ -z "${ZOPEN_SKIP_ZOSLIB_ENV_HOOK}" ]; then
+  generateZOSLIBHooks
 fi
 
 if ! resolveCommands; then


### PR DESCRIPTION
If ZOPEN_SKIP_ZOSLIB_ENV_HOOK is set to skip then
generateZOSLIBHooks will not be called and hence,
zoslib hooks will not be generated.