### PR TITLE
add `skip` option to ZOPEN_COMP

### DIFF
--- a/bin/zopen-build
+++ b/bin/zopen-build
@@ -653,7 +653,9 @@ checkEnv()
   else
     # user specified, so normalize in lower case
     ZOPEN_COMP=$(echo "${ZOPEN_COMP}" | tr '[A-Z]' '[a-z]')
-    implicitDeps="${implicitDeps} comp_${ZOPEN_COMP}"
+    if [ "${ZOPEN_COMP}x" != 'skipx' ]; then
+      implicitDeps="${implicitDeps} comp_${ZOPEN_COMP}"
+    fi
   fi
 
   if [ -z "${ZOPEN_DONT_ADD_ZOSLIB_DEP}" ]; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Content Update

## Category

- [ ] zopen framework
- [ ] Documentation
- [ ] CI/CD
- [x] Tools

## Description
Allows a `buildenv` or user to provide `ZOPEN_COMP=skip` if a compiler dependency is unneeded for the package.

## Related Issues
none
